### PR TITLE
refactor: move data-to-layer transforms from layer config to object

### DIFF
--- a/apps/docs/docs/concepts/data-model.md
+++ b/apps/docs/docs/concepts/data-model.md
@@ -40,15 +40,17 @@ classDiagram
     Image : name
     Image : data source
     Image : visibility, opacity
-    Image "0..*" --> "0..*" Layer : layer configurations (incl. data-to-layer transforms)
+    Image : data-to-layer transform
+    Image "0..*" --> "0..*" Layer : layer configurations
 
     class Labels
     Labels : id
     Labels : name
     Labels : data source
     Labels : visibility, opacity
+    Labels : data-to-layer transform
     Labels : label color/visibility/opacity
-    Labels "0..*" --> "0..*" Layer : layer configurations (incl. data-to-layer transforms)
+    Labels "0..*" --> "0..*" Layer : layer configurations
     Labels "0..*" ..> "1" Table
 
     class Points
@@ -56,8 +58,9 @@ classDiagram
     Points : name
     Points : data source
     Points : visibility, opacity
+    Points : data-to-layer transform
     Points : point marker/size/color/visibility/opacity
-    Points "0..*" --> "0..*" Layer : layer configurations (incl. data-to-layer transforms)
+    Points "0..*" --> "0..*" Layer : layer configurations
     Points "0..*" ..> "1" Table
 
     class Shapes
@@ -65,9 +68,10 @@ classDiagram
     Shapes : name
     Shapes : data source
     Shapes : visibility, opacity
+    Shapes : data-to-layer transform
     Shapes : shape fill color/visibility/opacity
     Shapes : shape stroke color/visibility/opacity
