### PR TITLE
feat: add interaction mode toolbar skeleton

### DIFF
--- a/apps/tissuumaps/src/components/panels/ViewerPanel/InteractionModeViewerControls.tsx
+++ b/apps/tissuumaps/src/components/panels/ViewerPanel/InteractionModeViewerControls.tsx
@@ -1,0 +1,8 @@
+export type InteractionModeViewerControlsProps = { className?: string };
+
+export function InteractionModeViewerControls({
+  className,
+}: InteractionModeViewerControlsProps) {
+  // TODO implement controls for switching interaction modes (pan, draw, etc.)
+  return <div className={className} />;
+}

--- a/apps/tissuumaps/src/components/panels/ViewerPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ViewerPanel/index.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useShallow } from "zustand/shallow";
 
-import { Viewer } from "@tissuumaps/viewer";
+import { Viewer, ViewerControl, ViewerControlAnchor } from "@tissuumaps/viewer";
 
 import { useTissUUmaps } from "../../../store";
 import { useLoadedImageDataAdapter } from "../../../store/adapters/LoadedImageDataAdapter";
@@ -9,6 +9,7 @@ import { useLoadedLabelsDataAdapter } from "../../../store/adapters/LoadedLabels
 import { useLoadedPointsDataAdapter } from "../../../store/adapters/LoadedPointsDataAdapter";
 import { useLoadedShapesDataAdapter } from "../../../store/adapters/LoadedShapesDataAdapter";
 import { useLoadedTableDataAdapter } from "../../../store/adapters/LoadedTableDataAdapter";
+import { InteractionModeViewerControls } from "./InteractionModeViewerControls";
 
 export type ViewerPanelProps = {
   className?: string;
@@ -59,5 +60,11 @@ export function ViewerPanel({ className }: ViewerPanelProps) {
     [viewerState, loadImage, loadLabels, loadPoints, loadShapes, loadTable],
   );
 
-  return <Viewer adapter={viewerAdapter} className={className} />;
+  return (
+    <Viewer adapter={viewerAdapter} className={className}>
+      <ViewerControl anchor={ViewerControlAnchor.TOP_LEFT}>
+        <InteractionModeViewerControls />
+      </ViewerControl>
+    </Viewer>
+  );
 }

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -91,6 +91,26 @@ export class OpenSeadragonController {
     }
   }
 
