### PR TITLE
Feat: add LayerConfigs UI

### DIFF
--- a/apps/tissuumaps/src/components/panels/ImagesPanel/ImageLayerConfigsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/ImagesPanel/ImageLayerConfigsWidget.tsx
@@ -1,0 +1,27 @@
+import {
+  type ImageLayerConfig,
+  createImageLayerConfig,
+} from "@tissuumaps/core";
+
+import { LayerConfigsWidget } from "@/components/widgets/LayerConfigsWidget";
+
+export type ImageLayerConfigsWidgetProps = {
+  layerConfigs: ImageLayerConfig[];
+  onChange: (newLayerConfigs: ImageLayerConfig[]) => void;
+  className?: string;
+};
+
+export function ImageLayerConfigsWidget({
+  layerConfigs,
+  onChange,
+  className,
+}: ImageLayerConfigsWidgetProps) {
+  return (
+    <LayerConfigsWidget
+      layerConfigs={layerConfigs}
+      createNewConfig={(layerId) => createImageLayerConfig({ layer: layerId })}
+      onChange={onChange}
+      className={className}
+    />
+  );
+}

--- a/apps/tissuumaps/src/components/panels/ImagesPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ImagesPanel/index.tsx
@@ -23,6 +23,7 @@ import { DataSourceWidget } from "@/components/widgets/DataSourceWidget";
 import { cn } from "@/lib/utils";
 import { useTissUUmaps } from "@/store";
 
+import { ImageLayerConfigsWidget } from "./ImageLayerConfigsWidget";
 import { ImageSettingsWidget } from "./ImageSettingsWidget";
 
 export type ImagesPanelProps = {
@@ -149,8 +150,14 @@ function ImageAccordionItem({ image, index }: ImageAccordionItemProps) {
             }}
             className="bg-card"
           />
+          <ImageLayerConfigsWidget
+            layerConfigs={image.layerConfigs}
+            onChange={(newLayerConfigs) =>
+              updateImage(image.id, { layerConfigs: newLayerConfigs })
+            }
+            className="bg-card"
+          />
           <ImageSettingsWidget image={image} className="bg-card" />
-          {/* TODO layer configs */}
         </AccordionPanel>
       </AccordionItem>
     </div>

--- a/apps/tissuumaps/src/components/panels/PointsPanel/PointsLayerConfigsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/PointsPanel/PointsLayerConfigsWidget.tsx
@@ -1,0 +1,118 @@
+import { useCallback } from "react";
+
+import {
+  type PointsLayerConfig,
+  createPointsLayerConfig,
+} from "@tissuumaps/core";
+
+import { Field, FieldLabel } from "@/components/common/field";
+import { SimpleAsyncCombobox } from "@/components/common/simple-combobox";
+import { LayerConfigsWidget } from "@/components/widgets/LayerConfigsWidget";
+import { useTissUUmaps } from "@/store";
+
+function usePointsDimensionSelector(pointsId: string | null) {
+  const loadPoints = useTissUUmaps((state) => state.loadPoints);
+
+  const suggestPointsDimensionQueries = useCallback(
+    async (currentQuery: string, options?: { signal?: AbortSignal }) => {
+      const { signal } = options ?? {};
+      signal?.throwIfAborted();
+      if (pointsId !== null) {
+        const data = await loadPoints(pointsId, { signal });
+        signal?.throwIfAborted();
+        return await data.suggestDimensionQueries(currentQuery, { signal });
+      }
+      return [];
+    },
+    [pointsId, loadPoints],
+  );
+
+  const resolvePointsDimensionQuery = useCallback(
+    async (query: string, options?: { signal?: AbortSignal }) => {
+      const { signal } = options ?? {};
+      signal?.throwIfAborted();
+      if (pointsId !== null) {
+        const data = await loadPoints(pointsId, { signal });
+        signal?.throwIfAborted();
+        return await data.resolveDimensionQuery(query, { signal });
+      }
+      return null;
+    },
+    [pointsId, loadPoints],
+  );
+
+  return { suggestPointsDimensionQueries, resolvePointsDimensionQuery };
+}
+
+export type PointsLayerConfigsWidgetProps = {
+  pointsId: string;
+  layerConfigs: PointsLayerConfig[];
+  onChange: (newLayerConfigs: PointsLayerConfig[]) => void;
+  className?: string;
+};
+
+export function PointsLayerConfigsWidget({
+  pointsId,
+  layerConfigs,
+  onChange,
+  className,
+}: PointsLayerConfigsWidgetProps) {
+  return (
+    <LayerConfigsWidget
+      layerConfigs={layerConfigs}
+      createNewConfig={(layerId) =>
+        createPointsLayerConfig({ layer: layerId, x: "", y: "" })
+      }
+      onChange={onChange}
+      extraFieldsLabel="Coordinates"
+      renderExtraFields={(config, update) => (
+        <PointsCoordinateFields
+          pointsId={pointsId}
+          config={config}
+          onUpdate={update}
+        />
+      )}
+      className={className}
+    />
+  );
+}
+
+type PointsCoordinateFieldsProps = {
+  pointsId: string;
+  config: PointsLayerConfig;
+  onUpdate: (updates: Partial<PointsLayerConfig>) => void;
+};
+
+function PointsCoordinateFields({
+  pointsId,
+  config,
+  onUpdate,
+}: PointsCoordinateFieldsProps) {
+  const { suggestPointsDimensionQueries, resolvePointsDimensionQuery } =
+    usePointsDimensionSelector(pointsId);
+
+  return (
+    <>
+      <Field>
+        <FieldLabel>X column</FieldLabel>
+        <SimpleAsyncCombobox
+          suggestQueries={suggestPointsDimensionQueries}
+          getItem={resolvePointsDimensionQuery}
+          itemQuery={(col) => col}
+          selectedItem={config.x || null}
+          onSelectedItemChange={(col) => onUpdate({ x: col ?? "" })}
+        />
+      </Field>
+      <Field>
+        <FieldLabel>Y column</FieldLabel>
+        <SimpleAsyncCombobox
+          suggestQueries={suggestPointsDimensionQueries}
+          getItem={resolvePointsDimensionQuery}
+          itemQuery={(col) => col}
+          selectedItem={config.y || null}
+          onSelectedItemChange={(col) => onUpdate({ y: col ?? "" })}
+        />
+      </Field>
+    </>
+  );
+}

