### PR TITLE
fix: change WebGL pointsize buffer type from HALF_FLOAT to FLOAT

### DIFF
--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -135,7 +135,7 @@ export class WebGLPointsController extends WebGLControllerBase {
       this._buffers.size,
       WebGLPointsController._attribLocations.SIZE,
       1,
-      this._gl.HALF_FLOAT,
+      this._gl.FLOAT,
     );
     WebGLUtils.configureVertexIntAttribute(
       this._gl,


### PR DESCRIPTION
... to match Float32Array

(Float16Array is only supported from ECMAScript 2025 onwards)