### PR TITLE
Fix: image settings do not synchronize

### DIFF
--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -453,11 +453,17 @@ export class OpenSeadragonController {
     if (tiledImageState.tiledImage === undefined) {
       throw new Error("Cannot update tiled image before it is created");
     }
-    const opacity = OpenSeadragonController._calculateOpacity(
+    const oldOpacity = tiledImageState.tiledImage.getOpacity();
+    const newOpacity = OpenSeadragonController._calculateOpacity(
       tiledImageState.ref,
     );
-    if (tiledImageState.tiledImage.getOpacity() !== opacity) {
-      tiledImageState.tiledImage.setOpacity(opacity);
+    if (oldOpacity !== newOpacity) {
+      tiledImageState.tiledImage.setOpacity(newOpacity);
+      if (oldOpacity === 0 && newOpacity > 0) {
+        // OpenSeadragon does not load tiles for invisible images,
+        // so we need to trigger a reload when an image becomes visible
+        tiledImageState.tiledImage.update(true);
+      }
     }
     this._updateTiledImageGeometry(tiledImageState);
   }

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -364,6 +364,7 @@ export class OpenSeadragonController {
       ) {
         tiledImageState = this._createTiledImage(i, ref);
       } else {
+        tiledImageState.ref = ref;
         const currentIndex = this._tiledImageStates.indexOf(tiledImageState);
         if (currentIndex !== i) {
           if (tiledImageState.tiledImage !== undefined) {


### PR DESCRIPTION
**The bug**: In OpenSeadragonController.ts:366, when _createOrUpdateTiledImages finds an existing tiled image state that matches a new ref, it calls _updateTiledImage(tiledImageState) — but tiledImageState.ref still points to the old ref from the previous synchronize call. So _calculateOpacity() reads the old opacity/visibility values, and since they haven't changed from the tiled image state's perspective, nothing gets updated. 

**The fix**: Set tiledImageState.ref = ref before doing any update logic, so the new opacity/visibility values are used when _calculateOpacity is called.