--- a/apps/tissuumaps/src/components/panels/PointsPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/PointsPanel/index.tsx
@@ -25,6 +25,7 @@ import { ItemsDataWidget } from "@/components/widgets/ItemsDataWidget";
 import { cn } from "@/lib/utils";
 import { useTissUUmaps } from "@/store";
 
+import { PointsLayerConfigsWidget } from "./PointsLayerConfigsWidget";
 import { PointsSettingsWidget } from "./PointsSettingsWidget";
 import { usePointsDataTableColumns } from "./usePointsDataTableColumns";
 import { usePointsDataWidget } from "./usePointsDataWidget";
@@ -212,7 +213,14 @@ function PointsAccordionItem({ points, index }: PointsAccordionItemProps) {
             }}
             className="bg-card"
           />
-          {/* TODO layer configs */}
+          <PointsLayerConfigsWidget
+            pointsId={points.id}
+            layerConfigs={points.layerConfigs}
+            onChange={(newLayerConfigs) =>
+              updatePoints(points.id, { layerConfigs: newLayerConfigs })
+            }
+            className="bg-card"
+          />
           <PointsSettingsWidget
             points={points}
             activeCategory={activeSettingsCategory}

--- a/apps/tissuumaps/src/components/panels/ShapesPanel/ShapesLayerConfigsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/ShapesPanel/ShapesLayerConfigsWidget.tsx
@@ -1,0 +1,27 @@
+import {
+  type ShapesLayerConfig,
+  createShapesLayerConfig,
+} from "@tissuumaps/core";
+
+import { LayerConfigsWidget } from "@/components/widgets/LayerConfigsWidget";
+
+export type ShapesLayerConfigsWidgetProps = {
+  layerConfigs: ShapesLayerConfig[];
+  onChange: (newLayerConfigs: ShapesLayerConfig[]) => void;
+  className?: string;
+};
+
+export function ShapesLayerConfigsWidget({
+  layerConfigs,
+  onChange,
+  className,
+}: ShapesLayerConfigsWidgetProps) {
+  return (
+    <LayerConfigsWidget
+      layerConfigs={layerConfigs}
+      createNewConfig={(layerId) => createShapesLayerConfig({ layer: layerId })}
+      onChange={onChange}
+      className={className}
+    />
+  );
+}

