### PR TITLE
feat: add SVGController skeleton and InteractionMode

### DIFF
--- a/apps/tissuumaps/src/components/panels/ViewerPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ViewerPanel/index.tsx
@@ -17,6 +17,7 @@ export type ViewerPanelProps = {
 export function ViewerPanel({ className }: ViewerPanelProps) {
   const viewerState = useTissUUmaps(
     useShallow((state) => ({
+      interactionMode: state.interactionMode,
       workspace: state.workspace,
       layers: state.layers,
       images: state.images,

--- a/apps/tissuumaps/src/store/slices/app.ts
+++ b/apps/tissuumaps/src/store/slices/app.ts
@@ -3,6 +3,7 @@ import { type JsonSchema, type UISchemaElement } from "@jsonforms/core";
 import {
   type ImageData,
   type ImageDataStorage,
+  type InteractionMode,
   type LabelsData,
   type LabelsDataStorage,
   type PointsData,
@@ -17,7 +18,6 @@ import {
   type TableData,
   type TableDataStorage,
 } from "@tissuumaps/core";
-import { type InteractionMode } from "@tissuumaps/core";
 import {
   CSVTableDataStorage,
   GeoJSONShapesDataStorage,

--- a/apps/tissuumaps/src/store/slices/app.ts
+++ b/apps/tissuumaps/src/store/slices/app.ts
@@ -17,6 +17,7 @@ import {
   type TableData,
   type TableDataStorage,
 } from "@tissuumaps/core";
+import { type InteractionMode } from "@tissuumaps/core";
 import {
   CSVTableDataStorage,
   GeoJSONShapesDataStorage,
@@ -88,6 +89,7 @@ export type AppSlice = AppSliceState & AppSliceActions;
 
 export type AppSliceState = {
   dark: boolean;
+  interactionMode: InteractionMode;
   workspace: FileSystemDirectoryHandle | null;
   imageDataStorageRegistry: Map<
     string,
@@ -113,6 +115,7 @@ export type AppSliceState = {
 
 export type AppSliceActions = {
   setDark: (dark: boolean) => void;
+  setInteractionMode: (interactionMode: InteractionMode) => void;
   setWorkspace: (workspace: FileSystemDirectoryHandle | null) => void;
   registerImageDataStorage: (
     type: string,
@@ -141,6 +144,11 @@ export const createAppSlice: TissUUmapsStateCreator<AppSlice> = (set) => ({
   setDark: (dark) => {
     set((draft) => {
       draft.dark = dark;
+    });
+  },
+  setInteractionMode: (interactionMode) => {
+    set((draft) => {
+      draft.interactionMode = interactionMode;
     });
   },
   setWorkspace: (dir) => {
@@ -179,6 +187,7 @@ export const createAppSlice: TissUUmapsStateCreator<AppSlice> = (set) => ({
 function createInitialAppSliceState(): AppSliceState {
   return {
     dark: false,
+    interactionMode: "pan",
     workspace: null,
     imageDataStorageRegistry: new Map([
       [

--- a/packages/@tissuumaps-core/src/controllers/SVGController.ts
+++ b/packages/@tissuumaps-core/src/controllers/SVGController.ts
@@ -99,7 +99,7 @@ export class SVGController {
       this._containerSize.width !== width ||
       this._containerSize.height !== height
     ) {
-      this._containerSize = newContainerSize;
+      this._containerSize = { width, height };
       this.container.setAttribute("width", width.toString());
       this.container.setAttribute("height", height.toString());
       this._updateTransformNode();

--- a/packages/@tissuumaps-core/src/controllers/SVGController.ts
+++ b/packages/@tissuumaps-core/src/controllers/SVGController.ts
@@ -1,0 +1,130 @@
+import { type InteractionMode, type MultiPolygon, type Rect } from "../types";
+
+const SVG_NAMESPACE = "http://www.w3.org/2000/svg";
+
+/**
+ * Controller for managing the drawing of SVG shapes
+ */
+export class SVGController {
+  public readonly container: SVGSVGElement;
+  public readonly transformNode: SVGGElement;
+  public readonly shapeCompleteHandler?: (shape: MultiPolygon) => void;
+  private _containerSize: { width: number; height: number };
+  private _viewport: Rect;
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore currently not used, but will be needed in the future
+  private _interactionMode?: InteractionMode;
+
+  /** Creates a positioned, full-size `<svg>` element for the SVG overlay */
+  static createContainer(): SVGSVGElement {
+    const container = document.createElementNS(SVG_NAMESPACE, "svg");
+    container.style.position = "absolute";
+    container.style.top = "0";
+    container.style.left = "0";
+    container.style.width = "100%";
+    container.style.height = "100%";
+    return container;
+  }
+
+  /**
+   * @param container - The `<svg>` element to draw on (typically created by {@link createContainer})
+   * @param viewport - Initial world-space viewport rectangle
+   * @param options - Optional shape drawing event handlers
+   */
+  constructor(
+    container: SVGSVGElement,
+    viewport: Rect,
+    options?: { onShapeComplete?: (shape: MultiPolygon) => void },
+  ) {
+    this.container = container;
+    this.transformNode = document.createElementNS(SVG_NAMESPACE, "g");
+    this.shapeCompleteHandler = options?.onShapeComplete;
+    this._containerSize = {
+      width: parseFloat(container.getAttribute("width") ?? "0"),
+      height: parseFloat(container.getAttribute("height") ?? "0"),
+    };
+    this._viewport = viewport;
+    container.replaceChildren(this.transformNode);
+    // TODO register mouse event handlers on container
+  }
+
+  /**
+   * Updates the world-space viewport rectangle
+   *
+   * @param newViewport - New viewport bounds in world coordinates
+   * @returns `true` if the viewport actually changed, `false` otherwise
+   */
+  setViewport(newViewport: Rect): boolean {
+    if (
+      this._viewport.x !== newViewport.x ||
+      this._viewport.y !== newViewport.y ||
+      this._viewport.width !== newViewport.width ||
+      this._viewport.height !== newViewport.height
+    ) {
+      this._viewport = newViewport;
+      this._updateTransformNode();
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Updates the interaction mode
+   *
+   * @param newInteractionMode - New interaction mode
+   */
+  setInteractionMode(newInteractionMode: InteractionMode) {
+    this._interactionMode = newInteractionMode;
+  }
+
+  /**
+   * Resizes the SVG container to match the given screen-space dimensions,
+   * accounting for `devicePixelRatio`
+   *
+   * @param newContainerSize - Desired container size in screen-space pixels
+   * @returns `true` if the container size actually changed, `false` otherwise
+   */
+  resizeContainer(newContainerSize: {
+    width: number;
+    height: number;
+  }): boolean {
+    let { width, height } = newContainerSize;
+    width *= window.devicePixelRatio;
+    height *= window.devicePixelRatio;
+    if (width <= 0 || height <= 0) {
+      width = 1;
+      height = 1;
+    }
+    if (
+      this._containerSize.width !== width ||
+      this._containerSize.height !== height
+    ) {
+      this._containerSize = newContainerSize;
+      this.container.setAttribute("width", width.toString());
+      this.container.setAttribute("height", height.toString());
+      this._updateTransformNode();
+      return true;
+    }
+    return false;
+  }
+
+  destroy(): void {}
+
+  // TODO implement mouse event handlers for shape drawing; upon shape completion, call shapeCompleteHandler (if defined);
+  // mouse coordinates can be transformed to world space coordinates using transformNode.getScreenCTM().inverse()
+
+  /**
+   * Updates the world-to-viewport transform based on the current container size
+   * (in screen coordinates) and the current viewport (in world coordinates)
+   */
+  private _updateTransformNode() {
+    const sx = this._containerSize.width / this._viewport.width;
+    const sy = this._containerSize.height / this._viewport.height;
+    const tx = -this._viewport.x * sx;
+    const ty = -this._viewport.y * sy;
+    this.transformNode.setAttribute(
+      "transform",
+      `translate(${tx} ${ty}) scale(${sx} ${sy})`,
+    );
+  }
+}

--- a/packages/@tissuumaps-core/src/index.ts
+++ b/packages/@tissuumaps-core/src/index.ts
@@ -1,5 +1,6 @@
 export { OpenSeadragonController } from "./controllers/OpenSeadragonController";
 export { WebGLController } from "./controllers/WebGLController";
+export { SVGController } from "./controllers/SVGController";
 
 export * from "./model/base";
 export * from "./model/configs";

--- a/packages/@tissuumaps-core/src/types.ts
+++ b/packages/@tissuumaps-core/src/types.ts
@@ -23,6 +23,11 @@ export type MappableArrayLike<T> = ArrayLike<T> & {
 };
 
 /**
+ * Interaction mode, determining how mouse events are interpreted
+ */
+export type InteractionMode = "pan";
+
+/**
  * A callback function that receives progress updates as a percentage (0-100)
  *
  * @param progress - The current progress as a percentage (0-100)

--- a/packages/@tissuumaps-viewer/src/adapter.ts
+++ b/packages/@tissuumaps-viewer/src/adapter.ts
@@ -4,10 +4,12 @@ import {
   type DrawOptions,
   type Image,
   type ImageData,
+  type InteractionMode,
   type Labels,
   type LabelsData,
   type Layer,
   type Marker,
+  type MultiPolygon,
   type Points,
   type PointsData,
   type Shapes,
@@ -17,6 +19,7 @@ import {
 } from "@tissuumaps/core";
 
 export interface ViewerAdapter {
+  interactionMode: InteractionMode;
   workspace: FileSystemDirectoryHandle | null;
   layers: Layer[];
   images: Image[];
@@ -52,4 +55,5 @@ export interface ViewerAdapter {
     tableId: string,
     options?: { signal?: AbortSignal },
   ) => Promise<TableData>;
+  addShape?: (shape: MultiPolygon) => void;
 }

--- a/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
+++ b/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
@@ -4,6 +4,7 @@ import { type OpenSeadragonController } from "@tissuumaps/core";
 
 import { type ViewerAdapter } from "../../adapter";
 import { useOpenSeadragon } from "../../hooks/useOpenSeadragon";
+import { useSVG } from "../../hooks/useSVG";
 import { useWebGL } from "../../hooks/useWebGL";
 
 export type ViewerProps = { adapter: ViewerAdapter; className?: string };
@@ -14,38 +15,47 @@ export function Viewer({ adapter, className }: ViewerProps) {
   const { setViewerElementRef, controllerRef: osRef } =
     useOpenSeadragon(adapter);
 
-  const glCanvas = useMemo(() => os?.viewer.canvas ?? null, [os]);
-  const glViewport = useMemo(
+  const parent = useMemo(() => os?.viewer.canvas ?? null, [os]);
+  const viewport = useMemo(
     () => os?.viewer.viewport.getBoundsNoRotate(true) ?? null,
     [os],
   );
-  const { controllerRef: glRef } = useWebGL(adapter, glCanvas, glViewport);
+  const { controllerRef: glRef } = useWebGL(adapter, parent, viewport);
+  const { controllerRef: svgRef } = useSVG(adapter, parent, viewport);
 
   useEffect(() => {
     const os = osRef.current;
     const resizeHandler = (event: OpenSeadragon.ResizeEvent) => {
+      console.debug("Resizing WebGL canvas and SVG container");
+      const newSize = {
+        width: event.newContainerSize.x,
+        height: event.newContainerSize.y,
+      };
       const gl = glRef.current;
       if (gl !== null) {
-        console.debug("Resizing WebGL canvas");
-        const canvasResized = gl.resizeCanvas({
-          width: event.newContainerSize.x,
-          height: event.newContainerSize.y,
-        });
+        const canvasResized = gl.resizeCanvas(newSize);
         if (canvasResized) {
           gl.draw();
         }
       }
+      const svg = svgRef.current;
+      if (svg !== null) {
+        svg.resizeContainer(newSize);
+      }
     };
     const viewportChangeHandler = (event: OpenSeadragon.ViewerEvent) => {
+      console.debug("Changing WebGL viewport and SVG viewport");
+      const newViewport = event.eventSource.viewport.getBoundsNoRotate(true);
       const gl = glRef.current;
       if (gl !== null) {
-        console.debug("Changing WebGL viewport");
-        const viewportChanged = gl.setViewport(
-          event.eventSource.viewport.getBoundsNoRotate(true),
-        );
+        const viewportChanged = gl.setViewport(newViewport);
         if (viewportChanged) {
           gl.draw();
         }
+      }
+      const svg = svgRef.current;
+      if (svg !== null) {
+        svg.setViewport(newViewport);
       }
     };
     if (os !== null) {
@@ -59,7 +69,7 @@ export function Viewer({ adapter, className }: ViewerProps) {
         os.viewer.removeHandler("viewport-change", viewportChangeHandler);
       }
     };
-  }, [osRef, glRef, setOS]);
+  }, [osRef, glRef, svgRef, setOS]);
 
   return <div ref={setViewerElementRef} className={className} />;
 }

--- a/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
@@ -1,0 +1,51 @@
+import { useEffect, useReducer, useRef } from "react";
+
+import { type Rect, SVGController } from "@tissuumaps/core";
+
+import type { ViewerAdapter } from "../adapter";
+
+export function useSVG(
+  adapter: ViewerAdapter,
+  parent: Element | null,
+  viewport: Rect | null,
+) {
+  const { interactionMode, addShape } = adapter;
+
+  const controllerRef = useRef<SVGController | null>(null);
+  const [controllerReady, markControllerReady] = useReducer((x) => x + 1, 0);
+
+  useEffect(() => {
+    let container: SVGSVGElement | undefined;
+    let controller: SVGController | undefined;
+    const abortController = new AbortController();
+    if (parent !== null && viewport !== null) {
+      console.debug("Initializing SVG");
+      container = parent.appendChild(SVGController.createContainer());
+      controller = new SVGController(container, viewport, {
+        onShapeComplete: addShape,
+      });
+      controllerRef.current = controller;
+      markControllerReady();
+    }
+    return () => {
+      abortController.abort();
+      if (controller !== undefined) {
+        controllerRef.current = null;
+        controller.destroy();
+      }
+      if (container !== undefined && parent !== null) {
+        parent.removeChild(container);
+      }
+    };
+  }, [parent, viewport, addShape]);
+
+  useEffect(() => {
+    const controller = controllerRef.current;
+    if (controller !== null) {
+      console.debug("Setting interaction mode");
+      controller.setInteractionMode(interactionMode);
+    }
+  }, [controllerReady, interactionMode]);
+
+  return { controllerRef, controllerReady };
+}

--- a/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
@@ -17,7 +17,6 @@ export function useSVG(
   useEffect(() => {
     let container: SVGSVGElement | undefined;
     let controller: SVGController | undefined;
-    const abortController = new AbortController();
     if (parent !== null && viewport !== null) {
       console.debug("Initializing SVG");
       container = parent.appendChild(SVGController.createContainer());
@@ -28,7 +27,6 @@ export function useSVG(
       markControllerReady();
     }
     return () => {
-      abortController.abort();
       if (controller !== undefined) {
         controllerRef.current = null;
         controller.destroy();


### PR DESCRIPTION
This PR adds an `SVGController` skeleton to `@tissuumaps/core` for managing the drawing of SVG shapes

Specifically, the `SVGController` manages an `<svg>` element that is overlayed on top of the OpenSeadragon drawer and the WebGL canvas elements. Depending on the newly introduced `InteractionMode`, the controller is supposed to handle mouse events for drawing Shapes. Currently, the only `InteractionMode` is `"pan"` (i.e., no drawing), but this may be extended as needed (e.g. by adding `"drawRectangle"`). Corresponding `interactionMode` adapters (in `@tissuumaps/viewer`) and `interactionMode/setInteractionMode()` application states/actions were added and wired up.

Importantly, all shapes are supposed to be added under the `transformNode` SVG group element, which transforms internal world coordinates to viewport coordinates in screen space, and is reactively synchronized to the current OpenSeadragon/WebGL viewport using the `setViewport()`, `resizeContainer()` and `updateTransformNode()` methods (already implemented and wired up in the `@tissuumaps/viewer` React component). Any cleanup code may be added to the `destroy()` method.

A React component skeleton for controlling the application's `interactionMode` will be added in a separate PR.