### PR TITLE
Add project settings for drawOptions

### DIFF
--- a/apps/tissuumaps/src/components/panels/ProjectPanel/ProjectSettingsDialog.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/ProjectSettingsDialog.tsx
@@ -86,8 +86,7 @@ export function ProjectSettingsDialog() {
               }
             />
             <FieldDescription className="text-xs text-muted-foreground">
-              Number of scanlines for shape rasterization (higher = more
-              accurate but slower)
+              Number of scanlines for shape rasterization
             </FieldDescription>
           </Field>
         </div>

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/ProjectSettingsDialog.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/ProjectSettingsDialog.tsx
@@ -1,4 +1,97 @@
+import { Input } from "@/components/ui/input";
+
+import { useTissUUmaps } from "../../../store";
+import {
+  Field,
+  FieldControl,
+  FieldDescription,
+  FieldLabel,
+} from "../../common/field";
+
 export function ProjectSettingsDialog() {
-  // TODO
-  return <></>;
+  const drawOptions = useTissUUmaps((state) => state.drawOptions);
+  const setDrawOptions = useTissUUmaps((state) => state.setDrawOptions);
+
+  return (
+    <form onSubmit={(e) => e.preventDefault()} aria-label="Project settings">
+      <fieldset className="border-0 m-0 p-0">
+        <legend className="mb-3 text-sm font-medium">Draw Options</legend>
+
+        <div className="space-y-4">
+          <Field>
+            <FieldLabel>Point Size Factor</FieldLabel>
+            <FieldControl
+              render={
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  min={0.1}
+                  step={0.1}
+                  value={drawOptions.pointSizeFactor}
+                  onChange={(e) =>
+                    setDrawOptions({
+                      pointSizeFactor: parseFloat(e.target.value) || 1,
+                    })
+                  }
+                />
+              }
+            />
+            <FieldDescription className="text-xs text-muted-foreground">
+              Global scaling factor for all point sizes
+            </FieldDescription>
+          </Field>
+
+          <Field>
+            <FieldLabel>Shape Stroke Width (px)</FieldLabel>
+            <FieldControl
+              render={
+                <Input
+                  type="number"
+                  inputMode="decimal"
+                  min={0}
+                  step={1}
+                  value={drawOptions.shapeStrokeWidth}
+                  onChange={(e) =>
+                    setDrawOptions({
+                      shapeStrokeWidth: parseFloat(e.target.value) || 1,
+                    })
+                  }
+                />
+              }
+            />
+            <FieldDescription className="text-xs text-muted-foreground">
+              Stroke width for shape outlines in pixels
+            </FieldDescription>
+          </Field>
+
+          <Field>
+            <FieldLabel>Shape Scanlines</FieldLabel>
+            <FieldControl
+              render={
+                <Input
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  step={1}
+                  value={drawOptions.numShapesScanlines}
+                  onChange={(e) =>
+                    setDrawOptions({
+                      numShapesScanlines: Math.max(
+                        1,
+                        parseInt(e.target.value, 10) || 1,
+                      ),
+                    })
+                  }
+                />
+              }
+            />
+            <FieldDescription className="text-xs text-muted-foreground">
+              Number of scanlines for shape rasterization (higher = more
+              accurate but slower)
+            </FieldDescription>
+          </Field>
+        </div>
+      </fieldset>
+    </form>
+  );
 }

--- a/apps/tissuumaps/src/store/slices/project.ts
+++ b/apps/tissuumaps/src/store/slices/project.ts
@@ -31,6 +31,7 @@ export type ProjectSliceState = {
 
 export type ProjectSliceActions = {
   setProjectName: (name: string) => void;
+  setDrawOptions: (options: Partial<DrawOptions>) => void;
   loadProject: (
     project: Project,
     options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
@@ -56,6 +57,11 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
   setProjectName: (name) => {
     set((draft) => {
       draft.projectName = name;
+    });
+  },
+  setDrawOptions: (options) => {
+    set((draft) => {
+      draft.drawOptions = { ...draft.drawOptions, ...options };
     });
   },
   loadProject: deduplicate(


### PR DESCRIPTION
# References and relevant issues

This PR closes [#237](https://scilifelab.atlassian.net/browse/TMAP-237?issueKey=TMAP-237&subProduct=jira-software)

# Description

- adds setters for the drawOptions
- adds UI for the draw options inside the project settings dialogue

# Screenshot

<img width="651" height="541" alt="image" src="https://github.com/user-attachments/assets/3b06b21e-2310-45b2-a0fc-32d5768a20d8" />

# Testing

- go to the landing page and click on "Show project settings"
- expect to see the dialogue shown in the screenshot
- make sure it's usable with mouse and keyboard

# Additional comments

- The drawing tool isn't implemented yet, so you won't see any effect of changing the draw options. If you want to have an indication that they are saved to the application state, you can add `console.log` statements in the setter function, like this:
```
  setDrawOptions: (options) => {
    console.log("Setting draw options:", options);
    set((draft) => {
      draft.drawOptions = { ...draft.drawOptions, ...options };
    });
    console.log("New draw options:", get().drawOptions);
  },
  ```

- The connected issue also mentions the `viewerOptions`. We decided to postpone those to a later issue.
<!--
Final Checklist:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
-->
