### PR TITLE
refactor: "constant" source type, premultiply point sizes

### DIFF
--- a/packages/@tissuumaps-core/src/assets/shaders/points.vert
+++ b/packages/@tissuumaps-core/src/assets/shaders/points.vert
@@ -1,7 +1,7 @@
 #version 300 es
 
 // maximum number of objects
-#define MAX_N_OBJECTS 256u
+#define MAX_N_OBJECTS 2048u
 
 // marker atlas configuration
 #define MARKER_ATLAS_GRID_SIZE 4u
@@ -13,7 +13,7 @@
 #define DISCARD gl_PointSize = 0.0; gl_Position = vec4(2.0, 2.0, 0.0, 1.0); v_color = vec4(0.0); v_marker = uvec3(0); return;
 
 // uniforms
-uniform float u_globalPointSizeFactor;
+uniform float u_worldPointSizeFactor;
 uniform mat3x2 u_worldToViewportMatrix;
 uniform vec2 u_viewportSize; // in world units
 uniform vec2 u_canvasSize; // in browser pixels
@@ -32,13 +32,12 @@ layout(std140) uniform ObjectsUBO {
     // is aligned to 4N. Since mat2x4 has 2 columns, its
     // base alignment is 2 * 4N = 8N = 32 bytes.
     mat2x4 transposedDataToWorldMatrices[MAX_N_OBJECTS];
-    vec4 objectPointSizeFactors[MAX_N_OBJECTS / 4u];
 };
 
 // vertex attributes
 layout(location = 0) in float a_x; // in data units
 layout(location = 1) in float a_y; // in data units
-layout(location = 2) in float a_size; // in data units
+layout(location = 2) in float a_size; // in world units
 layout(location = 3) in uint a_color; // packed 8-bit RGBA
 layout(location = 4) in uint a_marker; // marker index
 layout(location = 5) in uint a_object; // object index
@@ -71,21 +70,18 @@ void main() {
         DISCARD;
     }
 
-    // compute object-specific parameters
-    float objectPointSizeFactor = objectPointSizeFactors[a_object / 4u][a_object % 4u];
-    mat3x2 dataToWorldMatrix = mat3x2(transpose(transposedDataToWorldMatrices[a_object]));
-    float dataToWorldScale = (length(dataToWorldMatrix[0]) + length(dataToWorldMatrix[1])) / 2.0;
-    float canvasPixelRatio = dot(u_canvasSize / u_viewportSize, vec2(0.5));
-
     // compute point size in device pixels and discard points with non-positive size
-    float worldPointSize = a_size * objectPointSizeFactor * u_globalPointSizeFactor * dataToWorldScale;
+    float canvasPixelRatio = dot(u_canvasSize / u_viewportSize, vec2(0.5));
+    float worldPointSize = a_size * u_worldPointSizeFactor;
     float canvasPointSize = worldPointSize * canvasPixelRatio; // in browser pixels
     float devicePointSize = canvasPointSize * u_devicePixelRatio; // in device pixels
     if(devicePointSize <= 0.0) {
         DISCARD;
     }
+    gl_PointSize = devicePointSize;
 
     // compute point position in normalized device coordinates (NDCs) and discard points outside the viewport
+    mat3x2 dataToWorldMatrix = mat3x2(transpose(transposedDataToWorldMatrices[a_object]));
     vec2 worldPosition = dataToWorldMatrix * vec3(a_x, a_y, 1.0);
     vec2 viewportPosition = u_worldToViewportMatrix * vec3(worldPosition, 1.0); // in [0, 1]
     vec2 ndcPosition = (2.0 * viewportPosition - 1.0) * vec2(1.0, -1.0); // in [-1, 1], y flipped
@@ -93,19 +89,15 @@ void main() {
     if(ndcPosition.x + 0.5 * ndcPointSize.x < -1.0 || ndcPosition.x - 0.5 * ndcPointSize.x > 1.0 || ndcPosition.y + 0.5 * ndcPointSize.y < -1.0 || ndcPosition.y - 0.5 * ndcPointSize.y > 1.0) {
         DISCARD;
     }
+    gl_Position = vec4(ndcPosition, 0.0, 1.0);
 
     // unpack color and discard fully transparent points
     vec4 color = unpackColor(a_color);
     if(color.a == 0.0) {
         DISCARD;
     }
+    v_color = color;
 
     // get marker atlas coordinates
-    uvec3 marker = markerAtlasCoords(a_marker);
-
-    // set outputs
-    gl_PointSize = devicePointSize;
-    gl_Position = vec4(ndcPosition, 0.0, 1.0);
-    v_color = color;
-    v_marker = marker;
+    v_marker = markerAtlasCoords(a_marker);
 }

--- a/packages/@tissuumaps-core/src/model/labels.ts
+++ b/packages/@tissuumaps-core/src/model/labels.ts
@@ -25,8 +25,8 @@ import {
  */
 export const labelsDefaults = {
   labelColor: { random: { palette: defaultRandomLabelColorPalette } },
-  labelVisibility: { value: defaultLabelVisibility },
-  labelOpacity: { value: defaultLabelOpacity },
+  labelVisibility: { constant: { value: defaultLabelVisibility } },
+  labelOpacity: { constant: { value: defaultLabelOpacity } },
 } as const satisfies Partial<RawLabels>;
 
 /**

--- a/packages/@tissuumaps-core/src/model/points.ts
+++ b/packages/@tissuumaps-core/src/model/points.ts
@@ -28,11 +28,11 @@ import {
  * Default values for {@link RawPoints}
  */
 export const pointsDefaults = {
-  pointMarker: { value: defaultPointMarker },
-  pointSize: { value: defaultPointSize },
-  pointColor: { value: defaultPointColor },
-  pointVisibility: { value: defaultPointVisibility },
-  pointOpacity: { value: defaultPointOpacity },
+  pointMarker: { constant: { value: defaultPointMarker } },
+  pointSize: { constant: { value: defaultPointSize } },
+  pointColor: { constant: { value: defaultPointColor } },
+  pointVisibility: { constant: { value: defaultPointVisibility } },
+  pointOpacity: { constant: { value: defaultPointOpacity } },
   pointSizeFactor: 1,
 } as const satisfies Partial<RawPoints>;
 

--- a/packages/@tissuumaps-core/src/model/shapes.ts
+++ b/packages/@tissuumaps-core/src/model/shapes.ts
@@ -27,12 +27,12 @@ import {
  * Default values for {@link RawShapes}
  */
 export const shapesDefaults = {
-  shapeFillColor: { value: defaultShapeFillColor },
-  shapeFillVisibility: { value: defaultShapeFillVisibility },
-  shapeFillOpacity: { value: defaultShapeFillOpacity },
-  shapeStrokeColor: { value: defaultShapeStrokeColor },
-  shapeStrokeVisibility: { value: defaultShapeStrokeVisibility },
-  shapeStrokeOpacity: { value: defaultShapeStrokeOpacity },
+  shapeFillColor: { constant: { value: defaultShapeFillColor } },
+  shapeFillVisibility: { constant: { value: defaultShapeFillVisibility } },
+  shapeFillOpacity: { constant: { value: defaultShapeFillOpacity } },
+  shapeStrokeColor: { constant: { value: defaultShapeStrokeColor } },
+  shapeStrokeVisibility: { constant: { value: defaultShapeStrokeVisibility } },
+  shapeStrokeOpacity: { constant: { value: defaultShapeStrokeOpacity } },
 } as const satisfies Partial<RawShapes>;
 
 /**


### PR DESCRIPTION
switch to constant source type, render up to 2048 points objects, revert to premultiplying point sizes