### PR TITLE
feat: move x/y column configuration from points layer config to points data source

### DIFF
--- a/apps/tissuumaps/src/components/panels/PointsPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/PointsPanel/index.tsx
@@ -72,10 +72,7 @@ export function PointsPanel({ className }: PointsPanelProps) {
             id: crypto.randomUUID(),
             name,
             dataSource,
-            layerConfigs:
-              layers.length > 0
-                ? [{ layer: layers[0]!.id, x: "x", y: "y" }]
-                : [],
+            layerConfigs: layers.length > 0 ? [{ layer: layers[0]!.id }] : [],
           });
           addPoints(newPoints);
         }}

--- a/apps/tissuumaps/src/store/adapters/LoadedPointsDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedPointsDataAdapter.ts
@@ -24,32 +24,14 @@ export class LoadedPointsDataAdapter implements PointsData {
     return this._getData().getNames();
   }
 
-  async suggestDimensionQueries(
-    currentQuery: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string[]> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
-    return await this._getData().suggestDimensionQueries(currentQuery, options);
-  }
-
-  async resolveDimensionQuery(
-    query: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string | null> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
-    return await this._getData().resolveDimensionQuery(query, options);
-  }
-
-  async loadCoordinates(
-    dimension: string,
-    options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
-  ): Promise<Float32Array> {
+  async loadCoordinates(options?: {
+    signal?: AbortSignal;
+    onProgress?: ProgressCallback;
+  }): Promise<[Float32Array, Float32Array]> {
     const { signal, onProgress } = options ?? {};
     signal?.throwIfAborted();
     const state = useTissUUmaps.getState();
-    return await state.loadPointsCoordinates(this._pointsId, dimension, {
+    return await state.loadPointsCoordinates(this._pointsId, {
       signal,
       onProgress,
     });

--- a/apps/tissuumaps/src/store/slices/points.ts
+++ b/apps/tissuumaps/src/store/slices/points.ts
@@ -13,7 +13,7 @@ import { type TissUUmapsStateCreator } from "../index";
 type LoadedPointsData = {
   dataSource: PointsDataSource;
   data: PointsData;
-  loadedCoordinates: Map<string, Float32Array>;
+  loadedCoordinates?: [Float32Array, Float32Array];
 };
 
 export type PointsSlice = PointsSliceState & PointsSliceActions;
@@ -41,13 +41,12 @@ export type PointsSliceActions = {
   ) => Promise<PointsData>;
   loadPointsCoordinates: (
     pointsId: string,
-    dimension: string,
     options?: {
       signal?: AbortSignal;
       reload?: boolean;
       onProgress?: ProgressCallback;
     },
-  ) => Promise<Float32Array>;
+  ) => Promise<[Float32Array, Float32Array]>;
   unloadPoints: (pointsId: string) => boolean;
 };
 
@@ -216,7 +215,6 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
         draft.loadedPointsData.set(loadedDataKey, {
           dataSource,
           data,
-          loadedCoordinates: new Map(),
         });
         draft.loadedPoints.set(pointsId, loadedDataKey);
         if (newDataSource !== undefined) {
@@ -239,7 +237,7 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
     (_pointsId, options) => options?.signal,
   ),
   loadPointsCoordinates: deduplicate(
-    async (pointsId, dimension, options) => {
+    async (pointsId, options) => {
       const { signal, reload = false, onProgress } = options ?? {};
       signal?.throwIfAborted();
       // Check if the points, the corresponding data source, and the requested coordinates are already loaded
@@ -254,12 +252,11 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
           `Data source for points with ID ${pointsId} not loaded.`,
         );
       }
-      const oldCoordinates = loadedData.loadedCoordinates.get(dimension);
-      if (oldCoordinates !== undefined && !reload) {
-        return oldCoordinates;
+      if (loadedData.loadedCoordinates !== undefined && !reload) {
+        return loadedData.loadedCoordinates;
       }
       // Load the requested coordinates
-      const coordinates = await loadedData.data.loadCoordinates(dimension, {
+      const coordinates = await loadedData.data.loadCoordinates({
         signal,
         onProgress,
       });
@@ -291,11 +288,11 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
       set((draft) => {
         const loadedDataDraft =
           draft.loadedPointsData.get(currentLoadedDataKey)!;
-        loadedDataDraft.loadedCoordinates.set(dimension, coordinates);
+        loadedDataDraft.loadedCoordinates = coordinates;
       });
       return coordinates;
     },
-    (_pointsId, _dimension, options) => options?.signal,
+    (_pointsId, options) => options?.signal,
   ),
   unloadPoints: (pointsId) => {
     const state = get();

--- a/apps/tissuumaps/src/store/slices/shapes.ts
+++ b/apps/tissuumaps/src/store/slices/shapes.ts
@@ -249,9 +249,8 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
           `Data source for shapes with ID ${shapesId} not loaded.`,
         );
       }
-      const oldMultiPolygons = loadedData.loadedMultiPolygons;
-      if (oldMultiPolygons !== undefined && !reload) {
-        return oldMultiPolygons;
+      if (loadedData.loadedMultiPolygons !== undefined && !reload) {
+        return loadedData.loadedMultiPolygons;
       }
       // Load the requested multi-polygons
       const multiPolygons = await loadedData.data.loadMultiPolygons({

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -563,19 +563,8 @@ export class WebGLPointsController extends WebGLControllerBase {
         bufferSliceState.ref.data !== ref.data;
       let dataBounds = bufferSliceState?.dataBounds;
       // x/y
-      if (
-        bufferSliceChanged ||
-        dataBounds === undefined ||
-        bufferSliceState.current.layerConfig.x !== ref.layerConfig.x ||
-        bufferSliceState.current.layerConfig.y !== ref.layerConfig.y
-      ) {
-        const xData = await ref.data.loadCoordinates(ref.layerConfig.x, {
-          signal,
-        });
-        signal?.throwIfAborted();
-        const yData = await ref.data.loadCoordinates(ref.layerConfig.y, {
-          signal,
-        });
+      if (bufferSliceChanged || dataBounds === undefined) {
+        const [xData, yData] = await ref.data.loadCoordinates({ signal });
         signal?.throwIfAborted();
         dataBounds = WebGLPointsController._getDataBounds(xData, yData);
         WebGLUtils.loadBuffer(
@@ -777,8 +766,6 @@ export class WebGLPointsController extends WebGLControllerBase {
             pointSizeFactor: ref.points.pointSizeFactor,
           },
           layerConfig: {
-            x: ref.layerConfig.x,
-            y: ref.layerConfig.y,
             transform: structuredClone(ref.layerConfig.transform),
           },
         },
@@ -879,6 +866,6 @@ type PointsBufferSliceState = {
       | "pointOpacity"
       | "pointSizeFactor"
     >;
-    layerConfig: Pick<PointsLayerConfig, "x" | "y" | "transform">;
+    layerConfig: Pick<PointsLayerConfig, "transform">;
   };
 };

--- a/packages/@tissuumaps-core/src/model/points.ts
+++ b/packages/@tissuumaps-core/src/model/points.ts
@@ -176,21 +176,8 @@ export const pointsLayerConfigDefaults =
 /**
  * A layer-specific display configuration for two-dimensional point clouds
  */
-export interface RawPointsLayerConfig extends RawLayerConfig {
-  /**
-   * Dimension containing point-wise X coordinates
-   *
-   * @see {@link "../storage".PointsData.getDimensions}
-   */
-  x: string;
-
-  /**
-   * Dimension containing point-wise Y coordinates
-   *
-   * @see {@link "../storage".PointsData.getDimensions}
-   */
-  y: string;
-}
+// eslint-disable-next-line @typescript-eslint/no-empty-object-type
+export interface RawPointsLayerConfig extends RawLayerConfig {}
 
 /**
  * A {@link RawPointsLayerConfig} with {@link pointsLayerConfigDefaults} applied

--- a/packages/@tissuumaps-core/src/storage/points.ts
+++ b/packages/@tissuumaps-core/src/storage/points.ts
@@ -18,38 +18,13 @@ export interface PointsDataProvider<
  */
 export interface PointsData extends ItemsData {
   /**
-   * Returns dimension name suggestions matching the current query
+   * Loads the coordinates for all points
    *
-   * @param currentQuery - The partial dimension name to autocomplete
-   * @param options - Optional abort signal
-   * @returns A list of suggested dimension names matching the query
-   */
-  suggestDimensionQueries(
-    currentQuery: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string[]>;
-
-  /**
-   * Resolves a query to an exact dimension name
-   *
-   * @param query - The dimension query
-   * @param options - Optional abort signal
-   * @returns The resolved dimension name, or `null` if no match is found
-   */
-  resolveDimensionQuery(
-    query: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string | null>;
-
-  /**
-   * Loads the coordinate values for a dimension as a float array
-   *
-   * @param dimension - The dimension name (e.g. an X or Y coordinate column)
    * @param options - Optional abort signal and progress callback
-   * @returns The coordinate values for the dimension
+   * @returns The x and y coordinates as separate arrays, in index order
    */
-  loadCoordinates(
-    dimension: string,
-    options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
-  ): Promise<Float32Array>;
+  loadCoordinates(options?: {
+    signal?: AbortSignal;
+    onProgress?: ProgressCallback;
+  }): Promise<[Float32Array, Float32Array]>;
 }

--- a/packages/@tissuumaps-core/src/storage/points.ts
+++ b/packages/@tissuumaps-core/src/storage/points.ts
@@ -14,7 +14,7 @@ export interface PointsDataProvider<
 > extends DataProvider<TPointsDataSource, TPointsData> {}
 
 /**
- * Loaded point cloud data providing coordinate access by dimension name
+ * Loaded point cloud data providing coordinate access
  */
 export interface PointsData extends ItemsData {
   /**

--- a/packages/@tissuumaps-storage/src/table/TablePointsData.ts
+++ b/packages/@tissuumaps-storage/src/table/TablePointsData.ts
@@ -6,11 +6,13 @@ import {
 
 export class TablePointsData implements PointsData {
   private readonly _tableData: TableData;
-  private readonly _dimensionColumns?: string[];
+  private readonly _xColumn: string;
+  private readonly _yColumn: string;
 
-  constructor(tableData: TableData, dimensionColumns?: string[]) {
+  constructor(tableData: TableData, xColumn: string, yColumn: string) {
     this._tableData = tableData;
-    this._dimensionColumns = dimensionColumns;
+    this._xColumn = xColumn;
+    this._yColumn = yColumn;
   }
 
   getIds(): number[] {
@@ -25,41 +27,29 @@ export class TablePointsData implements PointsData {
     return this._tableData.getNames();
   }
 
-  async suggestDimensionQueries(
-    currentQuery: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string[]> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
-    if (this._dimensionColumns !== undefined) {
-      return this._dimensionColumns.filter((column) =>
-        column.includes(currentQuery),
-      );
-    }
-    return await this._tableData.suggestColumnQueries(currentQuery, { signal });
-  }
-
-  async resolveDimensionQuery(
-    query: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string | null> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
-    return await this._tableData.resolveColumnQuery(query, { signal });
-  }
-
-  async loadCoordinates(
-    dimension: string,
-    options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
-  ): Promise<Float32Array> {
+  async loadCoordinates(options?: {
+    signal?: AbortSignal;
+    onProgress?: ProgressCallback;
+  }): Promise<[Float32Array, Float32Array]> {
     const { signal, onProgress } = options ?? {};
     signal?.throwIfAborted();
-    const values = await this._tableData.loadValues<number>(dimension, {
+    const xPromise = this._tableData.loadValues<number>(this._xColumn, {
       signal,
       onProgress,
     });
+    const yPromise = this._tableData.loadValues<number>(this._yColumn, {
+      signal,
+      onProgress,
+    });
+    let [xData, yData] = await Promise.all([xPromise, yPromise]);
     signal?.throwIfAborted();
-    return values instanceof Float32Array ? values : Float32Array.from(values);
+    if (!(xData instanceof Float32Array)) {
+      xData = Float32Array.from(xData);
+    }
+    if (!(yData instanceof Float32Array)) {
+      yData = Float32Array.from(yData);
+    }
+    return [xData, yData];
   }
 
   close(): void {}

--- a/packages/@tissuumaps-storage/src/table/TablePointsDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/table/TablePointsDataProvider.ts
@@ -8,6 +8,7 @@ import { TablePointsData } from "./TablePointsData";
 import {
   type TablePointsDataSource,
   createDefaultTablePointsDataSource,
+  tablePointsDataSourceDefaults,
 } from "./TablePointsDataSource";
 
 export type LoadTableFunction = (
@@ -30,6 +31,14 @@ export class TablePointsDataProvider implements PointsDataProvider<
       table: {
         type: "string",
       },
+      x: {
+        type: "string",
+        default: tablePointsDataSourceDefaults.x,
+      },
+      y: {
+        type: "string",
+        default: tablePointsDataSourceDefaults.y,
+      },
     },
     required: ["table"],
   };
@@ -41,6 +50,16 @@ export class TablePointsDataProvider implements PointsDataProvider<
         type: "Control",
         scope: "#/properties/table",
         label: "Table",
+      },
+      {
+        type: "Control",
+        scope: "#/properties/x",
+        label: "X column",
+      },
+      {
+        type: "Control",
+        scope: "#/properties/y",
+        label: "Y column",
       },
     ],
   };
@@ -70,6 +89,10 @@ export class TablePointsDataProvider implements PointsDataProvider<
     });
     signal?.throwIfAborted();
 
-    return new TablePointsData(tableData, defaultDataSource.dimensionColumns);
+    return new TablePointsData(
+      tableData,
+      defaultDataSource.x,
+      defaultDataSource.y,
+    );
   }
 }

--- a/packages/@tissuumaps-storage/src/table/TablePointsDataSource.ts
+++ b/packages/@tissuumaps-storage/src/table/TablePointsDataSource.ts
@@ -2,7 +2,10 @@ import { type PointsDataSource } from "@tissuumaps/core";
 
 export const tablePointsDataSourceType = "table";
 
-export const tablePointsDataSourceDefaults = {};
+export const tablePointsDataSourceDefaults = {
+  x: "x",
+  y: "y",
+};
 
 export interface TablePointsDataSource extends PointsDataSource<
   typeof tablePointsDataSourceType
@@ -10,7 +13,8 @@ export interface TablePointsDataSource extends PointsDataSource<
   url: undefined; // Table data does not use a URL
   path: undefined; // Table data does not use a path
   table: string;
-  dimensionColumns?: string[];
+  x: string;
+  y: string;
 }
 
 export type DefaultTablePointsDataSource = Required<

--- a/packages/@tissuumaps-storage/src/table/TablePointsDataSource.ts
+++ b/packages/@tissuumaps-storage/src/table/TablePointsDataSource.ts
@@ -13,8 +13,8 @@ export interface TablePointsDataSource extends PointsDataSource<
   url: undefined; // Table data does not use a URL
   path: undefined; // Table data does not use a path
   table: string;
-  x: string;
-  y: string;
+  x?: string;
+  y?: string;
 }
 
 export type DefaultTablePointsDataSource = Required<


### PR DESCRIPTION
# References and relevant issues

TMAP-280

# Type of change

<!-- If "Other", please specify. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- Move the x/y column configuration from the points layer config to the table points data source
- Remove the "dimensions" concept in points data providers

# Use of AI

Code autocompletion

# Testing

Project builds and runs as before

# Further comments

This change was made following a recent offline discussion, where it was decided that the viewer should only ever display spatial coordinate systems.