### PR TITLE
feat: add interaction mode selector

### DIFF
--- a/apps/tissuumaps/src/components/panels/ViewerPanel/InteractionModeViewerControls.tsx
+++ b/apps/tissuumaps/src/components/panels/ViewerPanel/InteractionModeViewerControls.tsx
@@ -1,8 +1,63 @@
+import { HandIcon, PencilIcon, PentagonIcon, SquareIcon } from "lucide-react";
+
+import type { InteractionMode } from "@tissuumaps/core";
+
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { cn } from "@/lib/utils";
+import { useTissUUmaps } from "@/store";
+
 export type InteractionModeViewerControlsProps = { className?: string };
 
 export function InteractionModeViewerControls({
   className,
 }: InteractionModeViewerControlsProps) {
-  // TODO implement controls for switching interaction modes (pan, draw, etc.)
-  return <div className={className} />;
+  const interactionMode = useTissUUmaps((s) => s.interactionMode);
+  const setInteractionMode = useTissUUmaps((s) => s.setInteractionMode);
+
+  return (
+    <ToggleGroup
+      className={cn(
+        "m-2 gap-1 rounded-xl border border-border bg-background p-1.5 shadow-lg",
+        className,
+      )}
+      variant="default"
+      size="default"
+      value={[interactionMode]}
+      onValueChange={(value) => {
+        const mode = value[value.length - 1] as InteractionMode | undefined;
+        if (mode !== undefined) {
+          setInteractionMode(mode);
+        }
+      }}
+    >
+      <ToggleGroupItem
+        value="pan"
+        aria-label="Pan"
+        className="aria-pressed:bg-muted aria-pressed:text-foreground rounded-lg"
+      >
+        <HandIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value="drawRectangle"
+        aria-label="Draw rectangle"
+        className="aria-pressed:bg-muted aria-pressed:text-foreground rounded-lg"
+      >
+        <SquareIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value="drawPolygon"
+        aria-label="Draw polygon"
+        className="aria-pressed:bg-muted aria-pressed:text-foreground rounded-lg"
+      >
+        <PentagonIcon />
+      </ToggleGroupItem>
+      <ToggleGroupItem
+        value="drawFreehand"
+        aria-label="Draw freehand"
+        className="aria-pressed:bg-muted aria-pressed:text-foreground rounded-lg"
+      >
+        <PencilIcon />
+      </ToggleGroupItem>
+    </ToggleGroup>
+  );
 }

--- a/apps/tissuumaps/src/components/panels/ViewerPanel/InteractionModeViewerControls.tsx
+++ b/apps/tissuumaps/src/components/panels/ViewerPanel/InteractionModeViewerControls.tsx
@@ -1,6 +1,6 @@
 import { HandIcon, PencilIcon, PentagonIcon, SquareIcon } from "lucide-react";
 
-import type { InteractionMode } from "@tissuumaps/core";
+import { type InteractionMode } from "@tissuumaps/core";
 
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { cn } from "@/lib/utils";
@@ -11,22 +11,20 @@ export type InteractionModeViewerControlsProps = { className?: string };
 export function InteractionModeViewerControls({
   className,
 }: InteractionModeViewerControlsProps) {
-  const interactionMode = useTissUUmaps((s) => s.interactionMode);
-  const setInteractionMode = useTissUUmaps((s) => s.setInteractionMode);
+  const interactionMode = useTissUUmaps((state) => state.interactionMode);
+  const setInteractionMode = useTissUUmaps((state) => state.setInteractionMode);
 
   return (
     <ToggleGroup
       className={cn(
-        "m-2 gap-1 rounded-xl border border-border bg-background p-1.5 shadow-lg",
+        "m-2 rounded-xl border border-border bg-background p-1.5 shadow-lg",
         className,
       )}
-      variant="default"
-      size="default"
+      spacing={1}
       value={[interactionMode]}
       onValueChange={(value) => {
-        const mode = value[value.length - 1] as InteractionMode | undefined;
-        if (mode !== undefined) {
-          setInteractionMode(mode);
+        if (value.length > 0) {
+          setInteractionMode(value[0] as InteractionMode);
         }
       }}
     >

--- a/apps/tissuumaps/src/store/slices/app.ts
+++ b/apps/tissuumaps/src/store/slices/app.ts
@@ -94,6 +94,7 @@ export const createAppSlice: TissUUmapsStateCreator<AppSlice> = (set) => ({
     });
   },
   setInteractionMode: (interactionMode) => {
+    console.debug("Setting interaction mode to", interactionMode);
     set((draft) => {
       draft.interactionMode = interactionMode;
     });

--- a/apps/tissuumaps/src/store/slices/app.ts
+++ b/apps/tissuumaps/src/store/slices/app.ts
@@ -94,7 +94,6 @@ export const createAppSlice: TissUUmapsStateCreator<AppSlice> = (set) => ({
     });
   },
   setInteractionMode: (interactionMode) => {
-    console.debug("Setting interaction mode to", interactionMode);
     set((draft) => {
       draft.interactionMode = interactionMode;
     });

--- a/packages/@tissuumaps-core/src/types.ts
+++ b/packages/@tissuumaps-core/src/types.ts
@@ -25,7 +25,11 @@ export type MappableArrayLike<T> = ArrayLike<T> & {
 /**
  * Interaction mode, determining how mouse events are interpreted
  */
-export type InteractionMode = "pan";
+export type InteractionMode =
+  | "pan"
+  | "drawRectangle"
+  | "drawPolygon"
+  | "drawFreehand";
 
 /**
  * A callback function that receives progress updates as a percentage (0-100)


### PR DESCRIPTION
# References and relevant issues

Closes [#232](https://scilifelab.atlassian.net/browse/TMAP-232?atlOrigin=eyJpIjoiOTA5ZTVmNTYyMjY1NGU0NjhlYTAzZDYwNmZiMTAxMGQiLCJwIjoiaiJ9)

# Type of change

<!-- If "Other", please specify. -->

- [x] New feature (non-breaking change which adds functionality)

# List of changes made

- Extended `InteractionMode` type in `@tissuumaps/core` with` "drawRectangle"`, `"drawPolygon"`, and `"drawFreehand"` in addition to `"pan"`
- Implemented the `InteractionModeViewerControls` React component: a floating toolbar with a `ToggleGroup` that reads and sets the application's `interactionMode` state

# Screenshot of the fix

<img width="686" height="342" alt="image" src="https://github.com/user-attachments/assets/22a0069f-37cd-4a72-b974-5e72452690ce" />

# Use of AI

Claude Code was used to assist with implementation.

# Testing

<!-- Please delete options that are not relevant -->

- Switch between interaction modes using the toolbar in the top-left of the viewer and verify the active mode is highlighted

<!--
Final Checklist:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
-->
