### PR TITLE
fix: dynamic ubo size limit

### DIFF
--- a/packages/@tissuumaps-core/src/assets/shaders/points.vert
+++ b/packages/@tissuumaps-core/src/assets/shaders/points.vert
@@ -1,7 +1,7 @@
 #version 300 es
 
 // maximum number of objects
-#define MAX_N_OBJECTS 2048u
+#define MAX_N_OBJECTS __MAX_N_OBJECTS__u
 
 // marker atlas configuration
 #define MARKER_ATLAS_GRID_SIZE 4u

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -46,7 +46,7 @@ import { WebGLControllerBase } from "./WebGLControllerBase";
  * attributes (x, y, size, color, marker, object index).
  */
 export class WebGLPointsController extends WebGLControllerBase {
-  private static readonly _maxNumObjects = 2048; // see vertex shader
+  private static readonly _bytesPerObject = 32; // mat2x4 in std140 layout
   private static readonly _attribLocations = {
     X: 0,
     Y: 1,
@@ -60,6 +60,7 @@ export class WebGLPointsController extends WebGLControllerBase {
   };
 
   private readonly _program: WebGLProgram;
+  private readonly _maxNumObjects: number;
   private readonly _uniformLocations: {
     worldPointSizeFactor: WebGLUniformLocation;
     worldToViewportMatrix: WebGLUniformLocation;
@@ -93,10 +94,22 @@ export class WebGLPointsController extends WebGLControllerBase {
    */
   constructor(gl: WebGL2RenderingContext) {
     super(gl);
+    // query the GPU's uniform block size limit and derive max objects
+    const maxUniformBlockSize = gl.getParameter(
+      gl.MAX_UNIFORM_BLOCK_SIZE,
+    ) as number;
+    this._maxNumObjects = Math.floor(
+      maxUniformBlockSize / WebGLPointsController._bytesPerObject,
+    );
+    // inject the computed limit into the vertex shader source
+    const resolvedVertexShader = pointsVertexShader.replace(
+      "__MAX_N_OBJECTS__",
+      String(this._maxNumObjects),
+    );
     // load program
     this._program = WebGLUtils.loadProgram(
       this.gl,
-      pointsVertexShader,
+      resolvedVertexShader,
       pointsFragmentShader,
     );
     // get uniform locations
@@ -150,7 +163,7 @@ export class WebGLPointsController extends WebGLControllerBase {
       this.gl,
       this.gl.UNIFORM_BUFFER,
       this._buffers.objectsUBO,
-      WebGLPointsController._maxNumObjects * 8 * Float32Array.BYTES_PER_ELEMENT,
+      this._maxNumObjects * 8 * Float32Array.BYTES_PER_ELEMENT,
       this.gl.DYNAMIC_DRAW,
     );
     // create and configure VAO
@@ -269,11 +282,11 @@ export class WebGLPointsController extends WebGLControllerBase {
     signal?.throwIfAborted();
     const refs = await this._loadPoints(layers, points, loadPoints, { signal });
     signal?.throwIfAborted();
-    if (refs.length > WebGLPointsController._maxNumObjects) {
+    if (refs.length > this._maxNumObjects) {
       console.warn(
-        `Only rendering the first ${WebGLPointsController._maxNumObjects} out of ${refs.length} objects`,
+        `Only rendering the first ${this._maxNumObjects} out of ${refs.length} objects`,
       );
-      refs.length = WebGLPointsController._maxNumObjects;
+      refs.length = this._maxNumObjects;
     }
     let buffersResized = false;
     const n = refs.reduce((accum, ref) => accum + ref.data.getSize(), 0);
@@ -544,9 +557,7 @@ export class WebGLPointsController extends WebGLControllerBase {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
     let offset = 0;
-    const objectsUBOData = new Float32Array(
-      WebGLPointsController._maxNumObjects * 8,
-    );
+    const objectsUBOData = new Float32Array(this._maxNumObjects * 8);
     const newBufferSliceStates: PointsBufferSliceState[] = [];
     for (let i = 0; i < refs.length; i++) {
       const ref = refs[i]!;

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -98,12 +98,19 @@ export class WebGLPointsController extends WebGLControllerBase {
     const maxUniformBlockSize = gl.getParameter(
       gl.MAX_UNIFORM_BLOCK_SIZE,
     ) as number;
-    this._maxNumObjects = Math.floor(
-      maxUniformBlockSize / WebGLPointsController._bytesPerObject,
+    this._maxNumObjects = Math.min(
+      Math.floor(maxUniformBlockSize / WebGLPointsController._bytesPerObject),
+      65536, // object indices are stored as Uint16
     );
     // inject the computed limit into the vertex shader source
-    const resolvedVertexShader = pointsVertexShader.replace(
-      "__MAX_N_OBJECTS__",
+    const placeholder = "__MAX_N_OBJECTS__";
+    if (!pointsVertexShader.includes(placeholder)) {
+      throw new Error(
+        `Vertex shader is missing the ${placeholder} placeholder`,
+      );
+    }
+    const resolvedVertexShader = pointsVertexShader.replaceAll(
+      placeholder,
       String(this._maxNumObjects),
     );
     // load program


### PR DESCRIPTION
# References and relevant issues

The points vertex shader hardcoded `MAX_N_OBJECTS = 2048`, making the `ObjectsUBO` uniform block 65,536 bytes. On GPUs where `GL_MAX_UNIFORM_BLOCK_SIZE` is 16,384 bytes (the WebGL2 minimum), this caused a shader link failure:

> Uncaught Error: Shader program linking failed: Size of uniform block ObjectsUBO in VERTEX shader exceeds GL_MAX_UNIFORM_BLOCK_SIZE (16384)

See issue https://github.com/TissUUmaps/TissUUmaps4/issues/124

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# List of changes made

- Changed the `#define MAX_N_OBJECTS` in `points.vert` from a hardcoded value to a placeholder (`__MAX_N_OBJECTS__`) injected at runtime
- `WebGLPointsController` now queries `GL_MAX_UNIFORM_BLOCK_SIZE` at construction time and derives the maximum number of objects dynamically (e.g. 512 on 16 KB GPUs, 2048 on 64 KB GPUs)

# Screenshot of the fix

N/A

# Use of AI

This PR was created with the assistance of Claude Code.

# Testing

- [ ] Test on a device with `GL_MAX_UNIFORM_BLOCK_SIZE = 16384` (e.g. integrated/mobile GPU) and verify shader compiles and points render correctly
- [x] Test on a device with a higher limit (e.g. desktop GPU with 64 KB+) and verify no regression (tested on Windows 11 + Chrome, and Windows 11 + Firefox)

# Further comments

The WebGL2 spec only guarantees a minimum `GL_MAX_UNIFORM_BLOCK_SIZE` of 16,384 bytes. The previous hardcoded value of 2048 objects × 32 bytes = 65,536 bytes exceeded this on lower-end hardware.