### PR TITLE
fix: transform initialization

### DIFF
--- a/packages/@tissuumaps-core/src/controllers/SVGController.ts
+++ b/packages/@tissuumaps-core/src/controllers/SVGController.ts
@@ -45,23 +45,21 @@ export class SVGController {
 
   /**
    * @param container - The `<svg>` element to draw on (typically created by {@link createContainer})
-   * @param viewport - Initial world-space viewport rectangle
+   * @param initialViewport - Initial world-space viewport rectangle
    * @param options - Optional shape drawing event handlers
    */
   constructor(
     container: SVGSVGElement,
-    viewport: Rect,
+    initialViewport: Rect,
     options?: { onShapeComplete?: (shape: MultiPolygon) => void },
   ) {
     this.container = container;
     this.transformNode = document.createElementNS(SVG_NAMESPACE, "g");
     this.shapeCompleteHandler = options?.onShapeComplete;
-    this._containerSize = {
-      width: parseFloat(container.getAttribute("width") ?? "0"),
-      height: parseFloat(container.getAttribute("height") ?? "0"),
-    };
-    this._viewport = viewport;
     container.replaceChildren(this.transformNode);
+    this._containerSize = container.getBoundingClientRect();
+    this._viewport = initialViewport;
+    this._updateTransformNode();
 
     this._registerEventHandlers();
   }


### PR DESCRIPTION
# References and relevant issues

https://github.com/TissUUmaps/TissUUmaps4/pull/113#discussion_r3058360370

https://github.com/TissUUmaps/TissUUmaps4/pull/113#discussion_r3058360536

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- Initialize `containerSize` from `container.getBoundingClientRect()` after adding `container` to the DOM
- Properly initialize `transformNode.transform`, making sure that `transformNode.getScreenCTM()` is not null

# Use of AI

None

# Testing

Untested

# Further comments

These changes fix issues identified in #113 by GitHub Copilot (see references above)