--- a/apps/tissuumaps/src/components/panels/ShapesPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ShapesPanel/index.tsx
@@ -25,6 +25,7 @@ import { ItemsDataWidget } from "@/components/widgets/ItemsDataWidget";
 import { cn } from "@/lib/utils";
 import { useTissUUmaps } from "@/store";
 
+import { ShapesLayerConfigsWidget } from "./ShapesLayerConfigsWidget";
 import { ShapesSettingsWidget } from "./ShapesSettingsWidget";
 import { useShapesDataTableColumns } from "./useShapesDataTableColumns";
 import { useShapesDataWidget } from "./useShapesDataWidget";
@@ -191,7 +192,13 @@ function ShapesAccordionItem({ shapes, index }: ShapesAccordionItemProps) {
             }}
             className="bg-card"
           />
-          {/* TODO layer configs */}
+          <ShapesLayerConfigsWidget
+            layerConfigs={shapes.layerConfigs}
+            onChange={(newLayerConfigs) =>
+              updateShapes(shapes.id, { layerConfigs: newLayerConfigs })
+            }
+            className="bg-card"
+          />
           <ShapesSettingsWidget
             shapes={shapes}
             activeCategory={activeSettingsCategory}

--- a/apps/tissuumaps/src/components/widgets/LayerConfigsWidget/index.tsx
+++ b/apps/tissuumaps/src/components/widgets/LayerConfigsWidget/index.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/common/accordion";
 import { Field, FieldLabel } from "@/components/common/field";
 import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
+import { SimpleSelect } from "@/components/common/simple-select";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -179,20 +180,15 @@ function LayerConfigItem({
                   readOnly
                 />
               ) : (
-                <select
-                  className="w-full border rounded-md px-2 py-1 text-sm bg-background text-foreground"
+                <SimpleSelect
+                  items={layers}
+                  itemLabel={(layer) => layer.name}
+                  itemValue={(layer) => layer.id}
                   value={layerValue}
-                  onChange={(e) => onUpdate({ layer: e.target.value })}
-                >
-                  {layers.map((layer) => (
-                    <option key={layer.id} value={layer.id}>
-                      {layer.name}
-                    </option>
-                  ))}
-                  {layers.length === 0 && (
-                    <option value={layerValue}>{layerValue}</option>
-                  )}
-                </select>
+                  onValueChange={(value) =>
+                    onUpdate({ layer: value ?? undefined })
+                  }
+                />
               )}
             </Field>
           </AccordionPanel>

