### PR TITLE
feat: implement free-hand shape drawing

### DIFF
--- a/packages/@tissuumaps-core/src/controllers/SVGController.ts
+++ b/packages/@tissuumaps-core/src/controllers/SVGController.ts
@@ -320,12 +320,11 @@ export class SVGController {
       );
     }
 
-    const pointsString = this._freehandDrawingState.points
-      .map((v) => `${v.x},${v.y}`)
-      .join(" ");
+    const existingPoints =
+      this._freehandDrawingState.currentPolyline.getAttribute("points");
     this._freehandDrawingState.currentPolyline.setAttribute(
       "points",
-      pointsString,
+      `${existingPoints} ${worldPoint.x},${worldPoint.y}`,
     );
   };
 
@@ -349,14 +348,8 @@ export class SVGController {
       this._freehandDrawingState.hasLeftStart &&
       this._isNearPoint(releasePoint, firstPoint)
     ) {
-      console.debug("Freehand shape committed", { points: points.length });
       const multiPolygon = this._createMultiPolygon([...points, firstPoint]);
       this.shapeCompleteHandler?.(multiPolygon);
-    } else {
-      console.debug("Freehand shape discarded", {
-        points: points.length,
-        hasLeftStart: this._freehandDrawingState.hasLeftStart,
-      });
     }
 
     this._cancelFreehand();
@@ -369,7 +362,6 @@ export class SVGController {
     ) {
       return;
     }
-    console.debug("Freehand shape discarded (pointercancel)");
     this._cancelFreehand();
   };
 

--- a/packages/@tissuumaps-core/src/controllers/SVGController.ts
+++ b/packages/@tissuumaps-core/src/controllers/SVGController.ts
@@ -147,6 +147,7 @@ export class SVGController {
   }
 
   destroy(): void {
+    this._cancelFreehand();
     this._unregisterEventHandlers();
   }
 
