### PR TITLE
refactor: simplify data caching in application state

### DIFF
--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,8 +1,5 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
-  "compilerOptions": {
-    "baseUrl": "."
-  },
   "exclude": [".docusaurus", "build"]
 }

--- a/apps/tissuumaps/src/components/panels/LabelsPanel/LabelsSourcePanel.tsx
+++ b/apps/tissuumaps/src/components/panels/LabelsPanel/LabelsSourcePanel.tsx
@@ -28,7 +28,7 @@ export function LabelsSourcePanel({
     const value = labelsDataStorageRegistry.get(labels.dataSource.type);
     if (value === undefined) {
       throw new Error(
-        `No labels data Storage registered for data source type "${labels.dataSource.type}"`,
+        `No labels data storage adapter registered for data source type "${labels.dataSource.type}"`,
       );
     }
     return value;

--- a/apps/tissuumaps/src/hooks/useTableColumnSelector.ts
+++ b/apps/tissuumaps/src/hooks/useTableColumnSelector.ts
@@ -10,17 +10,9 @@ export function useTableColumnSelector(tableId: string | null) {
       const { signal } = options ?? {};
       signal?.throwIfAborted();
       if (tableId !== null) {
-        const loadedTable = await loadTable(tableId, { signal });
+        const data = await loadTable(tableId, { signal });
         signal?.throwIfAborted();
-        const loadedTableDataSource = useTissUUmaps
-          .getState()
-          .loadedTableDataSources.get(loadedTable.loadedDataSourceKey);
-        if (loadedTableDataSource !== undefined) {
-          return await loadedTableDataSource.data.suggestColumnQueries(
-            currentQuery,
-            { signal },
-          );
-        }
+        return await data.suggestColumnQueries(currentQuery, { signal });
       }
       return [];
     },
@@ -32,16 +24,9 @@ export function useTableColumnSelector(tableId: string | null) {
       const { signal } = options ?? {};
       signal?.throwIfAborted();
       if (tableId !== null) {
-        const loadedTable = await loadTable(tableId, { signal });
+        const data = await loadTable(tableId, { signal });
         signal?.throwIfAborted();
-        const loadedTableDataSource = useTissUUmaps
-          .getState()
-          .loadedTableDataSources.get(loadedTable.loadedDataSourceKey);
-        if (loadedTableDataSource !== undefined) {
-          return await loadedTableDataSource.data.resolveColumnQuery(query, {
-            signal,
-          });
-        }
+        return await data.resolveColumnQuery(query, { signal });
       }
       return null;
     },

--- a/apps/tissuumaps/src/store/adapters/LoadedImageDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedImageDataAdapter.ts
@@ -16,34 +16,24 @@ export class LoadedImageDataAdapter implements ImageData {
     this._imageId = imageId;
   }
 
-  get loadedImage() {
-    const state = useTissUUmaps.getState();
-    const loadedImage = state.loadedImages.get(this._imageId);
-    if (loadedImage === undefined) {
-      throw new Error(`Image with ID ${this._imageId} is not loaded.`);
-    }
-    return loadedImage;
-  }
-
-  get loadedImageDataSource() {
-    const state = useTissUUmaps.getState();
-    const loadedImageDataSource = state.loadedImageDataSources.get(
-      this.loadedImage.loadedDataSourceKey,
-    );
-    if (loadedImageDataSource === undefined) {
-      throw new Error(
-        `Data source with key ${this.loadedImage.loadedDataSourceKey} for image with ID ${this._imageId} is not loaded.`,
-      );
-    }
-    return loadedImageDataSource;
-  }
-
   getTileSource(): string | TileSourceConfig | CustomTileSource {
-    return this.loadedImageDataSource.data.getTileSource();
+    return this._getData().getTileSource();
   }
 
   destroy(): void {
     // ignored intentionally
+  }
+
+  private _getData() {
+    const state = useTissUUmaps.getState();
+    const loadedDataKey = state.loadedImages.get(this._imageId);
+    if (loadedDataKey !== undefined) {
+      const loadedData = state.loadedImageData.get(loadedDataKey);
+      if (loadedData !== undefined) {
+        return loadedData.data;
+      }
+    }
+    throw new Error(`Data source not loaded for image ID ${this._imageId}`);
   }
 }
 

--- a/apps/tissuumaps/src/store/adapters/LoadedLabelsDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedLabelsDataAdapter.ts
@@ -12,58 +12,36 @@ export class LoadedLabelsDataAdapter implements LabelsData {
     this._labelsId = labelsId;
   }
 
-  get loadedLabels() {
-    const state = useTissUUmaps.getState();
-    const loadedLabels = state.loadedLabels.get(this._labelsId);
-    if (loadedLabels === undefined) {
-      throw new Error(`Labels with ID ${this._labelsId} is not loaded.`);
-    }
-    return loadedLabels;
-  }
-
-  get loadedLabelsDataSource() {
-    const state = useTissUUmaps.getState();
-    const loadedLabelsDataSource = state.loadedLabelsDataSources.get(
-      this.loadedLabels.loadedDataSourceKey,
-    );
-    if (loadedLabelsDataSource === undefined) {
-      throw new Error(
-        `Data source with key ${this.loadedLabels.loadedDataSourceKey} for labels with ID ${this._labelsId} is not loaded.`,
-      );
-    }
-    return loadedLabelsDataSource;
-  }
-
   getIds(): number[] {
-    return this.loadedLabelsDataSource.data.getIds();
+    return this._getData().getIds();
   }
 
   getSize(): number {
-    return this.loadedLabelsDataSource.data.getSize();
+    return this._getData().getSize();
   }
 
   getWidth(level?: number): number {
-    return this.loadedLabelsDataSource.data.getWidth(level);
+    return this._getData().getWidth(level);
   }
 
   getHeight(level?: number): number {
-    return this.loadedLabelsDataSource.data.getHeight(level);
+    return this._getData().getHeight(level);
   }
 
   getLevelCount(): number {
-    return this.loadedLabelsDataSource.data.getLevelCount();
+    return this._getData().getLevelCount();
   }
 
   getLevelScale(level: number): number {
-    return this.loadedLabelsDataSource.data.getLevelScale(level);
+    return this._getData().getLevelScale(level);
   }
 
   getTileWidth(level: number): number {
-    return this.loadedLabelsDataSource.data.getTileWidth(level);
+    return this._getData().getTileWidth(level);
   }
 
   getTileHeight(level: number): number {
-    return this.loadedLabelsDataSource.data.getTileHeight(level);
+    return this._getData().getTileHeight(level);
   }
 
   loadTile(): Promise<UintArray> {
@@ -72,6 +50,18 @@ export class LoadedLabelsDataAdapter implements LabelsData {
 
   destroy(): void {
     // ignored intentionally
+  }
+
+  private _getData() {
+    const state = useTissUUmaps.getState();
+    const loadedDataKey = state.loadedLabels.get(this._labelsId);
+    if (loadedDataKey !== undefined) {
+      const loadedData = state.loadedLabelsData.get(loadedDataKey);
+      if (loadedData !== undefined) {
+        return loadedData.data;
+      }
+    }
+    throw new Error(`Data source not loaded for labels ID ${this._labelsId}`);
   }
 }
 

--- a/apps/tissuumaps/src/store/adapters/LoadedPointsDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedPointsDataAdapter.ts
@@ -12,34 +12,12 @@ export class LoadedPointsDataAdapter implements PointsData {
     this._pointsId = pointsId;
   }
 
-  get loadedPoints() {
-    const state = useTissUUmaps.getState();
-    const loadedPoints = state.loadedPoints.get(this._pointsId);
-    if (loadedPoints === undefined) {
-      throw new Error(`Points with ID ${this._pointsId} is not loaded.`);
-    }
-    return loadedPoints;
-  }
-
-  get loadedPointsDataSource() {
-    const state = useTissUUmaps.getState();
-    const loadedPointsDataSource = state.loadedPointsDataSources.get(
-      this.loadedPoints.loadedDataSourceKey,
-    );
-    if (loadedPointsDataSource === undefined) {
-      throw new Error(
-        `Data source with key ${this.loadedPoints.loadedDataSourceKey} for points with ID ${this._pointsId} is not loaded.`,
-      );
-    }
-    return loadedPointsDataSource;
-  }
-
   getIds(): number[] {
-    return this.loadedPointsDataSource.data.getIds();
+    return this._getData().getIds();
   }
 
   getSize(): number {
-    return this.loadedPointsDataSource.data.getSize();
+    return this._getData().getSize();
   }
 
   async suggestDimensionQueries(
@@ -48,10 +26,7 @@ export class LoadedPointsDataAdapter implements PointsData {
   ): Promise<string[]> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    return await this.loadedPointsDataSource.data.suggestDimensionQueries(
-      currentQuery,
-      options,
-    );
+    return await this._getData().suggestDimensionQueries(currentQuery, options);
   }
 
   async resolveDimensionQuery(
@@ -60,10 +35,7 @@ export class LoadedPointsDataAdapter implements PointsData {
   ): Promise<string | null> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    return await this.loadedPointsDataSource.data.resolveDimensionQuery(
-      query,
-      options,
-    );
+    return await this._getData().resolveDimensionQuery(query, options);
   }
 
   async loadCoordinates(
@@ -81,6 +53,18 @@ export class LoadedPointsDataAdapter implements PointsData {
 
   destroy(): void {
     // ignored intentionally
+  }
+
+  private _getData() {
+    const state = useTissUUmaps.getState();
+    const loadedDataKey = state.loadedPoints.get(this._pointsId);
+    if (loadedDataKey !== undefined) {
+      const loadedData = state.loadedPointsData.get(loadedDataKey);
+      if (loadedData !== undefined) {
+        return loadedData.data;
+      }
+    }
+    throw new Error(`Data source not loaded for points ID ${this._pointsId}`);
   }
 }
 

--- a/apps/tissuumaps/src/store/adapters/LoadedShapesDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedShapesDataAdapter.ts
@@ -16,34 +16,12 @@ export class LoadedShapesDataAdapter implements ShapesData {
     this._shapesId = shapesId;
   }
 
-  get loadedShapes() {
-    const state = useTissUUmaps.getState();
-    const loadedShapes = state.loadedShapes.get(this._shapesId);
-    if (loadedShapes === undefined) {
-      throw new Error(`Shapes with ID ${this._shapesId} is not loaded.`);
-    }
-    return loadedShapes;
-  }
-
-  get loadedShapesDataSource() {
-    const state = useTissUUmaps.getState();
-    const loadedShapesDataSource = state.loadedShapesDataSources.get(
-      this.loadedShapes.loadedDataSourceKey,
-    );
-    if (loadedShapesDataSource === undefined) {
-      throw new Error(
-        `Data source with key ${this.loadedShapes.loadedDataSourceKey} for shapes with ID ${this._shapesId} is not loaded.`,
-      );
-    }
-    return loadedShapesDataSource;
-  }
-
   getIds(): number[] {
-    return this.loadedShapesDataSource.data.getIds();
+    return this._getData().getIds();
   }
 
   getSize(): number {
-    return this.loadedShapesDataSource.data.getSize();
+    return this._getData().getSize();
   }
 
   async loadMultiPolygons(options?: {
@@ -61,6 +39,18 @@ export class LoadedShapesDataAdapter implements ShapesData {
 
   destroy(): void {
     // ignored intentionally
+  }
+
+  private _getData() {
+    const state = useTissUUmaps.getState();
+    const loadedDataKey = state.loadedShapes.get(this._shapesId);
+    if (loadedDataKey !== undefined) {
+      const loadedData = state.loadedShapesData.get(loadedDataKey);
+      if (loadedData !== undefined) {
+        return loadedData.data;
+      }
+    }
+    throw new Error(`Data source not loaded for shapes ID ${this._shapesId}`);
   }
 }
 

--- a/apps/tissuumaps/src/store/adapters/LoadedTableDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedTableDataAdapter.ts
@@ -16,34 +16,12 @@ export class LoadedTableDataAdapter implements TableData {
     this._tableId = tableId;
   }
 
-  get loadedTable() {
-    const state = useTissUUmaps.getState();
-    const loadedTable = state.loadedTables.get(this._tableId);
-    if (loadedTable === undefined) {
-      throw new Error(`Table with ID ${this._tableId} is not loaded.`);
-    }
-    return loadedTable;
-  }
-
-  get loadedTableDataSource() {
-    const state = useTissUUmaps.getState();
-    const loadedTableDataSource = state.loadedTableDataSources.get(
-      this.loadedTable.loadedDataSourceKey,
-    );
-    if (loadedTableDataSource === undefined) {
-      throw new Error(
-        `Data source with key ${this.loadedTable.loadedDataSourceKey} for table with ID ${this._tableId} is not loaded.`,
-      );
-    }
-    return loadedTableDataSource;
-  }
-
   getIds(): number[] {
-    return this.loadedTableDataSource.data.getIds();
+    return this._getData().getIds();
   }
 
   getSize(): number {
-    return this.loadedTableDataSource.data.getSize();
+    return this._getData().getSize();
   }
 
   async suggestColumnQueries(
@@ -52,10 +30,7 @@ export class LoadedTableDataAdapter implements TableData {
   ): Promise<string[]> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    return await this.loadedTableDataSource.data.suggestColumnQueries(
-      currentQuery,
-      options,
-    );
+    return await this._getData().suggestColumnQueries(currentQuery, options);
   }
 
   async resolveColumnQuery(
@@ -64,10 +39,7 @@ export class LoadedTableDataAdapter implements TableData {
   ): Promise<string | null> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    return await this.loadedTableDataSource.data.resolveColumnQuery(
-      query,
-      options,
-    );
+    return await this._getData().resolveColumnQuery(query, options);
   }
 
   async loadValues<T>(
@@ -98,6 +70,18 @@ export class LoadedTableDataAdapter implements TableData {
 
   destroy(): void {
     // ignored intentionally
+  }
+
+  private _getData() {
+    const state = useTissUUmaps.getState();
+    const loadedDataKey = state.loadedTables.get(this._tableId);
+    if (loadedDataKey !== undefined) {
+      const loadedData = state.loadedTableData.get(loadedDataKey);
+      if (loadedData !== undefined) {
+        return loadedData.data;
+      }
+    }
+    throw new Error(`Data source not loaded for table ID ${this._tableId}`);
   }
 }
 

--- a/apps/tissuumaps/src/store/slices/image.ts
+++ b/apps/tissuumaps/src/store/slices/image.ts
@@ -10,11 +10,7 @@ import {
 import { deduplicate } from "../deduplicate";
 import { type TissUUmapsStateCreator } from "../index";
 
-type LoadedImage = {
-  loadedDataSourceKey: string;
-};
-
-type LoadedImageDataSource = {
+type CachedImageData = {
   dataSource: ImageDataSource;
   data: ImageData;
 };
@@ -23,8 +19,8 @@ export type ImageSlice = ImageSliceState & ImageSliceActions;
 
 export type ImageSliceState = {
   images: Image[];
-  loadedImages: Map<string, LoadedImage>;
-  loadedImageDataSources: Map<string, LoadedImageDataSource>;
+  loadedImages: Map<string, string>;
+  loadedImageData: Map<string, CachedImageData>;
 };
 
 export type ImageSliceActions = {
@@ -40,7 +36,7 @@ export type ImageSliceActions = {
       reload?: boolean;
       onProgress?: ProgressCallback;
     },
-  ) => Promise<LoadedImage>;
+  ) => Promise<ImageData>;
   unloadImage: (imageId: string) => boolean;
 };
 
@@ -106,8 +102,8 @@ export const createImageSlice: TissUUmapsStateCreator<ImageSlice> = (
   },
   clearImages: () => {
     const state = get();
-    for (const loadedDataSource of state.loadedImageDataSources.values()) {
-      loadedDataSource.data.destroy();
+    for (const loadedData of state.loadedImageData.values()) {
+      loadedData.data.destroy();
     }
     set(createInitialImageSliceState());
   },
@@ -117,25 +113,28 @@ export const createImageSlice: TissUUmapsStateCreator<ImageSlice> = (
       signal?.throwIfAborted();
       // Check if the image is already loaded
       const state = get();
-      const loadedImage = state.loadedImages.get(imageId);
-      if (loadedImage !== undefined && !reload) {
-        return loadedImage;
+      const loadedDataKey = state.loadedImages.get(imageId);
+      if (loadedDataKey !== undefined && !reload) {
+        const loadedData = state.loadedImageData.get(loadedDataKey);
+        if (loadedData !== undefined) {
+          return loadedData.data;
+        }
       }
       // Find the image and the corresponding data source (if loaded)
       const image = state.images.find((image) => image.id === imageId);
       if (image === undefined) {
         throw new Error(`Image with ID ${imageId} not found.`);
       }
-      let oldLoadedDataSource: LoadedImageDataSource | undefined;
-      for (const loadedDataSource of state.loadedImageDataSources.values()) {
-        if (deepEqual(loadedDataSource.dataSource, image.dataSource)) {
-          oldLoadedDataSource = loadedDataSource;
+      let oldLoadedData: CachedImageData | undefined;
+      for (const loadedData of state.loadedImageData.values()) {
+        if (deepEqual(loadedData.dataSource, image.dataSource)) {
+          oldLoadedData = loadedData;
           break;
         }
       }
       // Load the data source if not already loaded or if a reload has been requested
-      let loadedDataSource = oldLoadedDataSource;
-      if (loadedDataSource === undefined || reload) {
+      let loadedData = oldLoadedData;
+      if (loadedData === undefined || reload) {
         const { dataStorageFactory } =
           state.imageDataStorageRegistry.get(image.dataSource.type) ?? {};
         if (dataStorageFactory === undefined) {
@@ -164,56 +163,49 @@ export const createImageSlice: TissUUmapsStateCreator<ImageSlice> = (
             "AbortError",
           );
         }
-        loadedDataSource = { dataSource: image.dataSource, data };
+        loadedData = { dataSource: currentImage.dataSource, data };
       }
       // Store the loaded image and the corresponding data source in the state
-      let newLoadedImage: LoadedImage;
       set((draft) => {
-        let loadedDataSourceKey;
-        for (const [key, value] of draft.loadedImageDataSources) {
-          if (deepEqual(value.dataSource, loadedDataSource.dataSource)) {
-            loadedDataSourceKey = key;
+        let loadedDataKey;
+        for (const [key, value] of draft.loadedImageData) {
+          if (deepEqual(value.dataSource, loadedData.dataSource)) {
+            loadedDataKey = key;
             break;
           }
         }
-        if (loadedDataSourceKey === undefined) {
+        if (loadedDataKey === undefined) {
           do {
-            loadedDataSourceKey = crypto.randomUUID();
-          } while (draft.loadedImageDataSources.has(loadedDataSourceKey));
+            loadedDataKey = crypto.randomUUID();
+          } while (draft.loadedImageData.has(loadedDataKey));
         }
-        newLoadedImage = { loadedDataSourceKey };
-        draft.loadedImages.set(imageId, newLoadedImage);
-        draft.loadedImageDataSources.set(loadedDataSourceKey, loadedDataSource);
+        draft.loadedImages.set(imageId, loadedDataKey);
+        draft.loadedImageData.set(loadedDataKey, loadedData);
       });
       // Clean up old data if the loaded data source has changed
       if (
-        oldLoadedDataSource !== undefined &&
-        oldLoadedDataSource.data !== loadedDataSource.data
+        oldLoadedData !== undefined &&
+        oldLoadedData.data !== loadedData.data
       ) {
-        oldLoadedDataSource.data.destroy();
+        oldLoadedData.data.destroy();
       }
-      return newLoadedImage!;
+      return loadedData.data;
     },
     (_imageId, options) => options?.signal,
   ),
   unloadImage: (imageId) => {
     const state = get();
-    const loadedImage = state.loadedImages.get(imageId);
-    if (loadedImage === undefined) {
+    const loadedDataKey = state.loadedImages.get(imageId);
+    if (loadedDataKey === undefined) {
       return false;
     }
-    const loadedDataSource = state.loadedImageDataSources.get(
-      loadedImage.loadedDataSourceKey,
-    );
-    if (loadedDataSource === undefined) {
+    const loadedData = state.loadedImageData.get(loadedDataKey);
+    if (loadedData === undefined) {
       throw new Error(`Data source for image with ID ${imageId} not loaded.`);
     }
     let destroy = true;
-    for (const [otherImageId, otherLoadedImage] of state.loadedImages) {
-      if (
-        otherImageId !== imageId &&
-        otherLoadedImage.loadedDataSourceKey === loadedImage.loadedDataSourceKey
-      ) {
+    for (const [otherImageId, otherLoadedDataKey] of state.loadedImages) {
+      if (otherImageId !== imageId && otherLoadedDataKey === loadedDataKey) {
         destroy = false;
         break;
       }
@@ -221,11 +213,11 @@ export const createImageSlice: TissUUmapsStateCreator<ImageSlice> = (
     set((draft) => {
       draft.loadedImages.delete(imageId);
       if (destroy) {
-        draft.loadedImageDataSources.delete(loadedImage.loadedDataSourceKey);
+        draft.loadedImageData.delete(loadedDataKey);
       }
     });
     if (destroy) {
-      loadedDataSource.data.destroy();
+      loadedData.data.destroy();
     }
     return true;
   },
@@ -235,6 +227,6 @@ function createInitialImageSliceState(): ImageSliceState {
   return {
     images: [],
     loadedImages: new Map(),
-    loadedImageDataSources: new Map(),
+    loadedImageData: new Map(),
   };
 }

--- a/apps/tissuumaps/src/store/slices/image.ts
+++ b/apps/tissuumaps/src/store/slices/image.ts
@@ -10,7 +10,7 @@ import {
 import { deduplicate } from "../deduplicate";
 import { type TissUUmapsStateCreator } from "../index";
 
-type CachedImageData = {
+type LoadedImageData = {
   dataSource: ImageDataSource;
   data: ImageData;
 };
@@ -20,7 +20,7 @@ export type ImageSlice = ImageSliceState & ImageSliceActions;
 export type ImageSliceState = {
   images: Image[];
   loadedImages: Map<string, string>;
-  loadedImageData: Map<string, CachedImageData>;
+  loadedImageData: Map<string, LoadedImageData>;
 };
 
 export type ImageSliceActions = {
@@ -125,7 +125,7 @@ export const createImageSlice: TissUUmapsStateCreator<ImageSlice> = (
       if (image === undefined) {
         throw new Error(`Image with ID ${imageId} not found.`);
       }
-      let oldLoadedData: CachedImageData | undefined;
+      let oldLoadedData: LoadedImageData | undefined;
       for (const loadedData of state.loadedImageData.values()) {
         if (deepEqual(loadedData.dataSource, image.dataSource)) {
           oldLoadedData = loadedData;

--- a/apps/tissuumaps/src/store/slices/labels.ts
+++ b/apps/tissuumaps/src/store/slices/labels.ts
@@ -10,11 +10,7 @@ import {
 import { deduplicate } from "../deduplicate";
 import { type TissUUmapsStateCreator } from "../index";
 
-type LoadedLabels = {
-  loadedDataSourceKey: string;
-};
-
-type LoadedLabelsDataSource = {
+type LoadedLabelsData = {
   dataSource: LabelsDataSource;
   data: LabelsData;
 };
@@ -23,8 +19,8 @@ export type LabelsSlice = LabelsSliceState & LabelsSliceActions;
 
 export type LabelsSliceState = {
   labels: Labels[];
-  loadedLabels: Map<string, LoadedLabels>;
-  loadedLabelsDataSources: Map<string, LoadedLabelsDataSource>;
+  loadedLabels: Map<string, string>;
+  loadedLabelsData: Map<string, LoadedLabelsData>;
 };
 
 export type LabelsSliceActions = {
@@ -40,7 +36,7 @@ export type LabelsSliceActions = {
       reload?: boolean;
       onProgress?: ProgressCallback;
     },
-  ) => Promise<LoadedLabels>;
+  ) => Promise<LabelsData>;
   unloadLabels: (labelsId: string) => boolean;
 };
 
@@ -106,8 +102,8 @@ export const createLabelsSlice: TissUUmapsStateCreator<LabelsSlice> = (
   },
   clearLabels: () => {
     const state = get();
-    for (const loadedDataSource of state.loadedLabelsDataSources.values()) {
-      loadedDataSource.data.destroy();
+    for (const loadedData of state.loadedLabelsData.values()) {
+      loadedData.data.destroy();
     }
     set(createInitialLabelsSliceState());
   },
@@ -117,25 +113,28 @@ export const createLabelsSlice: TissUUmapsStateCreator<LabelsSlice> = (
       signal?.throwIfAborted();
       // Check if the labels are already loaded
       const state = get();
-      const loadedLabels = state.loadedLabels.get(labelsId);
-      if (loadedLabels !== undefined && !reload) {
-        return loadedLabels;
+      const loadedDataKey = state.loadedLabels.get(labelsId);
+      if (loadedDataKey !== undefined && !reload) {
+        const loadedData = state.loadedLabelsData.get(loadedDataKey);
+        if (loadedData !== undefined) {
+          return loadedData.data;
+        }
       }
       // Find the labels and the corresponding data source (if loaded)
       const labels = state.labels.find((labels) => labels.id === labelsId);
       if (labels === undefined) {
         throw new Error(`Labels with ID ${labelsId} not found.`);
       }
-      let oldLoadedDataSource: LoadedLabelsDataSource | undefined;
-      for (const loadedDataSource of state.loadedLabelsDataSources.values()) {
-        if (deepEqual(loadedDataSource.dataSource, labels.dataSource)) {
-          oldLoadedDataSource = loadedDataSource;
+      let oldLoadedData: LoadedLabelsData | undefined;
+      for (const loadedData of state.loadedLabelsData.values()) {
+        if (deepEqual(loadedData.dataSource, labels.dataSource)) {
+          oldLoadedData = loadedData;
           break;
         }
       }
       // Load the data source if not already loaded or if a reload has been requested
-      let loadedDataSource = oldLoadedDataSource;
-      if (loadedDataSource === undefined || reload) {
+      let loadedData = oldLoadedData;
+      if (loadedData === undefined || reload) {
         const { dataStorageFactory } =
           state.labelsDataStorageRegistry.get(labels.dataSource.type) ?? {};
         if (dataStorageFactory === undefined) {
@@ -164,60 +163,49 @@ export const createLabelsSlice: TissUUmapsStateCreator<LabelsSlice> = (
             "AbortError",
           );
         }
-        loadedDataSource = { dataSource: labels.dataSource, data };
+        loadedData = { dataSource: currentLabels.dataSource, data };
       }
       // Store the loaded labels and the corresponding data source in the state
-      let newLoadedLabels: LoadedLabels;
       set((draft) => {
-        let loadedDataSourceKey;
-        for (const [key, value] of draft.loadedLabelsDataSources) {
-          if (deepEqual(value.dataSource, loadedDataSource.dataSource)) {
-            loadedDataSourceKey = key;
+        let loadedDataKey;
+        for (const [key, value] of draft.loadedLabelsData) {
+          if (deepEqual(value.dataSource, loadedData.dataSource)) {
+            loadedDataKey = key;
             break;
           }
         }
-        if (loadedDataSourceKey === undefined) {
+        if (loadedDataKey === undefined) {
           do {
-            loadedDataSourceKey = crypto.randomUUID();
-          } while (draft.loadedLabelsDataSources.has(loadedDataSourceKey));
+            loadedDataKey = crypto.randomUUID();
+          } while (draft.loadedLabelsData.has(loadedDataKey));
         }
-        newLoadedLabels = { loadedDataSourceKey };
-        draft.loadedLabels.set(labelsId, newLoadedLabels);
-        draft.loadedLabelsDataSources.set(
-          loadedDataSourceKey,
-          loadedDataSource,
-        );
+        draft.loadedLabels.set(labelsId, loadedDataKey);
+        draft.loadedLabelsData.set(loadedDataKey, loadedData);
       });
       // Clean up old data if the loaded data source has changed
       if (
-        oldLoadedDataSource !== undefined &&
-        oldLoadedDataSource.data !== loadedDataSource.data
+        oldLoadedData !== undefined &&
+        oldLoadedData.data !== loadedData.data
       ) {
-        oldLoadedDataSource.data.destroy();
+        oldLoadedData.data.destroy();
       }
-      return newLoadedLabels!;
+      return loadedData.data;
     },
     (_labelsId, options) => options?.signal,
   ),
   unloadLabels: (labelsId) => {
     const state = get();
-    const loadedLabels = state.loadedLabels.get(labelsId);
-    if (loadedLabels === undefined) {
+    const loadedDataKey = state.loadedLabels.get(labelsId);
+    if (loadedDataKey === undefined) {
       return false;
     }
-    const loadedDataSource = state.loadedLabelsDataSources.get(
-      loadedLabels.loadedDataSourceKey,
-    );
-    if (loadedDataSource === undefined) {
+    const loadedData = state.loadedLabelsData.get(loadedDataKey);
+    if (loadedData === undefined) {
       throw new Error(`Data source for labels with ID ${labelsId} not loaded.`);
     }
     let destroy = true;
-    for (const [otherLabelsId, otherLoadedLabels] of state.loadedLabels) {
-      if (
-        otherLabelsId !== labelsId &&
-        otherLoadedLabels.loadedDataSourceKey ===
-          loadedLabels.loadedDataSourceKey
-      ) {
+    for (const [otherLabelsId, otherLoadedData] of state.loadedLabels) {
+      if (otherLabelsId !== labelsId && otherLoadedData === loadedDataKey) {
         destroy = false;
         break;
       }
@@ -225,11 +213,11 @@ export const createLabelsSlice: TissUUmapsStateCreator<LabelsSlice> = (
     set((draft) => {
       draft.loadedLabels.delete(labelsId);
       if (destroy) {
-        draft.loadedLabelsDataSources.delete(loadedLabels.loadedDataSourceKey);
+        draft.loadedLabelsData.delete(loadedDataKey);
       }
     });
     if (destroy) {
-      loadedDataSource.data.destroy();
+      loadedData.data.destroy();
     }
     return true;
   },
@@ -239,6 +227,6 @@ function createInitialLabelsSliceState(): LabelsSliceState {
   return {
     labels: [],
     loadedLabels: new Map(),
-    loadedLabelsDataSources: new Map(),
+    loadedLabelsData: new Map(),
   };
 }

--- a/apps/tissuumaps/src/store/slices/points.ts
+++ b/apps/tissuumaps/src/store/slices/points.ts
@@ -10,11 +10,7 @@ import {
 import { deduplicate } from "../deduplicate";
 import { type TissUUmapsStateCreator } from "../index";
 
-type LoadedPoints = {
-  loadedDataSourceKey: string;
-};
-
-type LoadedPointsDataSource = {
+type LoadedPointsData = {
   dataSource: PointsDataSource;
   data: PointsData;
   loadedCoordinates: Map<string, Float32Array>;
@@ -24,8 +20,8 @@ export type PointsSlice = PointsSliceState & PointsSliceActions;
 
 export type PointsSliceState = {
   points: Points[];
-  loadedPoints: Map<string, LoadedPoints>;
-  loadedPointsDataSources: Map<string, LoadedPointsDataSource>;
+  loadedPoints: Map<string, string>;
+  loadedPointsData: Map<string, LoadedPointsData>;
 };
 
 export type PointsSliceActions = {
@@ -41,7 +37,7 @@ export type PointsSliceActions = {
       reload?: boolean;
       onProgress?: ProgressCallback;
     },
-  ) => Promise<LoadedPoints>;
+  ) => Promise<PointsData>;
   loadPointsCoordinates: (
     pointsId: string,
     dimension: string,
@@ -116,8 +112,8 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
   },
   clearPoints: () => {
     const state = get();
-    for (const loadedDataSource of state.loadedPointsDataSources.values()) {
-      loadedDataSource.data.destroy();
+    for (const loadedData of state.loadedPointsData.values()) {
+      loadedData.data.destroy();
     }
     set(createInitialPointsSliceState());
   },
@@ -127,25 +123,28 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
       signal?.throwIfAborted();
       // Check if the points are already loaded
       const state = get();
-      const loadedPoints = state.loadedPoints.get(pointsId);
-      if (loadedPoints !== undefined && !reload) {
-        return loadedPoints;
+      const loadedDataKey = state.loadedPoints.get(pointsId);
+      if (loadedDataKey !== undefined && !reload) {
+        const loadedData = state.loadedPointsData.get(loadedDataKey);
+        if (loadedData !== undefined) {
+          return loadedData.data;
+        }
       }
       // Find the points and the corresponding data source (if loaded)
       const points = state.points.find((points) => points.id === pointsId);
       if (points === undefined) {
         throw new Error(`Points with ID ${pointsId} not found.`);
       }
-      let oldLoadedDataSource: LoadedPointsDataSource | undefined;
-      for (const loadedDataSource of state.loadedPointsDataSources.values()) {
-        if (deepEqual(loadedDataSource.dataSource, points.dataSource)) {
-          oldLoadedDataSource = loadedDataSource;
+      let oldLoadedData: LoadedPointsData | undefined;
+      for (const loadedData of state.loadedPointsData.values()) {
+        if (deepEqual(loadedData.dataSource, points.dataSource)) {
+          oldLoadedData = loadedData;
           break;
         }
       }
       // Load the data source if not already loaded or if a reload has been requested
-      let loadedDataSource = oldLoadedDataSource;
-      if (loadedDataSource === undefined || reload) {
+      let loadedData = oldLoadedData;
+      if (loadedData === undefined || reload) {
         const { dataStorageFactory } =
           state.pointsDataStorageRegistry.get(points.dataSource.type) ?? {};
         if (dataStorageFactory === undefined) {
@@ -174,42 +173,37 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
             "AbortError",
           );
         }
-        loadedDataSource = {
+        loadedData = {
           dataSource: currentPoints.dataSource,
           data,
           loadedCoordinates: new Map(),
         };
       }
       // Store the loaded points and the corresponding data source in the state
-      let newLoadedPoints: LoadedPoints;
       set((draft) => {
-        let loadedDataSourceKey;
-        for (const [key, value] of draft.loadedPointsDataSources) {
-          if (deepEqual(value.dataSource, loadedDataSource.dataSource)) {
-            loadedDataSourceKey = key;
+        let loadedDataKey;
+        for (const [key, value] of draft.loadedPointsData) {
+          if (deepEqual(value.dataSource, loadedData.dataSource)) {
+            loadedDataKey = key;
             break;
           }
         }
-        if (loadedDataSourceKey === undefined) {
+        if (loadedDataKey === undefined) {
           do {
-            loadedDataSourceKey = crypto.randomUUID();
-          } while (draft.loadedPointsDataSources.has(loadedDataSourceKey));
+            loadedDataKey = crypto.randomUUID();
+          } while (draft.loadedPointsData.has(loadedDataKey));
         }
-        newLoadedPoints = { loadedDataSourceKey };
-        draft.loadedPoints.set(pointsId, newLoadedPoints);
-        draft.loadedPointsDataSources.set(
-          loadedDataSourceKey,
-          loadedDataSource,
-        );
+        draft.loadedPoints.set(pointsId, loadedDataKey);
+        draft.loadedPointsData.set(loadedDataKey, loadedData);
       });
       // Clean up old data if the loaded data source has changed
       if (
-        oldLoadedDataSource !== undefined &&
-        oldLoadedDataSource.data !== loadedDataSource.data
+        oldLoadedData !== undefined &&
+        oldLoadedData.data !== loadedData.data
       ) {
-        oldLoadedDataSource.data.destroy();
+        oldLoadedData.data.destroy();
       }
-      return newLoadedPoints!;
+      return loadedData.data;
     },
     (_pointsId, options) => options?.signal,
   ),
@@ -219,53 +213,43 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
       signal?.throwIfAborted();
       // Check if the points, the corresponding data source, and the requested coordinates are already loaded
       const state = get();
-      const loadedPoints = state.loadedPoints.get(pointsId);
-      if (loadedPoints === undefined) {
+      const loadedDataKey = state.loadedPoints.get(pointsId);
+      if (loadedDataKey === undefined) {
         throw new Error(`Points with ID ${pointsId} not loaded.`);
       }
-      const loadedDataSource = state.loadedPointsDataSources.get(
-        loadedPoints.loadedDataSourceKey,
-      );
-      if (loadedDataSource === undefined) {
+      const loadedData = state.loadedPointsData.get(loadedDataKey);
+      if (loadedData === undefined) {
         throw new Error(
           `Data source for points with ID ${pointsId} not loaded.`,
         );
       }
-      const oldCoordinates = loadedDataSource.loadedCoordinates.get(dimension);
+      const oldCoordinates = loadedData.loadedCoordinates.get(dimension);
       if (oldCoordinates !== undefined && !reload) {
         return oldCoordinates;
       }
       // Load the requested coordinates
-      const coordinates = await loadedDataSource.data.loadCoordinates(
-        dimension,
-        {
-          signal,
-          onProgress,
-        },
-      );
+      const coordinates = await loadedData.data.loadCoordinates(dimension, {
+        signal,
+        onProgress,
+      });
       signal?.throwIfAborted();
       // Check if the points have been unloaded or their data source has changed
       const currentState = get();
-      const currentLoadedPoints = currentState.loadedPoints.get(pointsId);
+      const currentLoadedDataKey = currentState.loadedPoints.get(pointsId);
       if (
-        currentLoadedPoints === undefined ||
-        currentLoadedPoints.loadedDataSourceKey !==
-          loadedPoints.loadedDataSourceKey
+        currentLoadedDataKey === undefined ||
+        currentLoadedDataKey !== loadedDataKey
       ) {
         throw new DOMException(
           `Points with ID ${pointsId} have been unloaded or their data source has changed.`,
           "AbortError",
         );
       }
-      const currentLoadedDataSource = currentState.loadedPointsDataSources.get(
-        currentLoadedPoints.loadedDataSourceKey,
-      );
+      const currentLoadedData =
+        currentState.loadedPointsData.get(currentLoadedDataKey);
       if (
-        currentLoadedDataSource === undefined ||
-        !deepEqual(
-          currentLoadedDataSource.dataSource,
-          loadedDataSource.dataSource,
-        )
+        currentLoadedData === undefined ||
+        !deepEqual(currentLoadedData.dataSource, loadedData.dataSource)
       ) {
         throw new DOMException(
           `Data source for points with ID ${pointsId} has been unloaded or changed.`,
@@ -274,11 +258,9 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
       }
       // Store the loaded coordinates in the state
       set((draft) => {
-        const loadedPointsDraft = draft.loadedPoints.get(pointsId)!;
-        const loadedDataSourceDraft = draft.loadedPointsDataSources.get(
-          loadedPointsDraft.loadedDataSourceKey,
-        )!;
-        loadedDataSourceDraft.loadedCoordinates.set(dimension, coordinates);
+        const loadedDataDraft =
+          draft.loadedPointsData.get(currentLoadedDataKey)!;
+        loadedDataDraft.loadedCoordinates.set(dimension, coordinates);
       });
       return coordinates;
     },
@@ -286,23 +268,17 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
   ),
   unloadPoints: (pointsId) => {
     const state = get();
-    const loadedPoints = state.loadedPoints.get(pointsId);
-    if (loadedPoints === undefined) {
+    const loadedDataKey = state.loadedPoints.get(pointsId);
+    if (loadedDataKey === undefined) {
       return false;
     }
-    const loadedDataSource = state.loadedPointsDataSources.get(
-      loadedPoints.loadedDataSourceKey,
-    );
-    if (loadedDataSource === undefined) {
+    const loadedData = state.loadedPointsData.get(loadedDataKey);
+    if (loadedData === undefined) {
       throw new Error(`Data source for points with ID ${pointsId} not loaded.`);
     }
     let destroy = true;
-    for (const [otherPointsId, otherLoadedPoints] of state.loadedPoints) {
-      if (
-        otherPointsId !== pointsId &&
-        otherLoadedPoints.loadedDataSourceKey ===
-          loadedPoints.loadedDataSourceKey
-      ) {
+    for (const [otherPointsId, otherLoadedDataKey] of state.loadedPoints) {
+      if (otherPointsId !== pointsId && otherLoadedDataKey === loadedDataKey) {
         destroy = false;
         break;
       }
@@ -310,11 +286,11 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
     set((draft) => {
       draft.loadedPoints.delete(pointsId);
       if (destroy) {
-        draft.loadedPointsDataSources.delete(loadedPoints.loadedDataSourceKey);
+        draft.loadedPointsData.delete(loadedDataKey);
       }
     });
     if (destroy) {
-      loadedDataSource.data.destroy();
+      loadedData.data.destroy();
     }
     return true;
   },
@@ -324,6 +300,6 @@ function createInitialPointsSliceState(): PointsSliceState {
   return {
     points: [],
     loadedPoints: new Map(),
-    loadedPointsDataSources: new Map(),
+    loadedPointsData: new Map(),
   };
 }

--- a/apps/tissuumaps/src/store/slices/shapes.ts
+++ b/apps/tissuumaps/src/store/slices/shapes.ts
@@ -11,11 +11,7 @@ import {
 import { deduplicate } from "../deduplicate";
 import { type TissUUmapsStateCreator } from "../index";
 
-type LoadedShapes = {
-  loadedDataSourceKey: string;
-};
-
-type LoadedShapesDataSource = {
+type LoadedShapesData = {
   dataSource: ShapesDataSource;
   data: ShapesData;
   loadedMultiPolygons?: MultiPolygon[];
@@ -25,8 +21,8 @@ export type ShapesSlice = ShapesSliceState & ShapesSliceActions;
 
 export type ShapesSliceState = {
   shapes: Shapes[];
-  loadedShapes: Map<string, LoadedShapes>;
-  loadedShapesDataSources: Map<string, LoadedShapesDataSource>;
+  loadedShapes: Map<string, string>;
+  loadedShapesData: Map<string, LoadedShapesData>;
 };
 
 export type ShapesSliceActions = {
@@ -42,7 +38,7 @@ export type ShapesSliceActions = {
       reload?: boolean;
       onProgress?: ProgressCallback;
     },
-  ) => Promise<LoadedShapes>;
+  ) => Promise<ShapesData>;
   loadShapesMultiPolygons: (
     shapesId: string,
     options?: {
@@ -116,8 +112,8 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
   },
   clearShapes: () => {
     const state = get();
-    for (const loadedDataSource of state.loadedShapesDataSources.values()) {
-      loadedDataSource.data.destroy();
+    for (const loadedData of state.loadedShapesData.values()) {
+      loadedData.data.destroy();
     }
     set(createInitialShapesSliceState());
   },
@@ -127,25 +123,28 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
       signal?.throwIfAborted();
       // Check if the shapes are already loaded
       const state = get();
-      const loadedShapes = state.loadedShapes.get(shapesId);
-      if (loadedShapes !== undefined && !reload) {
-        return loadedShapes;
+      const loadedDataKey = state.loadedShapes.get(shapesId);
+      if (loadedDataKey !== undefined && !reload) {
+        const loadedData = state.loadedShapesData.get(loadedDataKey);
+        if (loadedData !== undefined) {
+          return loadedData.data;
+        }
       }
       // Find the shapes and the corresponding data source (if loaded)
       const shapes = state.shapes.find((shapes) => shapes.id === shapesId);
       if (shapes === undefined) {
         throw new Error(`Shapes with ID ${shapesId} not found.`);
       }
-      let oldLoadedDataSource: LoadedShapesDataSource | undefined;
-      for (const loadedDataSource of state.loadedShapesDataSources.values()) {
-        if (deepEqual(loadedDataSource.dataSource, shapes.dataSource)) {
-          oldLoadedDataSource = loadedDataSource;
+      let oldLoadedData: LoadedShapesData | undefined;
+      for (const loadedData of state.loadedShapesData.values()) {
+        if (deepEqual(loadedData.dataSource, shapes.dataSource)) {
+          oldLoadedData = loadedData;
           break;
         }
       }
       // Load the data source if not already loaded or if a reload has been requested
-      let loadedDataSource = oldLoadedDataSource;
-      if (loadedDataSource === undefined || reload) {
+      let loadedData = oldLoadedData;
+      if (loadedData === undefined || reload) {
         const { dataStorageFactory } =
           state.shapesDataStorageRegistry.get(shapes.dataSource.type) ?? {};
         if (dataStorageFactory === undefined) {
@@ -174,38 +173,33 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
             "AbortError",
           );
         }
-        loadedDataSource = { dataSource: shapes.dataSource, data };
+        loadedData = { dataSource: currentShapes.dataSource, data };
       }
       // Store the loaded shapes and the corresponding data source in the state
-      let newLoadedShapes: LoadedShapes;
       set((draft) => {
-        let loadedDataSourceKey;
-        for (const [key, value] of draft.loadedShapesDataSources) {
-          if (deepEqual(value.dataSource, loadedDataSource.dataSource)) {
-            loadedDataSourceKey = key;
+        let loadedDataKey;
+        for (const [key, value] of draft.loadedShapesData) {
+          if (deepEqual(value.dataSource, loadedData.dataSource)) {
+            loadedDataKey = key;
             break;
           }
         }
-        if (loadedDataSourceKey === undefined) {
+        if (loadedDataKey === undefined) {
           do {
-            loadedDataSourceKey = crypto.randomUUID();
-          } while (draft.loadedShapesDataSources.has(loadedDataSourceKey));
+            loadedDataKey = crypto.randomUUID();
+          } while (draft.loadedShapesData.has(loadedDataKey));
         }
-        newLoadedShapes = { loadedDataSourceKey };
-        draft.loadedShapes.set(shapesId, newLoadedShapes);
-        draft.loadedShapesDataSources.set(
-          loadedDataSourceKey,
-          loadedDataSource,
-        );
+        draft.loadedShapes.set(shapesId, loadedDataKey);
+        draft.loadedShapesData.set(loadedDataKey, loadedData);
       });
       // Clean up old data if the loaded data source has changed
       if (
-        oldLoadedDataSource !== undefined &&
-        oldLoadedDataSource.data !== loadedDataSource.data
+        oldLoadedData !== undefined &&
+        oldLoadedData.data !== loadedData.data
       ) {
-        oldLoadedDataSource.data.destroy();
+        oldLoadedData.data.destroy();
       }
-      return newLoadedShapes!;
+      return loadedData.data;
     },
     (_shapesId, options) => options?.signal,
   ),
@@ -215,50 +209,43 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
       signal?.throwIfAborted();
       // Check if the shapes, the corresponding data source, and the requested multi-polygons are already loaded
       const state = get();
-      const loadedShapes = state.loadedShapes.get(shapesId);
-      if (loadedShapes === undefined) {
+      const loadedDataKey = state.loadedShapes.get(shapesId);
+      if (loadedDataKey === undefined) {
         throw new Error(`Shapes with ID ${shapesId} not loaded.`);
       }
-      const loadedDataSource = state.loadedShapesDataSources.get(
-        loadedShapes.loadedDataSourceKey,
-      );
-      if (loadedDataSource === undefined) {
+      const loadedData = state.loadedShapesData.get(loadedDataKey);
+      if (loadedData === undefined) {
         throw new Error(
           `Data source for shapes with ID ${shapesId} not loaded.`,
         );
       }
-      const oldMultiPolygons = loadedDataSource.loadedMultiPolygons;
+      const oldMultiPolygons = loadedData.loadedMultiPolygons;
       if (oldMultiPolygons !== undefined && !reload) {
         return oldMultiPolygons;
       }
       // Load the requested multi-polygons
-      const multiPolygons = await loadedDataSource.data.loadMultiPolygons({
+      const multiPolygons = await loadedData.data.loadMultiPolygons({
         signal,
         onProgress,
       });
       signal?.throwIfAborted();
       // Check if the shapes have been unloaded or their data source has changed
       const currentState = get();
-      const currentLoadedShapes = currentState.loadedShapes.get(shapesId);
+      const currentLoadedDataKey = currentState.loadedShapes.get(shapesId);
       if (
-        currentLoadedShapes === undefined ||
-        currentLoadedShapes.loadedDataSourceKey !==
-          loadedShapes.loadedDataSourceKey
+        currentLoadedDataKey === undefined ||
+        currentLoadedDataKey !== loadedDataKey
       ) {
         throw new DOMException(
           `Shapes with ID ${shapesId} have been unloaded or their data source has changed.`,
           "AbortError",
         );
       }
-      const currentLoadedDataSource = currentState.loadedShapesDataSources.get(
-        currentLoadedShapes.loadedDataSourceKey,
-      );
+      const currentLoadedData =
+        currentState.loadedShapesData.get(currentLoadedDataKey);
       if (
-        currentLoadedDataSource === undefined ||
-        !deepEqual(
-          currentLoadedDataSource.dataSource,
-          loadedDataSource.dataSource,
-        )
+        currentLoadedData === undefined ||
+        !deepEqual(currentLoadedData.dataSource, loadedData.dataSource)
       ) {
         throw new DOMException(
           `Data source for shapes with ID ${shapesId} has been unloaded or changed.`,
@@ -267,11 +254,9 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
       }
       // Store the loaded multi-polygons in the state
       set((draft) => {
-        const loadedShapes = draft.loadedShapes.get(shapesId)!;
-        const loadedDataSourceDraft = draft.loadedShapesDataSources.get(
-          loadedShapes.loadedDataSourceKey,
-        )!;
-        loadedDataSourceDraft.loadedMultiPolygons = multiPolygons;
+        const loadedDataDraft =
+          draft.loadedShapesData.get(currentLoadedDataKey)!;
+        loadedDataDraft.loadedMultiPolygons = multiPolygons;
       });
       return multiPolygons;
     },
@@ -279,23 +264,17 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
   ),
   unloadShapes: (shapesId) => {
     const state = get();
-    const loadedShapes = state.loadedShapes.get(shapesId);
-    if (loadedShapes === undefined) {
+    const loadedDataKey = state.loadedShapes.get(shapesId);
+    if (loadedDataKey === undefined) {
       return false;
     }
-    const loadedDataSource = state.loadedShapesDataSources.get(
-      loadedShapes.loadedDataSourceKey,
-    );
-    if (loadedDataSource === undefined) {
+    const loadedData = state.loadedShapesData.get(loadedDataKey);
+    if (loadedData === undefined) {
       throw new Error(`Data source for shapes with ID ${shapesId} not loaded.`);
     }
     let destroy = true;
-    for (const [otherShapesId, otherLoadedShapes] of state.loadedShapes) {
-      if (
-        otherShapesId !== shapesId &&
-        otherLoadedShapes.loadedDataSourceKey ===
-          loadedShapes.loadedDataSourceKey
-      ) {
+    for (const [otherShapesId, otherLoadedDataKey] of state.loadedShapes) {
+      if (otherShapesId !== shapesId && otherLoadedDataKey === loadedDataKey) {
         destroy = false;
         break;
       }
@@ -303,11 +282,11 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
     set((draft) => {
       draft.loadedShapes.delete(shapesId);
       if (destroy) {
-        draft.loadedShapesDataSources.delete(loadedShapes.loadedDataSourceKey);
+        draft.loadedShapesData.delete(loadedDataKey);
       }
     });
     if (destroy) {
-      loadedDataSource.data.destroy();
+      loadedData.data.destroy();
     }
     return true;
   },
@@ -317,6 +296,6 @@ function createInitialShapesSliceState(): ShapesSliceState {
   return {
     shapes: [],
     loadedShapes: new Map(),
-    loadedShapesDataSources: new Map(),
+    loadedShapesData: new Map(),
   };
 }

--- a/apps/tissuumaps/src/store/slices/table.ts
+++ b/apps/tissuumaps/src/store/slices/table.ts
@@ -11,11 +11,7 @@ import {
 import { deduplicate } from "../deduplicate";
 import { type TissUUmapsStateCreator } from "../index";
 
-type LoadedTable = {
-  loadedDataSourceKey: string;
-};
-
-type LoadedTableDataSource = {
+type LoadedTableData = {
   dataSource: TableDataSource;
   data: TableData;
   loadedValues: Map<string, MappableArrayLike<unknown>>;
@@ -26,8 +22,8 @@ export type TableSlice = TableSliceState & TableSliceActions;
 
 export type TableSliceState = {
   tables: Table[];
-  loadedTables: Map<string, LoadedTable>;
-  loadedTableDataSources: Map<string, LoadedTableDataSource>;
+  loadedTables: Map<string, string>;
+  loadedTableData: Map<string, LoadedTableData>;
 };
 
 export type TableSliceActions = {
@@ -43,7 +39,7 @@ export type TableSliceActions = {
       reload?: boolean;
       onProgress?: ProgressCallback;
     },
-  ) => Promise<LoadedTable>;
+  ) => Promise<TableData>;
   loadTableValues: <T>(
     tableId: string,
     column: string,
@@ -127,8 +123,8 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
   },
   clearTables: () => {
     const state = get();
-    for (const loadedDataSource of state.loadedTableDataSources.values()) {
-      loadedDataSource.data.destroy();
+    for (const loadedData of state.loadedTableData.values()) {
+      loadedData.data.destroy();
     }
     set(createInitialTableSliceState());
   },
@@ -138,25 +134,28 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
       signal?.throwIfAborted();
       // Check if the table is already loaded
       const state = get();
-      const loadedTable = state.loadedTables.get(tableId);
-      if (loadedTable !== undefined && !reload) {
-        return loadedTable;
+      const loadedDataKey = state.loadedTables.get(tableId);
+      if (loadedDataKey !== undefined && !reload) {
+        const loadedData = state.loadedTableData.get(loadedDataKey);
+        if (loadedData !== undefined) {
+          return loadedData.data;
+        }
       }
       // Find the table and the corresponding data source (if loaded)
       const table = state.tables.find((table) => table.id === tableId);
       if (table === undefined) {
         throw new Error(`Table with ID ${tableId} not found.`);
       }
-      let oldLoadedDataSource: LoadedTableDataSource | undefined;
-      for (const loadedDataSource of state.loadedTableDataSources.values()) {
-        if (deepEqual(loadedDataSource.dataSource, table.dataSource)) {
-          oldLoadedDataSource = loadedDataSource;
+      let oldLoadedData: LoadedTableData | undefined;
+      for (const loadedData of state.loadedTableData.values()) {
+        if (deepEqual(loadedData.dataSource, table.dataSource)) {
+          oldLoadedData = loadedData;
           break;
         }
       }
       // Load the data source if not already loaded or if a reload has been requested
-      let loadedDataSource = oldLoadedDataSource;
-      if (loadedDataSource === undefined || reload) {
+      let loadedData = oldLoadedData;
+      if (loadedData === undefined || reload) {
         const { dataStorageFactory } =
           state.tableDataStorageRegistry.get(table.dataSource.type) ?? {};
         if (dataStorageFactory === undefined) {
@@ -185,7 +184,7 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
             "AbortError",
           );
         }
-        loadedDataSource = {
+        loadedData = {
           dataSource: currentTable.dataSource,
           data,
           loadedValues: new Map(),
@@ -193,32 +192,30 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
         };
       }
       // Store the loaded table and the corresponding data source in the state
-      let newLoadedTable: LoadedTable;
       set((draft) => {
-        let loadedDataSourceKey;
-        for (const [key, value] of draft.loadedTableDataSources) {
-          if (deepEqual(value.dataSource, loadedDataSource.dataSource)) {
-            loadedDataSourceKey = key;
+        let loadedDataKey;
+        for (const [key, value] of draft.loadedTableData) {
+          if (deepEqual(value.dataSource, loadedData.dataSource)) {
+            loadedDataKey = key;
             break;
           }
         }
-        if (loadedDataSourceKey === undefined) {
+        if (loadedDataKey === undefined) {
           do {
-            loadedDataSourceKey = crypto.randomUUID();
-          } while (draft.loadedTableDataSources.has(loadedDataSourceKey));
+            loadedDataKey = crypto.randomUUID();
+          } while (draft.loadedTableData.has(loadedDataKey));
         }
-        newLoadedTable = { loadedDataSourceKey };
-        draft.loadedTables.set(tableId, newLoadedTable);
-        draft.loadedTableDataSources.set(loadedDataSourceKey, loadedDataSource);
+        draft.loadedTables.set(tableId, loadedDataKey);
+        draft.loadedTableData.set(loadedDataKey, loadedData);
       });
       // Clean up old data if the loaded data source has changed
       if (
-        oldLoadedDataSource !== undefined &&
-        oldLoadedDataSource.data !== loadedDataSource.data
+        oldLoadedData !== undefined &&
+        oldLoadedData.data !== loadedData.data
       ) {
-        oldLoadedDataSource.data.destroy();
+        oldLoadedData.data.destroy();
       }
-      return newLoadedTable!;
+      return loadedData.data;
     },
     (_tableId, options) => options?.signal,
   ),
@@ -236,48 +233,41 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
       signal?.throwIfAborted();
       // Check if the table, the corresponding data source, and the requested values are already loaded
       const state = get();
-      const loadedTable = state.loadedTables.get(tableId);
-      if (loadedTable === undefined) {
+      const loadedDataKey = state.loadedTables.get(tableId);
+      if (loadedDataKey === undefined) {
         throw new Error(`Table with ID ${tableId} not loaded.`);
       }
-      const loadedDataSource = state.loadedTableDataSources.get(
-        loadedTable.loadedDataSourceKey,
-      );
-      if (loadedDataSource === undefined) {
+      const loadedData = state.loadedTableData.get(loadedDataKey);
+      if (loadedData === undefined) {
         throw new Error(`Data source for table with ID ${tableId} not loaded.`);
       }
-      const oldValues = loadedDataSource.loadedValues.get(column);
+      const oldValues = loadedData.loadedValues.get(column);
       if (oldValues !== undefined && !reload) {
         return oldValues as MappableArrayLike<T>;
       }
       // Load the requested values
-      const values = await loadedDataSource.data.loadValues<T>(column, {
+      const values = await loadedData.data.loadValues<T>(column, {
         signal,
         onProgress,
       });
       signal?.throwIfAborted();
       // Check if the table has been unloaded or its data source has changed
       const currentState = get();
-      const currentLoadedTable = currentState.loadedTables.get(tableId);
+      const currentLoadedDataKey = currentState.loadedTables.get(tableId);
       if (
-        currentLoadedTable === undefined ||
-        currentLoadedTable.loadedDataSourceKey !==
-          loadedTable.loadedDataSourceKey
+        currentLoadedDataKey === undefined ||
+        currentLoadedDataKey !== loadedDataKey
       ) {
         throw new DOMException(
           `Table with ID ${tableId} has been unloaded or its data source has changed.`,
           "AbortError",
         );
       }
-      const currentLoadedDataSource = currentState.loadedTableDataSources.get(
-        currentLoadedTable.loadedDataSourceKey,
-      );
+      const currentLoadedData =
+        currentState.loadedTableData.get(currentLoadedDataKey);
       if (
-        currentLoadedDataSource === undefined ||
-        !deepEqual(
-          currentLoadedDataSource.dataSource,
-          loadedDataSource.dataSource,
-        )
+        currentLoadedData === undefined ||
+        !deepEqual(currentLoadedData.dataSource, loadedData.dataSource)
       ) {
         throw new DOMException(
           `Data source for table with ID ${tableId} has been unloaded or changed.`,
@@ -286,11 +276,9 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
       }
       // Store the loaded values in the state
       set((draft) => {
-        const loadedTableDraft = draft.loadedTables.get(tableId)!;
-        const loadedDataSourceDraft = draft.loadedTableDataSources.get(
-          loadedTableDraft.loadedDataSourceKey,
-        )!;
-        loadedDataSourceDraft.loadedValues.set(column, values);
+        const loadedDataDraft =
+          draft.loadedTableData.get(currentLoadedDataKey)!;
+        loadedDataDraft.loadedValues.set(column, values);
       });
       return values;
     },
@@ -302,47 +290,40 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
       signal?.throwIfAborted();
       // Check if the table, the corresponding data source, and the requested value range are already loaded
       const state = get();
-      const loadedTable = state.loadedTables.get(tableId);
-      if (loadedTable === undefined) {
+      const loadedDataKey = state.loadedTables.get(tableId);
+      if (loadedDataKey === undefined) {
         throw new Error(`Table with ID ${tableId} not loaded.`);
       }
-      const loadedDataSource = state.loadedTableDataSources.get(
-        loadedTable.loadedDataSourceKey,
-      );
-      if (loadedDataSource === undefined) {
+      const loadedData = state.loadedTableData.get(loadedDataKey);
+      if (loadedData === undefined) {
         throw new Error(`Data source for table with ID ${tableId} not loaded.`);
       }
-      if (loadedDataSource.loadedValueRanges.has(column) && !reload) {
-        return loadedDataSource.loadedValueRanges.get(column);
+      if (loadedData.loadedValueRanges.has(column) && !reload) {
+        return loadedData.loadedValueRanges.get(column);
       }
       // Load the requested value range
-      const valueRange = await loadedDataSource.data.loadValueRange(column, {
+      const valueRange = await loadedData.data.loadValueRange(column, {
         signal,
         onProgress,
       });
       signal?.throwIfAborted();
       // Check if the table has been unloaded or its data source has changed
       const currentState = get();
-      const currentLoadedTable = currentState.loadedTables.get(tableId);
+      const currentLoadedDataKey = currentState.loadedTables.get(tableId);
       if (
-        currentLoadedTable === undefined ||
-        currentLoadedTable.loadedDataSourceKey !==
-          loadedTable.loadedDataSourceKey
+        currentLoadedDataKey === undefined ||
+        currentLoadedDataKey !== loadedDataKey
       ) {
         throw new DOMException(
           `Table with ID ${tableId} has been unloaded or its data source has changed.`,
           "AbortError",
         );
       }
-      const currentLoadedDataSource = currentState.loadedTableDataSources.get(
-        currentLoadedTable.loadedDataSourceKey,
-      );
+      const currentLoadedData =
+        currentState.loadedTableData.get(currentLoadedDataKey);
       if (
-        currentLoadedDataSource === undefined ||
-        !deepEqual(
-          currentLoadedDataSource.dataSource,
-          loadedDataSource.dataSource,
-        )
+        currentLoadedData === undefined ||
+        !deepEqual(currentLoadedData.dataSource, loadedData.dataSource)
       ) {
         throw new DOMException(
           `Data source for table with ID ${tableId} has been unloaded or changed.`,
@@ -351,11 +332,9 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
       }
       // Store the loaded value range in the state
       set((draft) => {
-        const loadedTableDraft = draft.loadedTables.get(tableId)!;
-        const loadedDataSourceDraft = draft.loadedTableDataSources.get(
-          loadedTableDraft.loadedDataSourceKey,
-        )!;
-        loadedDataSourceDraft.loadedValueRanges.set(column, valueRange);
+        const loadedDataDraft =
+          draft.loadedTableData.get(currentLoadedDataKey)!;
+        loadedDataDraft.loadedValueRanges.set(column, valueRange);
       });
       return valueRange;
     },
@@ -363,22 +342,17 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
   ),
   unloadTable: (tableId) => {
     const state = get();
-    const loadedTable = state.loadedTables.get(tableId);
-    if (loadedTable === undefined) {
+    const loadedDataKey = state.loadedTables.get(tableId);
+    if (loadedDataKey === undefined) {
       return false;
     }
-    const loadedDataSource = state.loadedTableDataSources.get(
-      loadedTable.loadedDataSourceKey,
-    );
-    if (loadedDataSource === undefined) {
+    const loadedData = state.loadedTableData.get(loadedDataKey);
+    if (loadedData === undefined) {
       throw new Error(`Data source for table with ID ${tableId} not loaded.`);
     }
     let destroy = true;
-    for (const [otherTableId, otherLoadedTable] of state.loadedTables) {
-      if (
-        otherTableId !== tableId &&
-        otherLoadedTable.loadedDataSourceKey === loadedTable.loadedDataSourceKey
-      ) {
+    for (const [otherTableId, otherLoadedDataKey] of state.loadedTables) {
+      if (otherTableId !== tableId && otherLoadedDataKey === loadedDataKey) {
         destroy = false;
         break;
       }
@@ -386,11 +360,11 @@ export const createTableSlice: TissUUmapsStateCreator<TableSlice> = (
     set((draft) => {
       draft.loadedTables.delete(tableId);
       if (destroy) {
-        draft.loadedTableDataSources.delete(loadedTable.loadedDataSourceKey);
+        draft.loadedTableData.delete(loadedDataKey);
       }
     });
     if (destroy) {
-      loadedDataSource.data.destroy();
+      loadedData.data.destroy();
     }
     return true;
   },
@@ -400,6 +374,6 @@ function createInitialTableSliceState(): TableSliceState {
   return {
     tables: [],
     loadedTables: new Map(),
-    loadedTableDataSources: new Map(),
+    loadedTableData: new Map(),
   };
 }

--- a/apps/tissuumaps/tsconfig.json
+++ b/apps/tissuumaps/tsconfig.json
@@ -8,7 +8,6 @@
     "types": ["vite/client"],
     "jsx": "react-jsx",
     // shadcn/ui
-    "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"]
     }


### PR DESCRIPTION
# References and relevant issues

None

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other

Refactor: simplify data caching in application state

# List of changes made

- loadedDataObject map now points directly to loadedData
- loadedData holds both the loaded data source and the cached data
- load action directly returns the data object
- revert to "traditional getters" in adapters
- some minor, unrelated fixes

# Use of AI

Changes were implemented manually

# Testing

The modified code base builds and runs as before

# Further comments

These commits were cherry-picked from the `feat/table` branch