--- a/apps/tissuumaps/src/components/widgets/LayerConfigsWidget/index.tsx
+++ b/apps/tissuumaps/src/components/widgets/LayerConfigsWidget/index.tsx
@@ -1,0 +1,318 @@
+import { PlusIcon, Trash2Icon } from "lucide-react";
+import { type ReactNode } from "react";
+
+import { type LayerConfig } from "@tissuumaps/core";
+
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  AccordionTrigger,
+  AccordionTriggerRightDownIcon,
+} from "@/components/common/accordion";
+import { Field, FieldLabel } from "@/components/common/field";
+import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+import { useTissUUmaps } from "@/store";
+
+// ─── Shared base widget ───────────────────────────────────────────────────────
+
+type LayerConfigUpdate = Partial<LayerConfig> & Record<string, unknown>;
+
+type LayerConfigsWidgetProps<T extends LayerConfig> = {
+  layerConfigs: T[];
+  createNewConfig: (layerId: string) => T;
+  onChange: (newLayerConfigs: T[]) => void;
+  renderExtraFields?: (
+    config: T,
+    update: (updates: Partial<T>) => void,
+  ) => ReactNode;
+  extraFieldsLabel?: string;
+  className?: string;
+};
+
+export function LayerConfigsWidget<T extends LayerConfig>({
+  layerConfigs,
+  createNewConfig,
+  onChange,
+  renderExtraFields,
+  extraFieldsLabel = "Extra",
+  className,
+}: LayerConfigsWidgetProps<T>) {
+  const layers = useTissUUmaps((state) => state.layers);
+
+  const addConfig = () => {
+    if (layers.length === 0) return;
+    onChange([...layerConfigs, createNewConfig(layers[0]!.id)]);
+  };
+
+  const removeConfig = (index: number) => {
+    onChange(layerConfigs.filter((_, i) => i !== index));
+  };
+
+  const updateConfig = (index: number, updates: LayerConfigUpdate) => {
+    onChange(
+      layerConfigs.map((config, i) =>
+        i === index ? ({ ...config, ...updates } as T) : config,
+      ),
+    );
+  };
+
+  return (
+    <Fieldset
+      className={cn("flex flex-col gap-y-2 border rounded-md p-2", className)}
+    >
+      <FieldsetLegend className="font-medium text-foreground">
+        Layer configs
+      </FieldsetLegend>
+
+      {layerConfigs.length === 0 && (
+        <p className="text-sm text-muted-foreground">No layer configs</p>
+      )}
+
+      {layerConfigs.map((config, index) => {
+        const layerId = typeof config.layer === "string" ? config.layer : null;
+        const layerName =
+          layers.find((l) => l.id === layerId)?.name ??
+          layerId ??
+          `Config ${index + 1}`;
+
+        return (
+          <LayerConfigItem
+            key={index}
+            config={config}
+            layers={layers}
+            layerName={layerName}
+            onUpdate={(updates) => updateConfig(index, updates)}
+            onRemove={() => removeConfig(index)}
+            renderExtraFields={
+              renderExtraFields
+                ? (c, u) =>
+                    renderExtraFields(c as T, (updates) =>
+                      u(updates as LayerConfigUpdate),
+                    )
+                : undefined
+            }
+            extraFieldsLabel={extraFieldsLabel}
+          />
+        );
+      })}
+
+      <Button
+        variant="outline"
+        className="w-full"
+        onClick={addConfig}
+        disabled={layers.length === 0}
+        title={layers.length === 0 ? "No layers available" : undefined}
+      >
+        <PlusIcon className="size-4" />
+        Add layer config
+      </Button>
+    </Fieldset>
+  );
+}
+
+// ─── Single config item ───────────────────────────────────────────────────────
+
+type StoreLayer = { id: string; name: string };
+
+type LayerConfigItemProps = {
+  config: LayerConfig;
+  layers: StoreLayer[];
+  layerName: string;
+  onUpdate: (updates: LayerConfigUpdate) => void;
+  onRemove: () => void;
+  renderExtraFields?: (
+    config: LayerConfig,
+    update: (updates: LayerConfigUpdate) => void,
+  ) => ReactNode;
+  extraFieldsLabel: string;
+};
+
+function LayerConfigItem({
+  config,
+  layers,
+  layerName,
+  onUpdate,
+  onRemove,
+  renderExtraFields,
+  extraFieldsLabel,
+}: LayerConfigItemProps) {
+  const layerValue =
+    typeof config.layer === "string" ? config.layer : "(table-based)";
+  const isTableBased = typeof config.layer !== "string";
+
+  return (
+    <div className="border rounded-md bg-background">
+      {/* Config header: layer name + delete */}
+      <div className="flex flex-row items-center px-2 py-1 gap-x-2">
+        <span className="flex-1 text-sm font-medium truncate">{layerName}</span>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onRemove}
+          title="Remove layer config"
+        >
+          <Trash2Icon className="size-4" />
+        </Button>
+      </div>
+
+      {/* Sub-accordions */}
+      <Accordion className="border-t">
+        {/* Layer section */}
+        <AccordionItem value="layer">
+          <AccordionHeader className="px-2">
+            <AccordionTriggerRightDownIcon />
+            <AccordionTrigger>Layer</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
+            <Field>
+              <FieldLabel>Layer</FieldLabel>
+              {isTableBased ? (
+                <Input
+                  disabled
+                  value={`table: ${(config.layer as { table: string; column: string }).table} / ${(config.layer as { table: string; column: string }).column}`}
+                  readOnly
+                />
+              ) : (
+                <select
+                  className="w-full border rounded-md px-2 py-1 text-sm bg-background text-foreground"
+                  value={layerValue}
+                  onChange={(e) => onUpdate({ layer: e.target.value })}
+                >
+                  {layers.map((layer) => (
+                    <option key={layer.id} value={layer.id}>
+                      {layer.name}
+                    </option>
+                  ))}
+                  {layers.length === 0 && (
+                    <option value={layerValue}>{layerValue}</option>
+                  )}
+                </select>
+              )}
+            </Field>
+          </AccordionPanel>
+        </AccordionItem>
+
+        {/* Transform section */}
+        <AccordionItem value="transform">
+          <AccordionHeader className="px-2">
+            <AccordionTriggerRightDownIcon />
+            <AccordionTrigger>Transform</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel className="grid grid-cols-2 gap-x-2 gap-y-2 p-2 pl-6 pb-4">
+            <Field className="col-span-2">
+              <FieldLabel>Flip</FieldLabel>
+              <div className="flex flex-row items-center gap-x-2">
+                <Switch
+                  checked={config.flip}
+                  onCheckedChange={(checked) => onUpdate({ flip: checked })}
+                />
+                {config.flip ? "Yes" : "No"}
+              </div>
+            </Field>
+            <Field>
+              <FieldLabel>Scale</FieldLabel>
+              <Input
+                type="number"
+                inputMode="decimal"
+                step={0.1}
+                value={config.transform.scale}
+                onChange={(e) => {
+                  if (e.target.value !== "") {
+                    onUpdate({
+                      transform: {
+                        ...config.transform,
+                        scale: parseFloat(e.target.value),
+                      },
+                    });
+                  }
+                }}
+              />
+            </Field>
+            <Field>
+              <FieldLabel>Rotation (°)</FieldLabel>
+              <Input
+                type="number"
+                inputMode="decimal"
+                step={1}
+                value={config.transform.rotation}
+                onChange={(e) => {
+                  if (e.target.value !== "") {
+                    onUpdate({
+                      transform: {
+                        ...config.transform,
+                        rotation: parseFloat(e.target.value),
+                      },
+                    });
+                  }
+                }}
+              />
+            </Field>
+            <Field>
+              <FieldLabel>Translate X</FieldLabel>
+              <Input
+                type="number"
+                inputMode="decimal"
+                step={1}
+                value={config.transform.translation.x}
+                onChange={(e) => {
+                  if (e.target.value !== "") {
+                    onUpdate({
+                      transform: {
+                        ...config.transform,
+                        translation: {
+                          ...config.transform.translation,
+                          x: parseFloat(e.target.value),
+                        },
+                      },
+                    });
+                  }
+                }}
+              />
+            </Field>
+            <Field>
+              <FieldLabel>Translate Y</FieldLabel>
+              <Input
+                type="number"
+                inputMode="decimal"
+                step={1}
+                value={config.transform.translation.y}
+                onChange={(e) => {
+                  if (e.target.value !== "") {
+                    onUpdate({
+                      transform: {
+                        ...config.transform,
+                        translation: {
+                          ...config.transform.translation,
+                          y: parseFloat(e.target.value),
+                        },
+                      },
+                    });
+                  }
+                }}
+              />
+            </Field>
+          </AccordionPanel>
+        </AccordionItem>
+
+        {/* Extra section (type-specific fields) */}
+        {renderExtraFields && (
+          <AccordionItem value="extra">
+            <AccordionHeader className="px-2">
+              <AccordionTriggerRightDownIcon />
+              <AccordionTrigger>{extraFieldsLabel}</AccordionTrigger>
+            </AccordionHeader>
+            <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
+              {renderExtraFields(config, onUpdate)}
+            </AccordionPanel>
+          </AccordionItem>
+        )}
+      </Accordion>
+    </div>
+  );
+}