@@ -267,6 +268,8 @@ export class SVGController {
   // ─────────────────────────────────────────────────────────────
 
   private _handleFreehandPointerDown = (event: PointerEvent): void => {
+    if (this._freehandDrawingState) return;
+
     event.preventDefault();
     event.stopPropagation();
 
@@ -318,14 +321,16 @@ export class SVGController {
   private _handleFreehandPointerUp = (event: PointerEvent): void => {
     if (!this._freehandDrawingState || event.button !== 0) return;
 
+    const releasePoint = this._screenToWorld(event.clientX, event.clientY);
+    this._freehandDrawingState.points.push(releasePoint);
+
     const points = this._freehandDrawingState.points;
     const firstPoint = points[0]!;
-    const lastPoint = points[points.length - 1]!;
 
     if (
       points.length >= 2 &&
       this._freehandDrawingState.hasLeftStart &&
-      this._isNearPoint(lastPoint, firstPoint)
+      this._isNearPoint(releasePoint, firstPoint)
     ) {
       console.debug("Freehand shape committed", { points: points.length });
       const multiPolygon = this._createMultiPolygon([...points, firstPoint]);

--- a/packages/@tissuumaps-core/src/controllers/SVGController.ts
+++ b/packages/@tissuumaps-core/src/controllers/SVGController.ts
@@ -244,9 +244,8 @@ export class SVGController {
   // Polygon drawing
   // ─────────────────────────────────────────────────────────────
 
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-
   // @ts-expect-error currently not used
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private _handlePolygonPointerDown = (event: PointerEvent): void => {
     // TODO implement polygon drawing logic
     // TODO: Register polygon-specific move/up handlers
@@ -255,11 +254,13 @@ export class SVGController {
   };
 
   // @ts-expect-error currently not used
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private _handlePolygonPointerMove = (event: PointerEvent): void => {
     // TODO
   };
 
   // @ts-expect-error currently not used
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   private _handlePolygonPointerUp = (event: PointerEvent): void => {
     // TODO
   };

--- a/packages/@tissuumaps-core/src/controllers/SVGController.ts
+++ b/packages/@tissuumaps-core/src/controllers/SVGController.ts
@@ -17,9 +17,12 @@ type PolygonDrawingState = {
   // TODO extend for polygon drawing
 };
 
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 type FreehandDrawingState = {
-  // TODO extend for freehand drawing
+  points: Vertex[];
+  currentPolyline: SVGPolylineElement;
+  startHandle: SVGCircleElement;
+  hasLeftStart: boolean;
+  isNearStart: boolean;
 };
 
 /**
@@ -33,6 +36,8 @@ export class SVGController {
   private static readonly _previewStrokeColor = "#FF0000";
   private static readonly _previewStrokeWidthFactor = 0.0005;
   private static readonly _minShapeSizeFactor = 0.001;
+  private static readonly _closeShapeThresholdFactor = 0.01;
+  private static readonly _vertexMarkerRadiusFactor = 0.0015;
   private _containerSize: { width: number; height: number };
   private _viewport: Rect;
   // eslint-disable-next-line @typescript-eslint/ban-ts-comment
@@ -44,7 +49,6 @@ export class SVGController {
   // @ts-expect-error currently not used
   private _polygonDrawingState: PolygonDrawingState | null = null;
 
-  // @ts-expect-error currently not used
   private _freehandDrawingState: FreehandDrawingState | null = null;
 
   /** Creates a positioned, full-size `<svg>` element for the SVG overlay */
@@ -105,6 +109,9 @@ export class SVGController {
    * @param newInteractionMode - New interaction mode
    */
   setInteractionMode(newInteractionMode: InteractionMode) {
+    if (this._freehandDrawingState && newInteractionMode !== "drawFreehand") {
+      this._cancelFreehand();
+    }
     this._interactionMode = newInteractionMode;
   }
 
@@ -259,25 +266,90 @@ export class SVGController {
   // Freehand Drawing
   // ─────────────────────────────────────────────────────────────
 
-  // @ts-expect-error currently not used
   private _handleFreehandPointerDown = (event: PointerEvent): void => {
-    // TODO: Register freehand-specific move/up handlers
-    // document.addEventListener("pointermove", this._handleFreehandPointerMove);
-    // document.addEventListener("pointerup", this._handleFreehandPointerUp);
+    event.preventDefault();
+    event.stopPropagation();
+
+    document.addEventListener("pointermove", this._handleFreehandPointerMove);
+    document.addEventListener("pointerup", this._handleFreehandPointerUp);
+
+    const worldPoint = this._screenToWorld(event.clientX, event.clientY);
+
+    this._freehandDrawingState = {
+      points: [worldPoint],
+      currentPolyline: this._createPreviewPolyline(worldPoint),
+      startHandle: this._createVertexMarker(worldPoint),
+      hasLeftStart: false,
+      isNearStart: false,
+    };
   };
 
-  // @ts-expect-error currently not used
   private _handleFreehandPointerMove = (event: PointerEvent): void => {
-    // TODO
+    if (!this._freehandDrawingState) return;
+
+    const worldPoint = this._screenToWorld(event.clientX, event.clientY);
+    this._freehandDrawingState.points.push(worldPoint);
+
+    const firstPoint = this._freehandDrawingState.points[0]!;
+    const nearStart = this._isNearPoint(worldPoint, firstPoint);
+
+    if (!this._freehandDrawingState.hasLeftStart && !nearStart) {
+      this._freehandDrawingState.hasLeftStart = true;
+    }
+
+    const isNearStart = this._freehandDrawingState.hasLeftStart && nearStart;
+    if (isNearStart !== this._freehandDrawingState.isNearStart) {
+      this._freehandDrawingState.isNearStart = isNearStart;
+      this._setMarkerHighlighted(
+        this._freehandDrawingState.startHandle,
+        isNearStart,
+      );
+    }
+
+    const pointsString = this._freehandDrawingState.points
+      .map((v) => `${v.x},${v.y}`)
+      .join(" ");
+    this._freehandDrawingState.currentPolyline.setAttribute(
+      "points",
+      pointsString,
+    );
   };
 
-  // @ts-expect-error currently not used
   private _handleFreehandPointerUp = (event: PointerEvent): void => {
-    // TODO
+    if (!this._freehandDrawingState || event.button !== 0) return;
+
+    const points = this._freehandDrawingState.points;
+    const firstPoint = points[0]!;
+    const lastPoint = points[points.length - 1]!;
+
+    if (
+      points.length >= 2 &&
+      this._freehandDrawingState.hasLeftStart &&
+      this._isNearPoint(lastPoint, firstPoint)
+    ) {
+      const multiPolygon = this._createMultiPolygon([...points, firstPoint]);
+      this.shapeCompleteHandler?.(multiPolygon);
+    }
+
+    this._cancelFreehand();
   };
+
+  private _cancelFreehand(): void {
+    if (!this._freehandDrawingState) return;
+
+    this._freehandDrawingState.currentPolyline.remove();
+    this._freehandDrawingState.startHandle.remove();
+    this._freehandDrawingState = null;
+
+    document.removeEventListener(
+      "pointermove",
+      this._handleFreehandPointerMove,
+    );
+    document.removeEventListener("pointerup", this._handleFreehandPointerUp);
+  }
 
   // ─────────────────────────────────────────────────────────────
-  // Drawing Helpers
+  // Rectangle Drawing Helpers
   // ─────────────────────────────────────────────────────────────
 
   private _createPreviewRect(startPoint: Vertex): SVGRectElement {
@@ -344,6 +416,84 @@ export class SVGController {
     return (
       Math.abs(end.x - start.x) > minSize && Math.abs(end.y - start.y) > minSize
     );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // Freehand Drawing Helpers
+  // ─────────────────────────────────────────────────────────────
+
+  private _createPreviewPolyline(startPoint: Vertex): SVGPolylineElement {
+    const polyline = document.createElementNS(SVG_NAMESPACE, "polyline");
+    polyline.setAttribute("points", `${startPoint.x},${startPoint.y}`);
+    polyline.setAttribute("fill", "none");
+    polyline.setAttribute("stroke", SVGController._previewStrokeColor);
+    polyline.setAttribute(
+      "stroke-width",
+      (
+        this._viewport.width * SVGController._previewStrokeWidthFactor
+      ).toString(),
+    );
+
+    this.transformNode.appendChild(polyline);
+    return polyline;
+  }
+
+  private _createVertexMarker(point: Vertex): SVGCircleElement {
+    const circle = document.createElementNS(SVG_NAMESPACE, "circle");
+    const radius =
+      this._viewport.width * SVGController._vertexMarkerRadiusFactor;
+    circle.setAttribute("cx", point.x.toString());
+    circle.setAttribute("cy", point.y.toString());
+    circle.setAttribute("r", radius.toString());
+    circle.setAttribute("fill", SVGController._previewStrokeColor);
+
+    this.transformNode.appendChild(circle);
+    return circle;
+  }
+
+  private _setMarkerHighlighted(
+    marker: SVGCircleElement,
+    isHighlighted: boolean,
+  ): void {
+    const radius =
+      this._viewport.width * SVGController._vertexMarkerRadiusFactor;
+
+    if (isHighlighted) {
+      marker.setAttribute("fill", "none");
+      marker.setAttribute("stroke", SVGController._previewStrokeColor);
+      marker.setAttribute(
+        "stroke-width",
+        (
+          this._viewport.width *
+          SVGController._previewStrokeWidthFactor *
+          2
+        ).toString(),
+      );
+      marker.setAttribute("r", (radius * 1.5).toString());
+    } else {
+      marker.setAttribute("fill", SVGController._previewStrokeColor);
+      marker.setAttribute("stroke", "none");
+      marker.setAttribute("r", radius.toString());
+    }
+  }
+
+  private _createMultiPolygon(vertices: Vertex[]): MultiPolygon {
+    return {
+      polygons: [
+        {
+          shell: vertices.map((v) => ({ x: v.x, y: v.y })),
+          holes: [],
+        },
+      ],
+    };
+  }
+
+  private _isNearPoint(p1: Vertex, p2: Vertex): boolean {
+    const threshold =
+      this._viewport.width * SVGController._closeShapeThresholdFactor;
+    const dx = p1.x - p2.x;
+    const dy = p1.y - p2.y;
+    return dx * dx + dy * dy < threshold * threshold;
   }
 
   // ─────────────────────────────────────────────────────────────

--- a/packages/@tissuumaps-core/src/controllers/SVGController.ts
+++ b/packages/@tissuumaps-core/src/controllers/SVGController.ts
@@ -327,8 +327,14 @@ export class SVGController {
       this._freehandDrawingState.hasLeftStart &&
       this._isNearPoint(lastPoint, firstPoint)
     ) {
+      console.debug("Freehand shape committed", { points: points.length });
       const multiPolygon = this._createMultiPolygon([...points, firstPoint]);
       this.shapeCompleteHandler?.(multiPolygon);
+    } else {
+      console.debug("Freehand shape discarded", {
+        points: points.length,
+        hasLeftStart: this._freehandDrawingState.hasLeftStart,
+      });
     }
 
     this._cancelFreehand();

--- a/packages/@tissuumaps-core/src/controllers/SVGController.ts
+++ b/packages/@tissuumaps-core/src/controllers/SVGController.ts
@@ -18,6 +18,7 @@ type PolygonDrawingState = {
 };
 
 type FreehandDrawingState = {
+  pointerId: number;
   points: Vertex[];
   currentPolyline: SVGPolylineElement;
   startHandle: SVGCircleElement;
@@ -275,10 +276,15 @@ export class SVGController {
 
     document.addEventListener("pointermove", this._handleFreehandPointerMove);
     document.addEventListener("pointerup", this._handleFreehandPointerUp);
+    document.addEventListener(
+      "pointercancel",
+      this._handleFreehandPointerCancel,
+    );
 
     const worldPoint = this._screenToWorld(event.clientX, event.clientY);
 
     this._freehandDrawingState = {
+      pointerId: event.pointerId,
       points: [worldPoint],
       currentPolyline: this._createPreviewPolyline(worldPoint),
       startHandle: this._createVertexMarker(worldPoint),
@@ -288,7 +294,12 @@ export class SVGController {
   };
 
   private _handleFreehandPointerMove = (event: PointerEvent): void => {
-    if (!this._freehandDrawingState) return;
+    if (
+      !this._freehandDrawingState ||
+      event.pointerId !== this._freehandDrawingState.pointerId
+    ) {
+      return;
+    }
 
     const worldPoint = this._screenToWorld(event.clientX, event.clientY);
     this._freehandDrawingState.points.push(worldPoint);
@@ -319,7 +330,13 @@ export class SVGController {
   };
 
   private _handleFreehandPointerUp = (event: PointerEvent): void => {
-    if (!this._freehandDrawingState || event.button !== 0) return;
+    if (
+      !this._freehandDrawingState ||
+      event.button !== 0 ||
+      event.pointerId !== this._freehandDrawingState.pointerId
+    ) {
+      return;
+    }
 
     const releasePoint = this._screenToWorld(event.clientX, event.clientY);
     this._freehandDrawingState.points.push(releasePoint);
@@ -345,6 +362,17 @@ export class SVGController {
     this._cancelFreehand();
   };
 
+  private _handleFreehandPointerCancel = (event: PointerEvent): void => {
+    if (
+      !this._freehandDrawingState ||
+      event.pointerId !== this._freehandDrawingState.pointerId
+    ) {
+      return;
+    }
+    console.debug("Freehand shape discarded (pointercancel)");
+    this._cancelFreehand();
+  };
+
   private _cancelFreehand(): void {
     if (!this._freehandDrawingState) return;
 
@@ -357,6 +385,10 @@ export class SVGController {
       this._handleFreehandPointerMove,
     );
     document.removeEventListener("pointerup", this._handleFreehandPointerUp);
+    document.removeEventListener(
+      "pointercancel",
+      this._handleFreehandPointerCancel,
+    );
   }
 
   // ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
# References and relevant issues

Closes [TMAP-222](https://scilifelab.atlassian.net/browse/TMAP-222)

# Type of change

- [x] New feature (non-breaking change which adds functionality)

# List of changes made

<!-- Specify what changes have been made and why. -->

- functionality for free-hand drawing was added
- shape is drawn as a polyline that grows live as the cursor moves
- start point is marked as a small circle handle
- visual effect on starting point when coming close enough to close the shape 
- shape commits only when released near the start handle, otherwise it is discarded 

# Screenshot of the fix

<img width="764" height="520" alt="image" src="https://github.com/user-attachments/assets/acd0aebf-bd9d-44ce-810f-8bb0b0d53648" />

# Use of AI

This PR was created with the assistance of Claude Code.

# Testing

<!-- Please delete options that are not relevant -->

- open the browser dev tools console to observe commit/discard logs
- switch to free-hand mode
- start drawing by pressing and dragging with the mouse
- try to complete the shape by releasing near the start handle (~~console should log "Freehand shape committed"~~)
- try to release away from the start handle (~~console should log "Freehand shape discarded"~~)   
- try a quick click without dragging (~~console should log "Freehand shape discarded"~~)
- zoom in and confirm the stroke width, start handle, and close-tolerance keep their on-screen size  
- shift + drag should still pan 

<!--
Final Checklist:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
-->