+  addControl(
+    element: HTMLElement,
+    options?: OpenSeadragon.TControlOptions,
+  ): void {
+    this._viewer.setControlsEnabled(true);
+    this._viewer.addControl(element, options ?? {});
+  }
+
+  removeControl(element: HTMLElement): void {
+    this._viewer.removeControl(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore: OpenSeadragon typings are incorrect for this method
+      element,
+    );
+  }
+
+  clearControls(): void {
+    this._viewer.clearControls();
+  }
+
   /**
    * Installs OpenSeadragon `animation-start` and `animation-finish` handlers
    *

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -91,26 +91,6 @@ export class OpenSeadragonController {
     }
   }
 
-  addControl(
-    element: HTMLElement,
-    options?: OpenSeadragon.TControlOptions,
-  ): void {
-    this._viewer.setControlsEnabled(true);
-    this._viewer.addControl(element, options ?? {});
-  }
-
-  removeControl(element: HTMLElement): void {
-    this._viewer.removeControl(
-      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-      // @ts-ignore: OpenSeadragon typings are incorrect for this method
-      element,
-    );
-  }
-
-  clearControls(): void {
-    this._viewer.clearControls();
-  }
-
   /**
    * Installs OpenSeadragon `animation-start` and `animation-finish` handlers
    *

--- a/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
+++ b/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
@@ -1,14 +1,19 @@
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 
 import { type OpenSeadragonController } from "@tissuumaps/core";
 
 import { type ViewerAdapter } from "../../adapter";
+import { OpenSeadragonControllerProvider } from "../../context/OpenSeadragonControllerProvider";
 import { useOpenSeadragon } from "../../hooks/useOpenSeadragon";
 import { useWebGL } from "../../hooks/useWebGL";
 
-export type ViewerProps = { adapter: ViewerAdapter; className?: string };
+export type ViewerProps = {
+  adapter: ViewerAdapter;
+  children?: ReactNode;
+  className?: string;
+};
 
-export function Viewer({ adapter, className }: ViewerProps) {
+export function Viewer({ adapter, children, className }: ViewerProps) {
   const [os, setOS] = useState<OpenSeadragonController | null>(null);
 
   const { setViewerElementRef, controllerRef: osRef } =
@@ -61,5 +66,11 @@ export function Viewer({ adapter, className }: ViewerProps) {
     };
   }, [osRef, glRef, setOS]);
 
-  return <div ref={setViewerElementRef} className={className} />;
+  return (
+    <div ref={setViewerElementRef} className={className}>
+      <OpenSeadragonControllerProvider controller={os}>
+        {children}
+      </OpenSeadragonControllerProvider>
+    </div>
+  );
 }

--- a/packages/@tissuumaps-viewer/src/components/ViewerControl/index.tsx
+++ b/packages/@tissuumaps-viewer/src/components/ViewerControl/index.tsx
@@ -1,0 +1,40 @@
+import { type ReactNode, useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+
+import { useOpenSeadragonController } from "../../context/OpenSeadragonControllerContext";
+import { type ViewerControlAnchor } from "./types";
+
+export { ViewerControlAnchor } from "./types";
+
+export type ViewerControlProps = {
+  anchor?: ViewerControlAnchor;
+  attachToViewer?: boolean;
+  autoFade?: boolean;
+  children?: ReactNode;
+};
+
+export function ViewerControl({
+  anchor,
+  attachToViewer,
+  autoFade,
+  children,
+}: ViewerControlProps) {
+  const [container] = useState(() => document.createElement("div"));
+
+  const os = useOpenSeadragonController();
+
+  useEffect(() => {
+    if (os !== null) {
+      os.viewer.addControl(container, { anchor, attachToViewer, autoFade });
+    }
+    return () => {
+      if (os !== null) {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore OpenSeadragon typings are wrong
+        os.viewer.removeControl(container);
+      }
+    };
+  }, [os, container, anchor, attachToViewer, autoFade]);
+
+  return createPortal(children, container);
+}

--- a/packages/@tissuumaps-viewer/src/components/ViewerControl/index.tsx
+++ b/packages/@tissuumaps-viewer/src/components/ViewerControl/index.tsx
@@ -29,8 +29,7 @@ export function ViewerControl({
     }
     return () => {
       if (os !== null) {
-        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-        // @ts-ignore OpenSeadragon typings are wrong
+        // @ts-expect-error OpenSeadragon typings are wrong
         os.viewer.removeControl(container);
       }
     };

--- a/packages/@tissuumaps-viewer/src/components/ViewerControl/types.ts
+++ b/packages/@tissuumaps-viewer/src/components/ViewerControl/types.ts
@@ -1,0 +1,11 @@
+export const ViewerControlAnchor = {
+  NONE: 0,
+  TOP_LEFT: 1,
+  TOP_RIGHT: 2,
+  BOTTOM_LEFT: 3,
+  BOTTOM_RIGHT: 4,
+  ABSOLUTE: 5,
+} as const;
+
+export type ViewerControlAnchor =
+  (typeof ViewerControlAnchor)[keyof typeof ViewerControlAnchor];

--- a/packages/@tissuumaps-viewer/src/context/OpenSeadragonControllerContext.ts
+++ b/packages/@tissuumaps-viewer/src/context/OpenSeadragonControllerContext.ts
@@ -1,0 +1,10 @@
+import { createContext, useContext } from "react";
+
+import { type OpenSeadragonController } from "@tissuumaps/core";
+
+export const OpenSeadragonControllerContext =
+  createContext<OpenSeadragonController | null>(null);
+
+export function useOpenSeadragonController(): OpenSeadragonController | null {
+  return useContext(OpenSeadragonControllerContext);
+}

--- a/packages/@tissuumaps-viewer/src/context/OpenSeadragonControllerProvider.tsx
+++ b/packages/@tissuumaps-viewer/src/context/OpenSeadragonControllerProvider.tsx
@@ -1,0 +1,21 @@
+import { type ReactNode } from "react";
+
+import { type OpenSeadragonController } from "@tissuumaps/core";
+
+import { OpenSeadragonControllerContext } from "./OpenSeadragonControllerContext";
+
+export type OpenSeadragonControllerProviderProps = {
+  controller: OpenSeadragonController | null;
+  children: ReactNode;
+};
+
+export function OpenSeadragonControllerProvider({
+  controller,
+  children,
+}: OpenSeadragonControllerProviderProps) {
+  return (
+    <OpenSeadragonControllerContext.Provider value={controller}>
+      {children}
+    </OpenSeadragonControllerContext.Provider>
+  );
+}

--- a/packages/@tissuumaps-viewer/src/index.ts
+++ b/packages/@tissuumaps-viewer/src/index.ts
@@ -1,2 +1,7 @@
 export { type ViewerAdapter } from "./adapter";
 export { Viewer, type ViewerProps } from "./components/Viewer";
+export {
+  ViewerControl,
+  ViewerControlAnchor,
+  type ViewerControlProps,
+} from "./components/ViewerControl";


### PR DESCRIPTION
# References and relevant issues

Completes [TMAP-219](https://scilifelab.atlassian.net/browse/TMAP-219)

# Description

This PR adds a new `InteractionModeViewerControl` component skeleton to the `ViewerPanel`.

To imperatively register the `InteractionModeViewerControl` component with the OpenSeadragon viewer, a new `ViewerControl` component is introduced in `@tissuumaps/viewer`. The `ViewerComponent` control leverages the newly introduced `OpenSeadragonControllerContext` to access the `OpenSeadragonController` instance managed by the parent `Viewer` component. To not add the `ViewerComponent` control to the DOM before calling `OpenSeadragonController.viewer.addControl()`, a portal approach is used.

# Testing

Content added to the `InterationModeViewerControl` shows up on the top left of the viewer.

# Additional comments

This PR builds on https://github.com/TissUUmaps/TissUUmaps4/pull/96.