### PR TITLE
refactor: rename DrawOptions to RenderOptions

### DIFF
--- a/apps/docs/docs/concepts/data-model.md
+++ b/apps/docs/docs/concepts/data-model.md
@@ -21,7 +21,7 @@ classDiagram
     class Project
     Project : name
     Project : marker/size/color/visibility/opacity maps
-    Project : OpenSeadragon viewer options, WebGL draw options
+    Project : OpenSeadragon viewer options, WebGL render options
     Project "1" *--> "0..*" Layer : layers
     Project "1" *--> "0..*" Image : images
     Project "1" *--> "0..*" Labels : labels

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/ProjectSettingsDialog.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/ProjectSettingsDialog.tsx
@@ -9,13 +9,13 @@ import { Input } from "@/components/ui/input";
 import { useTissUUmaps } from "@/store";
 
 export function ProjectSettingsDialog() {
-  const drawOptions = useTissUUmaps((state) => state.drawOptions);
-  const setDrawOptions = useTissUUmaps((state) => state.setDrawOptions);
+  const renderOptions = useTissUUmaps((state) => state.renderOptions);
+  const setRenderOptions = useTissUUmaps((state) => state.setRenderOptions);
 
   return (
     <Fieldset className="border-0 m-0 p-0">
       <FieldsetLegend className="mb-3 text-sm font-medium">
-        Draw Options
+        Render Options
       </FieldsetLegend>
 
       <div className="space-y-4">
@@ -28,11 +28,11 @@ export function ProjectSettingsDialog() {
                 inputMode="decimal"
                 step={0.1}
                 min={0}
-                value={drawOptions.pointSizeFactor}
+                value={renderOptions.pointSizeFactor}
                 onChange={(event) => {
                   const newValue = event.target.valueAsNumber;
                   if (!isNaN(newValue)) {
-                    setDrawOptions({
+                    setRenderOptions({
                       pointSizeFactor: Math.max(0, newValue),
                     });
                   }
@@ -52,11 +52,11 @@ export function ProjectSettingsDialog() {
               <Input
                 type="number"
                 min={0}
-                value={drawOptions.shapeStrokeWidth}
+                value={renderOptions.shapeStrokeWidth}
                 onChange={(event) => {
                   const newValue = event.target.valueAsNumber;
                   if (!isNaN(newValue)) {
-                    setDrawOptions({
+                    setRenderOptions({
                       shapeStrokeWidth: Math.max(0, Math.trunc(newValue)),
                     });
                   }
@@ -76,11 +76,11 @@ export function ProjectSettingsDialog() {
               <Input
                 type="number"
                 min={1}
-                value={drawOptions.numShapesScanlines}
+                value={renderOptions.numShapesScanlines}
                 onChange={(event) => {
                   const newValue = event.target.valueAsNumber;
                   if (!isNaN(newValue)) {
-                    setDrawOptions({
+                    setRenderOptions({
                       numShapesScanlines: Math.max(1, Math.trunc(newValue)),
                     });
                   }

--- a/apps/tissuumaps/src/components/panels/ViewerPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ViewerPanel/index.tsx
@@ -34,7 +34,7 @@ export function ViewerPanel({ className }: ViewerPanelProps) {
       viewerOptions: state.viewerOptions,
       viewerAnimationStartOptions: state.viewerAnimationStartOptions,
       viewerAnimationFinishOptions: state.viewerAnimationFinishOptions,
-      drawOptions: state.drawOptions,
+      renderOptions: state.renderOptions,
       // rerender upon changes to data providers
       _imageDataProviders: state.imageDataProviders,
       _labelsDataProviders: state.labelsDataProviders,

--- a/apps/tissuumaps/src/store/slices/project.ts
+++ b/apps/tissuumaps/src/store/slices/project.ts
@@ -1,11 +1,11 @@
 import {
   type Color,
   type DefaultMap,
-  type DrawOptions,
   type Marker,
   type ProgressCallback,
   type Project,
   type RawProject,
+  type RenderOptions,
   type ViewerOptions,
   createProject,
   projectDefaults,
@@ -23,15 +23,15 @@ export type ProjectSliceState = {
   colorMaps: DefaultMap<Color>[];
   visibilityMaps: DefaultMap<boolean>[];
   opacityMaps: DefaultMap<number>[];
-  drawOptions: DrawOptions;
   viewerOptions: ViewerOptions;
   viewerAnimationStartOptions: ViewerOptions;
   viewerAnimationFinishOptions: ViewerOptions;
+  renderOptions: RenderOptions;
 };
 
 export type ProjectSliceActions = {
   setProjectName: (name: string) => void;
-  setDrawOptions: (options: Partial<DrawOptions>) => void;
+  setRenderOptions: (options: Partial<RenderOptions>) => void;
   loadProject: (
     project: Project,
     options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
@@ -59,9 +59,9 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
       draft.projectName = name;
     });
   },
-  setDrawOptions: (options) => {
+  setRenderOptions: (options) => {
     set((draft) => {
-      draft.drawOptions = { ...draft.drawOptions, ...options };
+      draft.renderOptions = { ...draft.renderOptions, ...options };
     });
   },
   loadProject: deduplicate(
@@ -76,7 +76,7 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
         colorMaps: structuredClone(project.colorMaps),
         visibilityMaps: structuredClone(project.visibilityMaps),
         opacityMaps: structuredClone(project.opacityMaps),
-        drawOptions: structuredClone(project.drawOptions),
+        renderOptions: structuredClone(project.renderOptions),
         viewerOptions: structuredClone(project.viewerOptions),
         viewerAnimationStartOptions: structuredClone(
           project.viewerAnimationStartOptions,
@@ -170,7 +170,7 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
       colorMaps: structuredClone(state.colorMaps),
       visibilityMaps: structuredClone(state.visibilityMaps),
       opacityMaps: structuredClone(state.opacityMaps),
-      drawOptions: structuredClone(state.drawOptions),
+      renderOptions: structuredClone(state.renderOptions),
       viewerOptions: structuredClone(state.viewerOptions),
       viewerAnimationStartOptions: structuredClone(
         state.viewerAnimationStartOptions,
@@ -203,7 +203,7 @@ function createInitialProjectSliceState(): ProjectSliceState {
     colorMaps: [],
     visibilityMaps: [],
     opacityMaps: [],
-    drawOptions: projectDefaults.drawOptions,
+    renderOptions: projectDefaults.renderOptions,
     viewerOptions: projectDefaults.viewerOptions,
     viewerAnimationStartOptions: projectDefaults.viewerAnimationStartOptions,
     viewerAnimationFinishOptions: projectDefaults.viewerAnimationFinishOptions,

--- a/packages/@tissuumaps-core/src/controllers/WebGLController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLController.ts
@@ -1,7 +1,7 @@
 import { deepEqual } from "fast-equals";
 
-import { defaultDrawOptions } from "../model/constants";
-import { type DrawOptions } from "../model/types";
+import { defaultRenderOptions } from "../model/constants";
+import { type RenderOptions } from "../model/types";
 import { type Rect } from "../types";
 import { WebGLUtils } from "../utils/WebGLUtils";
 import { WebGLPointsController } from "./WebGLPointsController";
@@ -20,7 +20,7 @@ export class WebGLController {
 
   public readonly canvas: HTMLCanvasElement;
   private _viewport: Rect;
-  private _drawOptions: DrawOptions;
+  private _renderOptions: RenderOptions;
   private _gl: WebGL2RenderingContext;
   private _pointsController: WebGLPointsController;
   private _shapesController: WebGLShapesController;
@@ -43,7 +43,7 @@ export class WebGLController {
   constructor(canvas: HTMLCanvasElement, initialViewport: Rect) {
     this.canvas = canvas;
     this._viewport = initialViewport;
-    this._drawOptions = structuredClone(defaultDrawOptions);
+    this._renderOptions = structuredClone(defaultRenderOptions);
     this._gl = WebGLController._createWebGLContext(this.canvas);
     this._pointsController = new WebGLPointsController(this._gl);
     this._shapesController = new WebGLShapesController(this._gl);
@@ -77,20 +77,20 @@ export class WebGLController {
   }
 
   /**
-   * Applies new draw options
+   * Applies new render options
    *
-   * @param drawOptions - The new draw options
+   * @param renderOptions - The new render options
    * @returns Flags indicating whether points and/or shapes need to be re-synchronized, and whether a redraw is needed
    */
-  setDrawOptions(drawOptions: DrawOptions): {
+  setRenderOptions(renderOptions: RenderOptions): {
     syncPoints: boolean;
     syncShapes: boolean;
     redraw: boolean;
   } {
-    if (!deepEqual(drawOptions, this._drawOptions)) {
-      this._drawOptions = drawOptions;
+    if (!deepEqual(renderOptions, this._renderOptions)) {
+      this._renderOptions = renderOptions;
       const syncShapes = this._shapesController.setNumScanlines(
-        drawOptions.numShapesScanlines,
+        renderOptions.numShapesScanlines,
       );
       return { syncPoints: false, syncShapes, redraw: true };
     }
@@ -162,8 +162,8 @@ export class WebGLController {
   draw(): void {
     this._gl.clearColor(0, 0, 0, 0);
     this._gl.clear(this._gl.COLOR_BUFFER_BIT);
-    this._pointsController.draw(this._viewport, this._drawOptions);
-    this._shapesController.draw(this._viewport, this._drawOptions);
+    this._pointsController.draw(this._viewport, this._renderOptions);
+    this._shapesController.draw(this._viewport, this._renderOptions);
   }
 
   /**

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -23,8 +23,8 @@ import {
   type Color,
   type CoordinateSpace,
   type DefaultMap,
-  type DrawOptions,
   type Marker,
+  type RenderOptions,
 } from "../model/types";
 import { type PointsData } from "../storage/points";
 import { type TableData } from "../storage/table";
@@ -303,9 +303,9 @@ export class WebGLPointsController extends WebGLControllerBase {
    * draws all points in a single `gl.POINTS` call with alpha blending.
    *
    * @param viewport - Current world-space viewport
-   * @param drawOptions - Current draw options (e.g. point size factor)
+   * @param renderOptions - Current render options (e.g. point size factor)
    */
-  draw(viewport: Rect, drawOptions: DrawOptions): void {
+  draw(viewport: Rect, renderOptions: RenderOptions): void {
     if (
       this._currentBufferSize === 0 ||
       this._markerAtlasTexture === undefined
@@ -326,7 +326,7 @@ export class WebGLPointsController extends WebGLControllerBase {
     );
     this.gl.uniform1f(
       this._uniformLocations.worldPointSizeFactor,
-      drawOptions.pointSizeFactor,
+      renderOptions.pointSizeFactor,
     );
     this.gl.uniformMatrix3x2fv(
       this._uniformLocations.worldToViewportMatrix,

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -3,7 +3,7 @@ import { deepEqual } from "fast-equals";
 import shapesFragmentShader from "../assets/shaders/shapes.frag?raw";
 import shapesVertexShader from "../assets/shaders/shapes.vert?raw";
 import {
-  defaultDrawOptions,
+  defaultRenderOptions,
   defaultShapeFillColor,
   defaultShapeFillOpacity,
   defaultShapeFillVisibility,
@@ -13,7 +13,11 @@ import {
 } from "../model/constants";
 import { type Layer } from "../model/layer";
 import { type Shapes, type ShapesLayerConfig } from "../model/shapes";
-import { type Color, type DefaultMap, type DrawOptions } from "../model/types";
+import {
+  type Color,
+  type DefaultMap,
+  type RenderOptions,
+} from "../model/types";
 import { type ShapesData } from "../storage/shapes";
 import { type TableData } from "../storage/table";
 import { type MultiPolygon, type Rect, type Vertex } from "../types";
@@ -49,7 +53,7 @@ export class WebGLShapesController extends WebGLControllerBase {
     shapeFillColors: WebGLUniformLocation;
     shapeStrokeColors: WebGLUniformLocation;
   };
-  private _numScanlines: number = defaultDrawOptions.numShapesScanlines;
+  private _numScanlines: number = defaultRenderOptions.numShapesScanlines;
   private _glShapes: GLShapes[] = [];
 
   /**
@@ -190,9 +194,9 @@ export class WebGLShapesController extends WebGLControllerBase {
    * scanline data texture.
    *
    * @param viewport - Current world-space viewport
-   * @param drawOptions - Current draw options (e.g. stroke width)
+   * @param renderOptions - Current render options (e.g. stroke width)
    */
-  draw(viewport: Rect, drawOptions: DrawOptions): void {
+  draw(viewport: Rect, renderOptions: RenderOptions): void {
     this.gl.useProgram(this._program);
     this.gl.uniformMatrix3x2fv(
       this._uniformLocations.viewportToWorldMatrix,
@@ -204,7 +208,7 @@ export class WebGLShapesController extends WebGLControllerBase {
     this.gl.uniform1ui(this._uniformLocations.numScanlines, this._numScanlines);
     this.gl.uniform1f(
       this._uniformLocations.strokeWidth,
-      drawOptions.shapeStrokeWidth,
+      renderOptions.shapeStrokeWidth,
     );
     this.gl.uniform1i(this._uniformLocations.scanlineData, 1);
     this.gl.uniform1i(this._uniformLocations.shapeFillColors, 2);

--- a/packages/@tissuumaps-core/src/model/constants.ts
+++ b/packages/@tissuumaps-core/src/model/constants.ts
@@ -1,8 +1,8 @@
 import {
   type Color,
   type CoordinateSpace,
-  type DrawOptions,
   Marker,
+  type RenderOptions,
   type SimilarityTransform,
   type ViewerOptions,
 } from "./types";
@@ -13,13 +13,6 @@ export const identityTransform = {
   rotation: 0,
   translation: { x: 0, y: 0 },
 } as const satisfies SimilarityTransform;
-
-/** Default WebGL draw options */
-export const defaultDrawOptions = {
-  pointSizeFactor: 1,
-  shapeStrokeWidth: 1,
-  numShapesScanlines: 512,
-} as const satisfies DrawOptions;
 
 /** Default OpenSeadragon viewer options */
 export const defaultViewerOptions = {
@@ -47,6 +40,13 @@ export const defaultViewerOptions = {
   showNavigationControl: false,
   imageSmoothingEnabled: false,
 } as const satisfies ViewerOptions;
+
+/** Default WebGL render options */
+export const defaultRenderOptions = {
+  pointSizeFactor: 1,
+  shapeStrokeWidth: 1,
+  numShapesScanlines: 512,
+} as const satisfies RenderOptions;
 
 // TODO always use defaultLabelColorPalette instead
 /** Default label color */

--- a/packages/@tissuumaps-core/src/model/layer.ts
+++ b/packages/@tissuumaps-core/src/model/layer.ts
@@ -53,7 +53,7 @@ export interface RawLayer extends RawModel {
    * A unitless scaling factor by which all point sizes are multiplied.
    *
    * Can be used to adjust the size of all points in a layer relative to other layers.
-   * Note that point sizes are also affected by {@link "./project".RawProject.drawOptions} as well as {@link "./points".RawPoints}-specific settings.
+   * Note that point sizes are also affected by {@link "./project".RawProject.renderOptions} as well as {@link "./points".RawPoints}-specific settings.
    *
    * @defaultValue {@link layerDefaults.pointSizeFactor}
    */

--- a/packages/@tissuumaps-core/src/model/points.ts
+++ b/packages/@tissuumaps-core/src/model/points.ts
@@ -84,7 +84,7 @@ export interface RawPoints extends RawRenderedDataObject<
    * A unitless scaling factor by which all point sizes are multiplied.
    *
    * Can be used to adjust the size of points without changing individual point sizes or the size unit.
-   * Note that point sizes are also affected by {@link "./layer".RawLayer.pointSizeFactor} and {@link "./project".RawProject.drawOptions}.
+   * Note that point sizes are also affected by {@link "./layer".RawLayer.pointSizeFactor} and {@link "./project".RawProject.renderOptions}.
    *
    * @defaultValue {@link pointsDefaults.pointSizeFactor}
    */

--- a/packages/@tissuumaps-core/src/model/project.ts
+++ b/packages/@tissuumaps-core/src/model/project.ts
@@ -1,5 +1,5 @@
 import { type Model, type RawModel, createModel } from "./base";
-import { defaultDrawOptions, defaultViewerOptions } from "./constants";
+import { defaultRenderOptions, defaultViewerOptions } from "./constants";
 import { type Image, type RawImage, createImage } from "./image";
 import { type Labels, type RawLabels, createLabels } from "./labels";
 import { type Layer, type RawLayer, createLayer } from "./layer";
@@ -9,8 +9,8 @@ import { type RawTable, type Table, createTable } from "./table";
 import {
   type Color,
   type DefaultMap,
-  type DrawOptions,
   type Marker,
+  type RenderOptions,
   type ViewerOptions,
 } from "./types";
 
@@ -23,7 +23,6 @@ export const projectDefaults = {
   colorMaps: [],
   visibilityMaps: [],
   opacityMaps: [],
-  drawOptions: defaultDrawOptions,
   viewerOptions: defaultViewerOptions,
   viewerAnimationStartOptions: {
     immediateRender: false,
@@ -32,13 +31,14 @@ export const projectDefaults = {
   viewerAnimationFinishOptions: {
     immediateRender: true, // set to true, even if initially set to false
   },
+  renderOptions: defaultRenderOptions,
 } as const satisfies Partial<RawProject>;
 
 /**
  * A TissUUmaps project
  *
  * Top-level container that assembles layers, data objects (images, labels,
- * points, shapes), tables, group-to-value maps, and viewer/draw options
+ * points, shapes), tables, group-to-value maps, and viewer/render options
  * into a single serializable configuration.
  */
 export interface RawProject extends RawModel {
@@ -113,13 +113,6 @@ export interface RawProject extends RawModel {
   opacityMaps?: DefaultMap<number>[];
 
   /**
-   * WebGL draw options for points/shapes
-   *
-   * @defaultValue {@link projectDefaults.drawOptions}
-   */
-  drawOptions?: DrawOptions;
-
-  /**
    * OpenSeadragon viewer options for images/labels
    *
    * @defaultValue {@link projectDefaults.viewerOptions}
@@ -145,6 +138,13 @@ export interface RawProject extends RawModel {
    * @see https://openseadragon.github.io/docs/OpenSeadragon.html#.Options
    */
   viewerAnimationFinishOptions?: ViewerOptions;
+
+  /**
+   * WebGL render options for points/shapes
+   *
+   * @defaultValue {@link projectDefaults.renderOptions}
+   */
+  renderOptions?: RenderOptions;
 }
 
 /**

--- a/packages/@tissuumaps-core/src/model/types.ts
+++ b/packages/@tissuumaps-core/src/model/types.ts
@@ -111,8 +111,8 @@ export type ViewerOptions = Omit<OpenSeadragon.Options, "element"> & {
   referenceStripElement?: never;
 };
 
-/** WebGL draw options for rendering points and shapes */
-export type DrawOptions = {
+/** WebGL render options for rendering points and shapes */
+export type RenderOptions = {
   /** Global point size scaling factor (unitless, multiplied with all point sizes) */
   pointSizeFactor: number;
 

--- a/packages/@tissuumaps-viewer/src/adapter.ts
+++ b/packages/@tissuumaps-viewer/src/adapter.ts
@@ -1,7 +1,6 @@
 import {
   type Color,
   type DefaultMap,
-  type DrawOptions,
   type Image,
   type ImageData,
   type InteractionMode,
@@ -12,6 +11,7 @@ import {
   type MultiPolygon,
   type Points,
   type PointsData,
+  type RenderOptions,
   type Shapes,
   type ShapesData,
   type TableData,
@@ -34,7 +34,7 @@ export interface ViewerAdapter {
   viewerOptions: ViewerOptions;
   viewerAnimationStartOptions: ViewerOptions;
   viewerAnimationFinishOptions: ViewerOptions;
-  drawOptions: DrawOptions;
+  renderOptions: RenderOptions;
   loadImage: (
     imageId: string,
     options?: { signal?: AbortSignal },

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -19,7 +19,7 @@ export function useWebGL(
     colorMaps,
     visibilityMaps,
     opacityMaps,
-    drawOptions,
+    renderOptions,
     loadPoints,
     loadShapes,
     loadTable,
@@ -68,9 +68,9 @@ export function useWebGL(
   useEffect(() => {
     const controller = controllerRef.current;
     if (controllerReady && controller !== null) {
-      console.debug("Setting WebGL draw options");
+      console.debug("Setting WebGL render options");
       const { syncPoints, syncShapes, redraw } =
-        controller.setDrawOptions(drawOptions);
+        controller.setRenderOptions(renderOptions);
       if (syncPoints) {
         dispatchSyncPoints();
       }
@@ -81,7 +81,7 @@ export function useWebGL(
         controller.draw();
       }
     }
-  }, [controllerReady, drawOptions]);
+  }, [controllerReady, renderOptions]);
 
   useEffect(() => {
     const controller = controllerRef.current;


### PR DESCRIPTION
# References and relevant issues

TMAP-244

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: refactor

# List of changes made

- Rename WebGL `DrawOptions` to `RenderOptions`

# Use of AI

None

# Testing

None

# Further comments

This rename was prompted by confusion regarding the "drawing" of shapes