### PR DESCRIPTION
## Type of change

- [x] New feature (non-breaking change which adds functionality)

## List of changes made

- **Created LayerConfigs UI widget system**: Implemented complete layer configuration interface for all data types (images, points, shapes)
- **Created base LayerConfigsWidget** (`widgets/LayerConfigsWidget/index.tsx`): Generic component handling layer selection, transform controls (flip, scale, rotation, translation), and extensible extra fields section
- **Created ImageLayerConfigsWidget** (`ImagesPanel/ImageLayerConfigsWidget.tsx`): Panel-specific wrapper for image layer configurations
- **Created PointsLayerConfigsWidget** (`PointsPanel/PointsLayerConfigsWidget.tsx`): Specialized for points with coordinate dimension selectors (X/Y columns) using async combobox with dimension loading
- **Created ShapesLayerConfigsWidget** (`ShapesPanel/ShapesLayerConfigsWidget.tsx`): Panel-specific wrapper for shape layer configurations
- **Integrated LayerConfigs UI into panels**: Added functional LayerConfigsWidget components to ImagesPanel, PointsPanel, and ShapesPanel, replacing "TODO layer configs" placeholders
- **Implemented layer config management**: Users can now add/remove layer configurations, select target layers, control transform properties (scale, rotation, flip, translation), and configure type-specific fields like point coordinates