### PR TITLE
feat: add a "Clear project" button to the project panel

### DIFF
--- a/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useCallback, useRef } from "react";
 
 import { Button } from "@/components/ui/button";
 import {
@@ -29,6 +29,20 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
   const loadProjectFromFile = useTissUUmaps(
     (state) => state.loadProjectFromFile,
   );
+  const clearProject = useTissUUmaps((state) => state.clearProject);
+
+  const confirmClearProject = useCallback(() => {
+    if (
+      window.confirm(
+        "Are you sure you want to clear the project? All unsaved changes will be lost.",
+      )
+    ) {
+      clearProject();
+      const url = new URL(window.location.href);
+      url.searchParams.delete("project");
+      window.history.replaceState({}, "", url);
+    }
+  }, [clearProject]);
 
   return (
     <div className={className}>
@@ -99,6 +113,20 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
                 }}
               >
                 Download project
+              </Button>
+            }
+          />
+        </Field>
+        <Field>
+          <FieldControl
+            render={
+              <Button
+                onClick={(event) => {
+                  event.preventDefault();
+                  confirmClearProject();
+                }}
+              >
+                Clear project
               </Button>
             }
           />


### PR DESCRIPTION
# References and relevant issues

Closes [TMAP-235](https://scilifelab.atlassian.net/browse/TMAP-235)

# Description
Adds a "Clear project" button to the Project tab that resets the currently loaded application state via the `clearProject` store action.

Before clearing, the user is prompted for confirmation with `window.confirm()` (a proper `AlertDialogProvider` can replace this later). If confirmed, the `?project=` URL parameter is also removed from the address bar via `window.history.replaceState`, so that a page refresh does not inadvertently reload the cleared project.

# Testing
 **Via URL parameter**
* Open the app with a project URL, e.g. http://localhost:5173/?project=https://user.it.uu.se/~chrav452/TissUUmaps4/data/heart/project_heart_cropped.json
* Wait for the project to load, then go to the **Project** tab and click **Clear project**
* Verify that a confirmation dialog appears
* Click **Cancel** — confirm the project remains loaded and the URL is unchanged
* Click **Clear project** again and confirm — verify the project is cleared and `?project=` is removed from the URL
* Refresh the page and verify the project is not reloaded

 **Via Load project button** 
* Load a project using the **Load project** button
* Click **Clear project** and confirm - verify the project is cleared

<!--
Final Checklist:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
-->