-    Shapes "0..*" --> "0..*" Layer : layer configurations (incl. data-to-layer transforms)
+    Shapes "0..*" --> "0..*" Layer : layer configurations
     Shapes "0..*" ..> "1" Table
 
     class Table

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -481,16 +481,17 @@ export class OpenSeadragonController {
     if (tiledImageState.tiledImage === undefined) {
       throw new Error("Cannot update tiled image before it is created");
     }
+    const { flip, transform } =
+      "image" in tiledImageState.ref
+        ? tiledImageState.ref.image
+        : tiledImageState.ref.labels;
     const m = mat3.create();
-    const dataToLayerMatrix = TransformUtils.toSimilarityMatrix(
-      tiledImageState.ref.layerConfig.transform,
-      {
-        center: {
-          x: tiledImageState.tiledImage.getContentSize().x / 2,
-          y: tiledImageState.tiledImage.getContentSize().y / 2,
-        },
+    const dataToLayerMatrix = TransformUtils.toSimilarityMatrix(transform, {
+      center: {
+        x: tiledImageState.tiledImage.getContentSize().x / 2,
+        y: tiledImageState.tiledImage.getContentSize().y / 2,
       },
-    );
+    });
     mat3.multiply(m, dataToLayerMatrix, m);
     const layerToWorldMatrix = TransformUtils.toSimilarityMatrix(
       tiledImageState.ref.layer.transform,
@@ -498,11 +499,8 @@ export class OpenSeadragonController {
     mat3.multiply(m, layerToWorldMatrix, m);
     const dataToWorldTransform = TransformUtils.fromSimilarityMatrix(m);
     const bounds = tiledImageState.tiledImage.getBoundsNoRotate();
-    if (
-      tiledImageState.tiledImage.getFlip() !==
-      tiledImageState.ref.layerConfig.flip
-    ) {
-      tiledImageState.tiledImage.setFlip(tiledImageState.ref.layerConfig.flip);
+    if (tiledImageState.tiledImage.getFlip() !== flip) {
+      tiledImageState.tiledImage.setFlip(flip);
     }
     const width =
       tiledImageState.tiledImage.getContentSize().x *

--- a/packages/@tissuumaps-core/src/controllers/WebGLControllerBase.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLControllerBase.ts
@@ -1,7 +1,7 @@
 import { mat3 } from "gl-matrix";
 
-import { type LayerConfig } from "../model/base";
 import { type Layer } from "../model/layer";
+import { type SimilarityTransform } from "../model/types";
 import { type Rect } from "../types";
 import { TransformUtils } from "../utils/TransformUtils";
 
@@ -25,21 +25,19 @@ export class WebGLControllerBase {
    * Applies, in order: optional horizontal flip, data → layer transform,
    * then layer → world transform.
    *
+   * @param obj - Object providing the flip flag and data → layer transform
    * @param layer - Layer providing the layer → world transform
-   * @param layerConfig - Layer configuration providing the flip flag and data → layer transform
    */
   protected static createDataToWorldMatrix(
+    obj: { flip: boolean; transform: SimilarityTransform },
     layer: Layer,
-    layerConfig: LayerConfig,
   ): mat3 {
     const dataToWorldMatrix = mat3.create();
-    if (layerConfig.flip) {
+    if (obj.flip) {
       const flipMatrix = mat3.fromScaling(mat3.create(), [-1, 1]);
       mat3.multiply(dataToWorldMatrix, flipMatrix, dataToWorldMatrix);
     }
-    const dataToLayerMatrix = TransformUtils.toSimilarityMatrix(
-      layerConfig.transform,
-    );
+    const dataToLayerMatrix = TransformUtils.toSimilarityMatrix(obj.transform);
     mat3.multiply(dataToWorldMatrix, dataToLayerMatrix, dataToWorldMatrix);
     const layerToWorldMatrix = TransformUtils.toSimilarityMatrix(
       layer.transform,
@@ -87,12 +85,12 @@ export class WebGLControllerBase {
    * Inverse of {@link createDataToWorldMatrix}: applies world → layer,
    * layer → data, then optional horizontal un-flip.
    *
+   * @param obj - Object providing the data → layer transform (inverted) and flip flag
    * @param layer - Layer providing the layer → world transform (inverted)
-   * @param layerConfig - Layer configuration providing the data → layer transform (inverted) and flip flag
    */
   protected static createWorldToDataMatrix(
+    obj: { flip: boolean; transform: SimilarityTransform },
     layer: Layer,
-    layerConfig: LayerConfig,
   ): mat3 {
     const worldToDataMatrix = mat3.create();
     const worldToLayerMatrix = TransformUtils.toSimilarityMatrix(
@@ -100,12 +98,10 @@ export class WebGLControllerBase {
     );
     mat3.invert(worldToLayerMatrix, worldToLayerMatrix);
     mat3.multiply(worldToDataMatrix, worldToLayerMatrix, worldToDataMatrix);
-    const layerToDataMatrix = TransformUtils.toSimilarityMatrix(
-      layerConfig.transform,
-    );
+    const layerToDataMatrix = TransformUtils.toSimilarityMatrix(obj.transform);
     mat3.invert(layerToDataMatrix, layerToDataMatrix);
     mat3.multiply(worldToDataMatrix, layerToDataMatrix, worldToDataMatrix);
-    if (layerConfig.flip) {
+    if (obj.flip) {
       const flipMatrix = mat3.fromScaling(mat3.create(), [-1, 1]);
       mat3.multiply(worldToDataMatrix, flipMatrix, worldToDataMatrix);
     }

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -766,7 +766,6 @@ export class WebGLPointsController extends WebGLControllerBase {
             pointSizeFactor: ref.points.pointSizeFactor,
             transform: structuredClone(ref.points.transform),
           },
-          layerConfig: {},
         },
       });
       objectsUBOData.set(
@@ -863,6 +862,5 @@ type PointsBufferSliceState = {
       | "pointSizeFactor"
       | "transform"
     >;
-    layerConfig: Pick<PointsLayerConfig, never>;
   };
 };

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -374,8 +374,8 @@ export class WebGLPointsController extends WebGLControllerBase {
       yMax = -Infinity;
     for (const bufferSliceState of this._bufferSliceStates) {
       const transform = WebGLPointsController.createDataToWorldMatrix(
+        bufferSliceState.ref.points,
         bufferSliceState.ref.layer,
-        bufferSliceState.ref.layerConfig,
       );
       const { x, y, width, height } = TransformUtils.transformBoundingBox(
         bufferSliceState.dataBounds,
@@ -616,8 +616,8 @@ export class WebGLPointsController extends WebGLControllerBase {
           ref.points.pointSizeFactor ||
         bufferSliceState.current.layer.transform.scale !==
           ref.layer.transform.scale ||
-        bufferSliceState.current.layerConfig.transform.scale !==
-          ref.layerConfig.transform.scale ||
+        bufferSliceState.current.points.transform.scale !==
+          ref.points.transform.scale ||
         !deepEqual(
           bufferSliceState.current.points.pointSize,
           ref.points.pointSize,
@@ -647,7 +647,7 @@ export class WebGLPointsController extends WebGLControllerBase {
         }
         let sizeFactor = ref.points.pointSizeFactor * ref.layer.pointSizeFactor;
         if (activeUnit === "data") {
-          sizeFactor *= ref.layerConfig.transform.scale;
+          sizeFactor *= ref.points.transform.scale;
         }
         if (activeUnit === "data" || activeUnit === "layer") {
           sizeFactor *= ref.layer.transform.scale;
@@ -764,18 +764,14 @@ export class WebGLPointsController extends WebGLControllerBase {
             pointVisibility: structuredClone(ref.points.pointVisibility),
             pointOpacity: structuredClone(ref.points.pointOpacity),
             pointSizeFactor: ref.points.pointSizeFactor,
+            transform: structuredClone(ref.points.transform),
           },
-          layerConfig: {
-            transform: structuredClone(ref.layerConfig.transform),
-          },
+          layerConfig: {},
         },
       });
       objectsUBOData.set(
         TransformUtils.transposeAsGLMat2x4(
-          WebGLPointsController.createDataToWorldMatrix(
-            ref.layer,
-            ref.layerConfig,
-          ),
+          WebGLPointsController.createDataToWorldMatrix(ref.points, ref.layer),
         ),
         i * 8,
       );
@@ -865,7 +861,8 @@ type PointsBufferSliceState = {
       | "pointVisibility"
       | "pointOpacity"
       | "pointSizeFactor"
+      | "transform"
     >;
-    layerConfig: Pick<PointsLayerConfig, "transform">;
+    layerConfig: Pick<PointsLayerConfig, never>;
   };
 };

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -219,8 +219,8 @@ export class WebGLShapesController extends WebGLControllerBase {
         continue; // scanline data texture is currently being regenerated
       }
       const worldToDataMatrix = WebGLShapesController.createWorldToDataMatrix(
+        glShapes.ref.shapes,
         glShapes.ref.layer,
-        glShapes.ref.layerConfig,
       );
       this.gl.uniformMatrix3x2fv(
         this._uniformLocations.worldToDataMatrix,
@@ -264,8 +264,8 @@ export class WebGLShapesController extends WebGLControllerBase {
       yMax = -Infinity;
     for (const glShapes of this._glShapes) {
       const transform = WebGLShapesController.createDataToWorldMatrix(
+        glShapes.ref.shapes,
         glShapes.ref.layer,
-        glShapes.ref.layerConfig,
       );
       const { x, y, width, height } = TransformUtils.transformBoundingBox(
         glShapes.dataBounds,

--- a/packages/@tissuumaps-core/src/model/base.ts
+++ b/packages/@tissuumaps-core/src/model/base.ts
@@ -95,6 +95,8 @@ export function createDataObject<
 export const renderedDataObjectDefaults = {
   visibility: true,
   opacity: 1,
+  flip: false,
+  transform: identityTransform,
   layerConfigs: [],
 } as const satisfies Partial<
   RawRenderedDataObject<RawDataSource<string>, RawLayerConfig>
@@ -120,6 +122,20 @@ export interface RawRenderedDataObject<
    * @defaultValue {@link renderedDataObjectDefaults.opacity}
    */
   opacity?: number;
+
+  /**
+   * Horizontal reflection, applied before transformation
+   *
+   * @defaultValue {@link layerConfigDefaults.flip}
+   */
+  flip?: boolean;
+
+  /**
+   * Transformation from data object space to layer space
+   *
+   * @defaultValue {@link layerConfigDefaults.transform}
+   */
+  transform?: SimilarityTransform;
 
   /**
    * Layer configurations specifying how this data object is displayed on each layer
@@ -227,10 +243,8 @@ export function createDataSource<TType extends string>(
 /**
  * Default values for {@link RawLayerConfig}
  */
-export const layerConfigDefaults = {
-  flip: false,
-  transform: identityTransform,
-} as const satisfies Partial<RawLayerConfig>;
+export const layerConfigDefaults =
+  {} as const satisfies Partial<RawLayerConfig>;
 
 /**
  * A layer-specific display configuration for rendered data objects
@@ -244,20 +258,6 @@ export interface RawLayerConfig extends RawModel {
    * - A table column holding the layer ID values for each item
    */
   layer: string | { table: string; column: string };
-
-  /**
-   * Horizontal reflection, applied before transformation
-   *
-   * @defaultValue {@link layerConfigDefaults.flip}
-   */
-  flip?: boolean;
-
-  /**
-   * Transformation from data object space to layer space
-   *
-   * @defaultValue {@link layerConfigDefaults.transform}
-   */
-  transform?: SimilarityTransform;
 }
 
 /**
@@ -268,7 +268,9 @@ export type LayerConfig = Model &
   Omit<
     RawLayerConfig,
     // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    keyof Model | keyof typeof layerConfigDefaults
+    | keyof Model
+    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents,@typescript-eslint/no-duplicate-type-constituents
+    | keyof typeof layerConfigDefaults
   >;
 
 /**

--- a/packages/@tissuumaps-core/src/model/base.ts
+++ b/packages/@tissuumaps-core/src/model/base.ts
@@ -126,14 +126,14 @@ export interface RawRenderedDataObject<
   /**
    * Horizontal reflection, applied before transformation
    *
-   * @defaultValue {@link layerConfigDefaults.flip}
+   * @defaultValue {@link renderedDataObjectDefaults.flip}
    */
   flip?: boolean;
 
   /**
    * Transformation from data object space to layer space
    *
-   * @defaultValue {@link layerConfigDefaults.transform}
+   * @defaultValue {@link renderedDataObjectDefaults.transform}
    */
   transform?: SimilarityTransform;
 


### PR DESCRIPTION
# References and relevant issues

TMAP-313

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: refactor

# List of changes made

- Move `flip` and `transform` from `LayerConfig` to `RenderedDataObject`

# Use of AI

None

# Testing

None

# Further comments

None