### PR TITLE
Add sections to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,39 @@ If this PR addresses an existing issue on the repo, please link to that issue he
 If this PR depends on another PR (even in another repo), please link to it with "Depends on #(PR-number)" or "Depends on org/repo#(PR-number)".
 -->
 
-# Description
+# Type of change
 
+<!-- If "Other", please specify. -->
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Improvement (non-breaking change which modifies an existing feature)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Other
+
+# List of changes made
+
+<!-- Specify what changes have been made and why -->
+
+-
+-
+
+# Screenshot of the fix
+
+<!-- Attach screenshot if relevant -->
+
+# Testing
+
+<!-- Please delete options that are not relevant -->
+
+- A certain branch in other repos is needed
+- A rebuild is needed due to new dependencies
+- Requires new configuration settings
+- Instructions on how to test
+
+# Further comments
+
+<!-- Specify questions or related information -->
 <!--
 What does this pull request (PR) do?
 Is it a new feature, a bug fix, an improvement, or something else? Why is it necessary?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,14 +18,18 @@ If this PR depends on another PR (even in another repo), please link to it with 
 
 # List of changes made
 
-<!-- Specify what changes have been made and why -->
+<!-- Specify what changes have been made and why. -->
 
 -
 -
 
 # Screenshot of the fix
 
-<!-- Attach screenshot if relevant -->
+<!-- Attach screenshot if relevant. -->
+
+# Use of AI
+
+<!-- Please specify if AI was used in any way during the process of creating the pull request and the code inside it. If yes, specify in which way it was used. -->
 
 # Testing
 
@@ -38,12 +42,7 @@ If this PR depends on another PR (even in another repo), please link to it with 
 
 # Further comments
 
-<!-- Specify questions or related information -->
-<!--
-What does this pull request (PR) do?
-Is it a new feature, a bug fix, an improvement, or something else? Why is it necessary?
-If relevant, please add a screenshot or a screen capture: "An image is worth a thousand words!"
--->
+<!-- Specify questions or related information. -->
 
 <!--
 Final Checklist:


### PR DESCRIPTION
# References and relevant issues

No connected issue, rather based on offline discussions.

# Description

This PR adds some additional sections to the template for these PR descriptions. It's based on the template that one of the NBIS sysdev teams is using in their projects. It can be seen, e.g. here: https://github.com/NBISweden/bird-ringing/blob/develop/.github/PULL_REQUEST_TEMPLATE.md 

<!--
Final Checklist:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
-->
