### PR TITLE
refactor: replace LayerConfig by object-level layer setting

### DIFF
--- a/apps/docs/docs/concepts/data-model.md
+++ b/apps/docs/docs/concepts/data-model.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 A single **_Project_** can hold multiple rendered data objects (**_Images_**, **_Labels_**, **_Points_**, **_Shapes_**).
 
-Each rendered data object can be shown on zero or more **_Layers_**, as configured by corresponding layer configurations.
+Each rendered data object can be shown on one or more **_Layers_**; a single item (e.g. point, shape) is never shown on more than one layer.
 
 Rendered data objects representing multi-item data (_Labels_, _Points_, _Shapes_) can link to **_Table_** columns for item configuration.
 
@@ -41,7 +41,7 @@ classDiagram
     Image : data source
     Image : visibility, opacity
     Image : data-to-layer transform
-    Image "0..*" --> "0..*" Layer : layer configurations
+    Image "0..*" --> "1..*" Layer
 
     class Labels
     Labels : id
@@ -50,7 +50,7 @@ classDiagram
     Labels : visibility, opacity
     Labels : data-to-layer transform
     Labels : label color/visibility/opacity
-    Labels "0..*" --> "0..*" Layer : layer configurations
+    Labels "0..*" --> "1..*" Layer
     Labels "0..*" ..> "1" Table
 
     class Points
@@ -60,7 +60,7 @@ classDiagram
     Points : visibility, opacity
     Points : data-to-layer transform
     Points : point marker/size/color/visibility/opacity
-    Points "0..*" --> "0..*" Layer : layer configurations
+    Points "0..*" --> "1..*" Layer
     Points "0..*" ..> "1" Table
 
     class Shapes
@@ -71,7 +71,7 @@ classDiagram
     Shapes : data-to-layer transform
     Shapes : shape fill color/visibility/opacity
     Shapes : shape stroke color/visibility/opacity
-    Shapes "0..*" --> "0..*" Layer : layer configurations
+    Shapes "0..*" --> "1..*" Layer
     Shapes "0..*" ..> "1" Table
 
     class Table

--- a/apps/docs/docs/concepts/data-model.md
+++ b/apps/docs/docs/concepts/data-model.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 A single **_Project_** can hold multiple rendered data objects (**_Images_**, **_Labels_**, **_Points_**, **_Shapes_**).
 
-Each rendered data object can be shown on one or more **_Layers_**; a single item (e.g. point, shape) is never shown on more than one layer.
+Each rendered data object is shown on a single **_Layer_**; multi-item data (e.g. points, shapes) can be distributed across multiple layers.
 
 Rendered data objects representing multi-item data (_Labels_, _Points_, _Shapes_) can link to **_Table_** columns for item configuration.
 

--- a/apps/docs/docs/concepts/data-model.md
+++ b/apps/docs/docs/concepts/data-model.md
@@ -41,7 +41,7 @@ classDiagram
     Image : data source
     Image : visibility, opacity
     Image : data-to-layer transform
-    Image "0..*" --> "1..*" Layer
+    Image "0..*" --> "1" Layer
 
     class Labels
     Labels : id
@@ -50,7 +50,7 @@ classDiagram
     Labels : visibility, opacity
     Labels : data-to-layer transform
     Labels : label color/visibility/opacity
-    Labels "0..*" --> "1..*" Layer
+    Labels "0..*" --> "1" Layer
     Labels "0..*" ..> "1" Table
 
     class Points
@@ -60,7 +60,7 @@ classDiagram
     Points : visibility, opacity
     Points : data-to-layer transform
     Points : point marker/size/color/visibility/opacity
-    Points "0..*" --> "1..*" Layer
+    Points "0..*" --> "0..*" Layer
     Points "0..*" ..> "1" Table
 
     class Shapes
@@ -71,7 +71,7 @@ classDiagram
     Shapes : data-to-layer transform
     Shapes : shape fill color/visibility/opacity
     Shapes : shape stroke color/visibility/opacity
-    Shapes "0..*" --> "1..*" Layer
+    Shapes "0..*" --> "0..*" Layer
     Shapes "0..*" ..> "1" Table
 
     class Table

--- a/apps/tissuumaps/src/components/panels/ImagesPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ImagesPanel/index.tsx
@@ -62,7 +62,7 @@ export function ImagesPanel({ className }: ImagesPanelProps) {
             id: crypto.randomUUID(),
             name,
             dataSource,
-            layerConfigs: layers.length > 0 ? [{ layer: layers[0]!.id }] : [],
+            layer: layers[0]!.id, // FIXME
           });
           addImage(image);
         }}

--- a/apps/tissuumaps/src/components/panels/LabelsPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/LabelsPanel/index.tsx
@@ -72,7 +72,7 @@ export function LabelsPanel({ className }: LabelsPanelProps) {
             id: crypto.randomUUID(),
             name,
             dataSource,
-            layerConfigs: layers.length > 0 ? [{ layer: layers[0]!.id }] : [],
+            layer: layers[0]!.id, // FIXME
           });
           addLabels(newLabels);
         }}

--- a/apps/tissuumaps/src/components/panels/PointsPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/PointsPanel/index.tsx
@@ -72,7 +72,7 @@ export function PointsPanel({ className }: PointsPanelProps) {
             id: crypto.randomUUID(),
             name,
             dataSource,
-            layerConfigs: layers.length > 0 ? [{ layer: layers[0]!.id }] : [],
+            layer: layers[0]!.id, // FIXME
           });
           addPoints(newPoints);
         }}

--- a/apps/tissuumaps/src/components/panels/ShapesPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ShapesPanel/index.tsx
@@ -72,7 +72,7 @@ export function ShapesPanel({ className }: ShapesPanelProps) {
             id: crypto.randomUUID(),
             name,
             dataSource,
-            layerConfigs: layers.length > 0 ? [{ layer: layers[0]!.id }] : [],
+            layer: layers[0]!.id, // FIXME
           });
           addShapes(newShapes);
         }}

--- a/apps/tissuumaps/src/components/panels/ViewerPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ViewerPanel/index.tsx
@@ -44,22 +44,22 @@ export function ViewerPanel({ className }: ViewerPanelProps) {
     })),
   );
 
-  const loadImage = useLoadedImageDataAdapter();
-  const loadLabels = useLoadedLabelsDataAdapter();
-  const loadPoints = useLoadedPointsDataAdapter();
-  const loadShapes = useLoadedShapesDataAdapter();
-  const loadTable = useLoadedTableDataAdapter();
+  const getImage = useLoadedImageDataAdapter();
+  const getLabels = useLoadedLabelsDataAdapter();
+  const getPoints = useLoadedPointsDataAdapter();
+  const getShapes = useLoadedShapesDataAdapter();
+  const getTable = useLoadedTableDataAdapter();
 
   const viewerAdapter = useMemo(
     () => ({
       ...viewerState,
-      loadImage,
-      loadLabels,
-      loadPoints,
-      loadShapes,
-      loadTable,
+      getImage,
+      getLabels,
+      getPoints,
+      getShapes,
+      getTable,
     }),
-    [viewerState, loadImage, loadLabels, loadPoints, loadShapes, loadTable],
+    [viewerState, getImage, getLabels, getPoints, getShapes, getTable],
   );
 
   return (

--- a/apps/tissuumaps/src/store/adapters/LoadedImageDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedImageDataAdapter.ts
@@ -37,7 +37,7 @@ export class LoadedImageDataAdapter implements ImageData {
   }
 }
 
-export function useLoadedImageDataAdapter(): ViewerAdapter["loadImage"] {
+export function useLoadedImageDataAdapter(): ViewerAdapter["getImage"] {
   const loadImage = useTissUUmaps((state) => state.loadImage);
   return useCallback(
     async (imageId, options) => {

--- a/apps/tissuumaps/src/store/adapters/LoadedLabelsDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedLabelsDataAdapter.ts
@@ -69,7 +69,7 @@ export class LoadedLabelsDataAdapter implements LabelsData {
   }
 }
 
-export function useLoadedLabelsDataAdapter(): ViewerAdapter["loadLabels"] {
+export function useLoadedLabelsDataAdapter(): ViewerAdapter["getLabels"] {
   const loadLabels = useTissUUmaps((state) => state.loadLabels);
   return useCallback(
     async (labelsId, options) => {

--- a/apps/tissuumaps/src/store/adapters/LoadedPointsDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedPointsDataAdapter.ts
@@ -54,7 +54,7 @@ export class LoadedPointsDataAdapter implements PointsData {
   }
 }
 
-export function useLoadedPointsDataAdapter(): ViewerAdapter["loadPoints"] {
+export function useLoadedPointsDataAdapter(): ViewerAdapter["getPoints"] {
   const loadPoints = useTissUUmaps((state) => state.loadPoints);
   return useCallback(
     async (pointsId, options) => {

--- a/apps/tissuumaps/src/store/adapters/LoadedShapesDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedShapesDataAdapter.ts
@@ -58,7 +58,7 @@ export class LoadedShapesDataAdapter implements ShapesData {
   }
 }
 
-export function useLoadedShapesDataAdapter(): ViewerAdapter["loadShapes"] {
+export function useLoadedShapesDataAdapter(): ViewerAdapter["getShapes"] {
   const loadShapes = useTissUUmaps((state) => state.loadShapes);
   return useCallback(
     async (shapesId, options) => {

--- a/apps/tissuumaps/src/store/adapters/LoadedTableDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedTableDataAdapter.ts
@@ -102,7 +102,7 @@ export class LoadedTableDataAdapter implements TableData {
   }
 }
 
-export function useLoadedTableDataAdapter(): ViewerAdapter["loadTable"] {
+export function useLoadedTableDataAdapter(): ViewerAdapter["getTable"] {
   const loadTable = useTissUUmaps((state) => state.loadTable);
   return useCallback(
     async (tableId, options) => {

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -2,8 +2,8 @@ import { mat3 } from "gl-matrix";
 import OpenSeadragon from "openseadragon";
 
 import { defaultViewerOptions } from "../model/constants";
-import { type Image, type ImageLayerConfig } from "../model/image";
-import { type Labels, type LabelsLayerConfig } from "../model/labels";
+import { type Image } from "../model/image";
+import { type Labels } from "../model/labels";
 import { type Layer } from "../model/layer";
 import { type ViewerOptions } from "../model/types";
 import { type ImageData } from "../storage/image";
@@ -224,8 +224,7 @@ export class OpenSeadragonController {
   }
 
   /**
-   * Loads image and labels data for every layer configuration that references
-   * one of the given layers, producing a flat list of {@link ObjectRef} entries
+   * Loads image and labels for every layer, producing a flat list of {@link ObjectRef} entries
    *
    * Objects that fail to load are logged and skipped.
    */
@@ -247,30 +246,25 @@ export class OpenSeadragonController {
     signal?.throwIfAborted();
     const refs: ObjectRef[] = [];
     for (const layer of layers) {
-      for (const image of images) {
-        for (let i = 0; i < image.layerConfigs.length; i++) {
-          const layerConfig = image.layerConfigs[i]!;
-          if (layerConfig.layer !== layer.id) {
-            continue;
-          }
+      for (const currentImage of images) {
+        if (currentImage.layer === layer.id) {
           let data;
           try {
-            data = await loadImage(image.id, { signal });
+            data = await loadImage(currentImage.id, { signal });
           } catch (error) {
-            console.error(`Failed to load image with ID '${image.id}'`, error);
+            console.error(
+              `Failed to load image with ID '${currentImage.id}'`,
+              error,
+            );
           }
           signal?.throwIfAborted();
           if (data !== undefined) {
-            refs.push({ layer, image, layerConfig, layerConfigIndex: i, data });
+            refs.push({ layer, image: currentImage, data });
           }
         }
       }
       for (const currentLabels of labels) {
-        for (let i = 0; i < currentLabels.layerConfigs.length; i++) {
-          const layerConfig = currentLabels.layerConfigs[i]!;
-          if (layerConfig.layer !== layer.id) {
-            continue;
-          }
+        if (currentLabels.layer === layer.id) {
           let data;
           try {
             data = await loadLabels(currentLabels.id, { signal });
@@ -282,13 +276,7 @@ export class OpenSeadragonController {
           }
           signal?.throwIfAborted();
           if (data !== undefined) {
-            refs.push({
-              layer,
-              labels: currentLabels,
-              layerConfig,
-              layerConfigIndex: i,
-              data,
-            });
+            refs.push({ layer, labels: currentLabels, data });
           }
         }
       }
@@ -320,8 +308,7 @@ export class OpenSeadragonController {
             ref.image.id === tiledImageState.ref.image.id) ||
             ("labels" in ref &&
               "labels" in tiledImageState.ref &&
-              ref.labels.id === tiledImageState.ref.labels.id)) &&
-          ref.layerConfigIndex === tiledImageState.ref.layerConfigIndex,
+              ref.labels.id === tiledImageState.ref.labels.id)),
       );
       if (ref !== undefined) {
         tiledImageStatesByRef.set(ref, tiledImageState);
@@ -364,8 +351,7 @@ export class OpenSeadragonController {
           ("labels" in ref &&
             "labels" in tiledImageState.ref &&
             ref.labels.id === tiledImageState.ref.labels.id)
-        ) ||
-        tiledImageState.ref.layerConfigIndex !== ref.layerConfigIndex
+        )
       ) {
         tiledImageState = this._createTiledImage(i, ref);
       } else {
@@ -412,7 +398,7 @@ export class OpenSeadragonController {
             })(),
       index: index,
       // https://github.com/openseadragon/openseadragon/issues/2765
-      // flipped: layerConfig.flip,
+      // flipped: image.flip / labels.flip,
       opacity: OpenSeadragonController._calculateOpacity(ref),
       success: (event) => {
         const { item: tiledImage } = event as unknown as {
@@ -569,21 +555,17 @@ export class OpenSeadragonController {
   }
 }
 
-/** Reference binding an image to a specific layer and layer configuration */
+/** Reference binding an image to a specific layer */
 type ImageRef = {
   layer: Layer;
   image: Image;
-  layerConfig: ImageLayerConfig;
-  layerConfigIndex: number;
   data: ImageData;
 };
 
-/** Reference binding a labels object to a specific layer and layer configuration */
+/** Reference binding a labels object to a specific layer */
 type LabelsRef = {
   layer: Layer;
   labels: Labels;
-  layerConfig: LabelsLayerConfig;
-  layerConfigIndex: number;
   data: LabelsData;
 };
 

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -251,11 +251,14 @@ export class OpenSeadragonController {
         let data;
         try {
           data = await loadImage(currentImage.id, { signal });
+          signal?.throwIfAborted();
         } catch (error) {
-          console.error(
-            `Failed to load image with ID '${currentImage.id}'`,
-            error,
-          );
+          if (!signal?.aborted) {
+            console.error(
+              `Failed to load image with ID '${currentImage.id}'`,
+              error,
+            );
+          }
           continue;
         } finally {
           signal?.throwIfAborted();
@@ -267,11 +270,14 @@ export class OpenSeadragonController {
         let data;
         try {
           data = await loadLabels(currentLabels.id, { signal });
+          signal?.throwIfAborted();
         } catch (error) {
-          console.error(
-            `Failed to load labels with ID '${currentLabels.id}'`,
-            error,
-          );
+          if (!signal?.aborted) {
+            console.error(
+              `Failed to load labels with ID '${currentLabels.id}'`,
+              error,
+            );
+          }
           continue;
         }
         signal?.throwIfAborted();

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -180,19 +180,19 @@ export class OpenSeadragonController {
    * @param layers - Layers to render
    * @param images - Image data objects to display
    * @param labels - Labels data objects to display
-   * @param loadImage - Async loader for image data
-   * @param loadLabels - Async loader for labels data
+   * @param getImage - Async getter for image data
+   * @param getLabels - Async getter for labels data
    * @param options - Optional abort signal
    */
   async synchronize(
     layers: Layer[],
     images: Image[],
     labels: Labels[],
-    loadImage: (
+    getImage: (
       imageId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<ImageData>,
-    loadLabels: (
+    getLabels: (
       labelsId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<LabelsData>,
@@ -204,8 +204,8 @@ export class OpenSeadragonController {
       layers,
       images,
       labels,
-      loadImage,
-      loadLabels,
+      getImage,
+      getLabels,
       { signal },
     );
     signal?.throwIfAborted();
@@ -232,11 +232,11 @@ export class OpenSeadragonController {
     layers: Layer[],
     images: Image[],
     labels: Labels[],
-    loadImage: (
+    getImage: (
       imageId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<ImageData>,
-    loadLabels: (
+    getLabels: (
       labelsId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<LabelsData>,
@@ -247,11 +247,9 @@ export class OpenSeadragonController {
     const refs: ObjectRef[] = [];
     for (const layer of layers) {
       for (const currentImage of images.filter((x) => x.layer === layer.id)) {
-        // images can only be shown on one layer, so we don't need to cache them here
         let data;
         try {
-          data = await loadImage(currentImage.id, { signal });
-          signal?.throwIfAborted();
+          data = await getImage(currentImage.id, { signal });
         } catch (error) {
           if (!signal?.aborted) {
             console.error(
@@ -263,14 +261,12 @@ export class OpenSeadragonController {
         } finally {
           signal?.throwIfAborted();
         }
-        refs.push({ layer, image: currentImage, data });
+        refs.push({ layer, image: currentImage, data: data });
       }
       for (const currentLabels of labels.filter((x) => x.layer === layer.id)) {
-        // labels can only be shown on one layer, so we don't need to cache them here
         let data;
         try {
-          data = await loadLabels(currentLabels.id, { signal });
-          signal?.throwIfAborted();
+          data = await getLabels(currentLabels.id, { signal });
         } catch (error) {
           if (!signal?.aborted) {
             console.error(
@@ -282,7 +278,7 @@ export class OpenSeadragonController {
         } finally {
           signal?.throwIfAborted();
         }
-        refs.push({ layer, labels: currentLabels, data });
+        refs.push({ layer, labels: currentLabels, data: data });
       }
     }
     return refs;

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -279,8 +279,9 @@ export class OpenSeadragonController {
             );
           }
           continue;
+        } finally {
+          signal?.throwIfAborted();
         }
-        signal?.throwIfAborted();
         refs.push({ layer, labels: currentLabels, data });
       }
     }

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -246,39 +246,36 @@ export class OpenSeadragonController {
     signal?.throwIfAborted();
     const refs: ObjectRef[] = [];
     for (const layer of layers) {
-      for (const currentImage of images) {
-        if (currentImage.layer === layer.id) {
-          let data;
-          try {
-            data = await loadImage(currentImage.id, { signal });
-          } catch (error) {
-            console.error(
-              `Failed to load image with ID '${currentImage.id}'`,
-              error,
-            );
-          }
+      for (const currentImage of images.filter((x) => x.layer === layer.id)) {
+        // images can only be shown on one layer, so we don't need to cache them here
+        let data;
+        try {
+          data = await loadImage(currentImage.id, { signal });
+        } catch (error) {
+          console.error(
+            `Failed to load image with ID '${currentImage.id}'`,
+            error,
+          );
+          continue;
+        } finally {
           signal?.throwIfAborted();
-          if (data !== undefined) {
-            refs.push({ layer, image: currentImage, data });
-          }
         }
+        refs.push({ layer, image: currentImage, data });
       }
-      for (const currentLabels of labels) {
-        if (currentLabels.layer === layer.id) {
-          let data;
-          try {
-            data = await loadLabels(currentLabels.id, { signal });
-          } catch (error) {
-            console.error(
-              `Failed to load labels with ID '${currentLabels.id}'`,
-              error,
-            );
-          }
-          signal?.throwIfAborted();
-          if (data !== undefined) {
-            refs.push({ layer, labels: currentLabels, data });
-          }
+      for (const currentLabels of labels.filter((x) => x.layer === layer.id)) {
+        // labels can only be shown on one layer, so we don't need to cache them here
+        let data;
+        try {
+          data = await loadLabels(currentLabels.id, { signal });
+        } catch (error) {
+          console.error(
+            `Failed to load labels with ID '${currentLabels.id}'`,
+            error,
+          );
+          continue;
         }
+        signal?.throwIfAborted();
+        refs.push({ layer, labels: currentLabels, data });
       }
     }
     return refs;

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -1,3 +1,4 @@
+import { deepEqual } from "fast-equals";
 import { mat3 } from "gl-matrix";
 import OpenSeadragon from "openseadragon";
 
@@ -305,10 +306,18 @@ export class OpenSeadragonController {
           ref.layer.id === tiledImageState.ref.layer.id &&
           (("image" in ref &&
             "image" in tiledImageState.ref &&
-            ref.image.id === tiledImageState.ref.image.id) ||
+            ref.image.id === tiledImageState.ref.image.id &&
+            deepEqual(
+              ref.image.dataSource,
+              tiledImageState.ref.image.dataSource,
+            )) ||
             ("labels" in ref &&
               "labels" in tiledImageState.ref &&
-              ref.labels.id === tiledImageState.ref.labels.id)),
+              ref.labels.id === tiledImageState.ref.labels.id &&
+              deepEqual(
+                ref.labels.dataSource,
+                tiledImageState.ref.labels.dataSource,
+              ))),
       );
       if (ref !== undefined) {
         tiledImageStatesByRef.set(ref, tiledImageState);
@@ -347,10 +356,18 @@ export class OpenSeadragonController {
         !(
           ("image" in ref &&
             "image" in tiledImageState.ref &&
-            ref.image.id === tiledImageState.ref.image.id) ||
+            tiledImageState.ref.image.id === ref.image.id &&
+            deepEqual(
+              tiledImageState.ref.image.dataSource,
+              ref.image.dataSource,
+            )) ||
           ("labels" in ref &&
             "labels" in tiledImageState.ref &&
-            ref.labels.id === tiledImageState.ref.labels.id)
+            tiledImageState.ref.labels.id === ref.labels.id &&
+            deepEqual(
+              tiledImageState.ref.labels.dataSource,
+              ref.labels.dataSource,
+            ))
         )
       ) {
         tiledImageState = this._createTiledImage(i, ref);

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -663,6 +663,7 @@ export class WebGLPointsController extends WebGLControllerBase {
       // marker
       if (
         bufferSliceChanged ||
+        bufferSliceState === undefined ||
         !deepEqual(
           bufferSliceState.config.points.pointMarker,
           ref.points.pointMarker,
@@ -688,6 +689,7 @@ export class WebGLPointsController extends WebGLControllerBase {
       // size
       if (
         bufferSliceChanged ||
+        bufferSliceState === undefined ||
         bufferSliceState.config.layer.pointSizeFactor !==
           ref.layer.pointSizeFactor ||
         bufferSliceState.config.layer.transform.scale !==
@@ -750,6 +752,7 @@ export class WebGLPointsController extends WebGLControllerBase {
       // color, visibility, opacity
       if (
         bufferSliceChanged ||
+        bufferSliceState === undefined ||
         bufferSliceState.config.layer.visibility !== ref.layer.visibility ||
         bufferSliceState.config.layer.opacity !== ref.layer.opacity ||
         bufferSliceState.config.points.visibility !== ref.points.visibility ||

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -18,7 +18,7 @@ import {
   defaultPointVisibility,
 } from "../model/constants";
 import { type Layer } from "../model/layer";
-import { type Points, type PointsLayerConfig } from "../model/points";
+import { type Points } from "../model/points";
 import {
   type Color,
   type CoordinateSpace,
@@ -267,7 +267,9 @@ export class WebGLPointsController extends WebGLControllerBase {
   ): Promise<void> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    const refs = await this._loadPoints(layers, points, loadPoints, { signal });
+    const refs = await this._loadPoints(layers, points, loadPoints, loadTable, {
+      signal,
+    });
     signal?.throwIfAborted();
     if (refs.length > WebGLPointsController._maxNumObjects) {
       console.warn(
@@ -276,7 +278,7 @@ export class WebGLPointsController extends WebGLControllerBase {
       refs.length = WebGLPointsController._maxNumObjects;
     }
     let buffersResized = false;
-    const n = refs.reduce((accum, ref) => accum + ref.data.getSize(), 0);
+    const n = refs.reduce((accum, ref) => accum + ref.numPoints, 0);
     if (this._currentBufferSize !== n) {
       this._resizePointBuffers(n);
       buffersResized = true;
@@ -466,7 +468,7 @@ export class WebGLPointsController extends WebGLControllerBase {
   }
 
   /**
-   * Loads points data for every layer configuration matching the given layers
+   * Loads points for every layer
    *
    * Objects that fail to load are logged and skipped.
    *
@@ -479,6 +481,10 @@ export class WebGLPointsController extends WebGLControllerBase {
       pointsId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<PointsData>,
+    loadTable: (
+      tableId: string,
+      options?: { signal?: AbortSignal },
+    ) => Promise<TableData>,
     options?: { signal?: AbortSignal },
   ): Promise<PointsRef[]> {
     const { signal } = options ?? {};
@@ -486,11 +492,10 @@ export class WebGLPointsController extends WebGLControllerBase {
     const refs: PointsRef[] = [];
     for (const layer of layers) {
       for (const currentPoints of points) {
-        for (let i = 0; i < currentPoints.layerConfigs.length; i++) {
-          const layerConfig = currentPoints.layerConfigs[i]!;
-          if (layerConfig.layer !== layer.id) {
-            continue;
-          }
+        if (
+          currentPoints.layer === layer.id ||
+          typeof currentPoints.layer !== "string"
+        ) {
           let data;
           try {
             data = await loadPoints(currentPoints.id, { signal });
@@ -503,14 +508,41 @@ export class WebGLPointsController extends WebGLControllerBase {
             }
           }
           signal?.throwIfAborted();
-          if (data !== undefined && data.getSize() > 0) {
-            refs.push({
-              layer,
-              points: currentPoints,
-              layerConfig,
-              layerConfigIndex: i,
-              data,
-            });
+          if (data !== undefined) {
+            let numPoints = data.getSize();
+            let pointMask: boolean[] | undefined;
+            if (numPoints > 0 && typeof currentPoints.layer !== "string") {
+              const tableData = await loadTable(currentPoints.layer.table, {
+                signal,
+              });
+              signal?.throwIfAborted();
+              const tableIds = tableData.getIds();
+              signal?.throwIfAborted();
+              const tableLayers = await tableData.loadValues<string>(
+                currentPoints.layer.column,
+                { signal },
+              );
+              signal?.throwIfAborted();
+              const pointLayers = new Map(
+                tableIds.map((id, i) => [id, tableLayers[i]!]),
+              );
+              pointMask = data
+                .getIds()
+                .map((pointId) => pointLayers.get(pointId) === layer.id);
+              numPoints = pointMask.reduce(
+                (accum, include) => accum + (include ? 1 : 0),
+                0,
+              );
+            }
+            if (numPoints > 0) {
+              refs.push({
+                layer,
+                points: currentPoints,
+                pointMask,
+                numPoints,
+                data,
+              });
+            }
           }
         }
       }
@@ -550,7 +582,7 @@ export class WebGLPointsController extends WebGLControllerBase {
     const newBufferSliceStates: PointsBufferSliceState[] = [];
     for (let i = 0; i < refs.length; i++) {
       const ref = refs[i]!;
-      const numPoints = ref.data.getSize();
+      const { pointMask, numPoints } = ref;
       const bufferSliceState = this._bufferSliceStates[i];
       const bufferSliceChanged =
         buffersResized ||
@@ -559,13 +591,20 @@ export class WebGLPointsController extends WebGLControllerBase {
         bufferSliceState.offset !== offset ||
         bufferSliceState.ref.layer.id !== ref.layer.id ||
         bufferSliceState.ref.points.id !== ref.points.id ||
-        bufferSliceState.ref.layerConfigIndex !== ref.layerConfigIndex ||
         bufferSliceState.ref.data !== ref.data;
+      let pointIds = ref.data.getIds();
+      if (pointMask !== undefined) {
+        pointIds = pointIds.filter((_, j) => pointMask[j]);
+      }
       let dataBounds = bufferSliceState?.dataBounds;
       // x/y
       if (bufferSliceChanged || dataBounds === undefined) {
-        const [xData, yData] = await ref.data.loadCoordinates({ signal });
+        let [xData, yData] = await ref.data.loadCoordinates({ signal });
         signal?.throwIfAborted();
+        if (pointMask !== undefined) {
+          xData = xData.filter((_, j) => pointMask[j]);
+          yData = yData.filter((_, j) => pointMask[j]);
+        }
         dataBounds = WebGLPointsController._getDataBounds(xData, yData);
         WebGLUtils.loadBuffer(
           this.gl,
@@ -591,7 +630,7 @@ export class WebGLPointsController extends WebGLControllerBase {
         )
       ) {
         const markerData = await MarkerDataUtils.loadMarkerData(
-          ref.data.getIds(),
+          pointIds,
           ref.points.pointMarker,
           markerMaps,
           defaultPointMarker,
@@ -653,7 +692,7 @@ export class WebGLPointsController extends WebGLControllerBase {
           sizeFactor *= ref.layer.transform.scale;
         }
         const sizeData = await SizeDataUtils.loadSizeData(
-          ref.data.getIds(),
+          pointIds,
           ref.points.pointSize,
           sizeMaps,
           defaultPointSize,
@@ -699,7 +738,7 @@ export class WebGLPointsController extends WebGLControllerBase {
           colorData = new Uint32Array(numPoints).fill(0);
         } else {
           const visibilityData = await VisibilityDataUtils.loadVisibilityData(
-            ref.data.getIds(),
+            pointIds,
             ref.points.pointVisibility,
             visibilityMaps,
             defaultPointVisibility,
@@ -708,7 +747,7 @@ export class WebGLPointsController extends WebGLControllerBase {
           );
           signal?.throwIfAborted();
           const opacityData = await OpacityDataUtils.loadOpacityData(
-            ref.data.getIds(),
+            pointIds,
             ref.points.pointOpacity,
             opacityMaps,
             defaultPointOpacity,
@@ -717,7 +756,7 @@ export class WebGLPointsController extends WebGLControllerBase {
           );
           signal?.throwIfAborted();
           colorData = await ColorDataUtils.loadColorData(
-            ref.data.getIds(),
+            pointIds,
             ref.points.pointColor,
             colorMaps,
             defaultPointColor,
@@ -819,12 +858,12 @@ export class WebGLPointsController extends WebGLControllerBase {
   }
 }
 
-/** Binding of a points data object to a specific layer and layer configuration */
+/** Binding of a points data object to a specific layer */
 type PointsRef = {
   layer: Layer;
   points: Points;
-  layerConfig: PointsLayerConfig;
-  layerConfigIndex: number;
+  pointMask: boolean[] | undefined;
+  numPoints: number;
   data: PointsData;
 };
 

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -490,61 +490,69 @@ export class WebGLPointsController extends WebGLControllerBase {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
     const refs: PointsRef[] = [];
+    const dataCache = new Map<string, PointsData>();
+    const pointLayersCache = new Map<
+      string,
+      Map<number, string | undefined> | undefined
+    >();
     for (const layer of layers) {
-      for (const currentPoints of points) {
-        if (
-          currentPoints.layer === layer.id ||
-          typeof currentPoints.layer !== "string"
-        ) {
-          let data;
+      for (const currentPoints of points.filter(
+        (x) => x.layer === layer.id || typeof x.layer !== "string",
+      )) {
+        let data = dataCache.get(currentPoints.id);
+        if (data === undefined) {
           try {
             data = await loadPoints(currentPoints.id, { signal });
           } catch (error) {
-            if (!signal?.aborted) {
-              console.error(
-                `Failed to load points with ID '${currentPoints.id}'`,
-                error,
-              );
-            }
+            console.error(
+              `Failed to load points with ID '${currentPoints.id}'`,
+              error,
+            );
+            continue;
+          } finally {
+            signal?.throwIfAborted();
           }
-          signal?.throwIfAborted();
-          if (data !== undefined) {
-            let numPoints = data.getSize();
-            let pointMask: boolean[] | undefined;
-            if (numPoints > 0 && typeof currentPoints.layer !== "string") {
-              const tableData = await loadTable(currentPoints.layer.table, {
-                signal,
-              });
-              signal?.throwIfAborted();
-              const tableIds = tableData.getIds();
-              signal?.throwIfAborted();
-              const tableLayers = await tableData.loadValues<string>(
-                currentPoints.layer.column,
-                { signal },
-              );
-              signal?.throwIfAborted();
-              const pointLayers = new Map(
-                tableIds.map((id, i) => [id, tableLayers[i]!]),
-              );
-              pointMask = data
-                .getIds()
-                .map((pointId) => pointLayers.get(pointId) === layer.id);
-              numPoints = pointMask.reduce(
-                (accum, include) => accum + (include ? 1 : 0),
-                0,
-              );
-            }
-            if (numPoints > 0) {
-              refs.push({
-                layer,
-                points: currentPoints,
-                pointMask,
-                numPoints,
-                data,
-              });
-            }
-          }
+          dataCache.set(currentPoints.id, data);
         }
+        let numPoints = data.getSize();
+        if (numPoints === 0) {
+          continue;
+        }
+        let pointLayers = pointLayersCache.get(currentPoints.id);
+        if (
+          pointLayers === undefined &&
+          !pointLayersCache.has(currentPoints.id) &&
+          typeof currentPoints.layer !== "string"
+        ) {
+          const tableData = await loadTable(currentPoints.layer.table, {
+            signal,
+          });
+          signal?.throwIfAborted();
+          const tableIds = tableData.getIds();
+          signal?.throwIfAborted();
+          const tableLayers = await tableData.loadValues<string>(
+            currentPoints.layer.column,
+            { signal },
+          );
+          signal?.throwIfAborted();
+          pointLayers = new Map(tableIds.map((id, i) => [id, tableLayers[i]]));
+          pointLayersCache.set(currentPoints.id, pointLayers);
+        }
+        let pointMask: boolean[] | undefined;
+        if (numPoints > 0 && pointLayers !== undefined) {
+          pointMask = data.getIds().map((x) => pointLayers.get(x) === layer.id);
+          numPoints = pointMask.reduce((accum, x) => accum + (x ? 1 : 0), 0);
+        }
+        if (numPoints === 0) {
+          continue;
+        }
+        refs.push({
+          layer,
+          points: currentPoints,
+          pointMask,
+          numPoints,
+          data,
+        });
       }
     }
     return refs;

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -613,6 +613,7 @@ export class WebGLPointsController extends WebGLControllerBase {
         bufferSliceState.offset !== offset ||
         bufferSliceState.ref.layer.id !== ref.layer.id ||
         bufferSliceState.ref.points.id !== ref.points.id ||
+        bufferSliceState.ref.numPoints !== ref.numPoints ||
         bufferSliceState.ref.data !== ref.data;
       let pointIds = ref.data.getIds();
       if (pointMask !== undefined) {

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -495,9 +495,12 @@ export class WebGLPointsController extends WebGLControllerBase {
       string,
       Map<number, string | undefined> | undefined
     >();
+    const failedPoints = new Set<string>();
     for (const layer of layers) {
       for (const currentPoints of points.filter(
-        (x) => x.layer === layer.id || typeof x.layer !== "string",
+        (points) =>
+          !failedPoints.has(points.id) &&
+          (points.layer === layer.id || typeof points.layer !== "string"),
       )) {
         let data = dataCache.get(currentPoints.id);
         if (data === undefined) {
@@ -511,6 +514,7 @@ export class WebGLPointsController extends WebGLControllerBase {
                 error,
               );
             }
+            failedPoints.add(currentPoints.id);
             continue;
           } finally {
             signal?.throwIfAborted();
@@ -527,29 +531,31 @@ export class WebGLPointsController extends WebGLControllerBase {
           !pointLayersCache.has(currentPoints.id) &&
           typeof currentPoints.layer !== "string"
         ) {
-          let tableIds, tableLayers;
           try {
             const tableData = await loadTable(currentPoints.layer.table, {
               signal,
             });
             signal?.throwIfAborted();
-            tableIds = tableData.getIds();
+            const tableIds = tableData.getIds();
             signal?.throwIfAborted();
-            tableLayers = await tableData.loadValues<string>(
+            const tableLayers = await tableData.loadValues<string>(
               currentPoints.layer.column,
               { signal },
             );
             signal?.throwIfAborted();
+            pointLayers = new Map(
+              tableIds.map((id, i) => [id, tableLayers[i]]),
+            );
           } catch (error) {
             console.error(
               `Failed to load point layers for points with ID '${currentPoints.id}'`,
               error,
             );
+            failedPoints.add(currentPoints.id);
             continue;
           } finally {
             signal?.throwIfAborted();
           }
-          pointLayers = new Map(tableIds.map((id, i) => [id, tableLayers[i]]));
           pointLayersCache.set(currentPoints.id, pointLayers);
         }
         let pointMask: boolean[] | undefined;

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -492,7 +492,7 @@ export class WebGLPointsController extends WebGLControllerBase {
     const refs: PointsRef[] = [];
     const dataCache = new Map<string, PointsData>();
     const pointLayersCache = new Map<
-      string,
+      string, // JSON-serialized layer config
       Map<number, string | undefined> | undefined
     >();
     const failedPoints = new Set<string>();
@@ -502,8 +502,10 @@ export class WebGLPointsController extends WebGLControllerBase {
           !failedPoints.has(points.id) &&
           (points.layer === layer.id || typeof points.layer !== "string"),
       )) {
-        let data = dataCache.get(currentPoints.id);
-        if (data === undefined) {
+        let data: PointsData | undefined;
+        if (dataCache.has(currentPoints.id)) {
+          data = dataCache.get(currentPoints.id)!;
+        } else {
           try {
             data = await loadPoints(currentPoints.id, { signal });
             signal?.throwIfAborted();
@@ -521,58 +523,63 @@ export class WebGLPointsController extends WebGLControllerBase {
           }
           dataCache.set(currentPoints.id, data);
         }
+
         let numPoints = data.getSize();
         if (numPoints === 0) {
           continue;
         }
-        let pointLayers = pointLayersCache.get(currentPoints.id);
-        if (
-          pointLayers === undefined &&
-          !pointLayersCache.has(currentPoints.id) &&
-          typeof currentPoints.layer !== "string"
-        ) {
-          try {
-            const tableData = await loadTable(currentPoints.layer.table, {
-              signal,
-            });
-            signal?.throwIfAborted();
-            const tableIds = tableData.getIds();
-            signal?.throwIfAborted();
-            const tableLayers = await tableData.loadValues<string>(
-              currentPoints.layer.column,
-              { signal },
-            );
-            signal?.throwIfAborted();
-            pointLayers = new Map(
-              tableIds.map((id, i) => [id, tableLayers[i]]),
-            );
-          } catch (error) {
-            if (!signal?.aborted) {
-              console.error(
-                `Failed to load point layers for points with ID '${currentPoints.id}'`,
-                error,
+
+        let pointLayers: Map<number, string | undefined> | undefined;
+        if (typeof currentPoints.layer !== "string") {
+          const pointLayersCacheKey = JSON.stringify(currentPoints.layer);
+          if (pointLayersCache.has(pointLayersCacheKey)) {
+            pointLayers = pointLayersCache.get(pointLayersCacheKey);
+          } else {
+            try {
+              const tableData = await loadTable(currentPoints.layer.table, {
+                signal,
+              });
+              signal?.throwIfAborted();
+              const tableIds = tableData.getIds();
+              signal?.throwIfAborted();
+              const tableLayers = await tableData.loadValues<string>(
+                currentPoints.layer.column,
+                { signal },
               );
+              signal?.throwIfAborted();
+              pointLayers = new Map(
+                tableIds.map((id, i) => [id, tableLayers[i]]),
+              );
+            } catch (error) {
+              if (!signal?.aborted) {
+                console.error(
+                  `Failed to load point layers for points with ID '${currentPoints.id}'`,
+                  error,
+                );
+              }
+              failedPoints.add(currentPoints.id);
+              continue;
+            } finally {
+              signal?.throwIfAborted();
             }
-            failedPoints.add(currentPoints.id);
-            continue;
-          } finally {
-            signal?.throwIfAborted();
+            pointLayersCache.set(pointLayersCacheKey, pointLayers);
           }
-          pointLayersCache.set(currentPoints.id, pointLayers);
         }
-        let pointMask: boolean[] | undefined;
-        if (numPoints > 0 && pointLayers !== undefined) {
-          pointMask = data.getIds().map((x) => pointLayers.get(x) === layer.id);
-          numPoints = pointMask.reduce((accum, x) => accum + (x ? 1 : 0), 0);
+
+        if (pointLayers !== undefined) {
+          numPoints = data
+            .getIds()
+            .filter((id) => pointLayers.get(id) === layer.id).length;
+          if (numPoints === 0) {
+            continue;
+          }
         }
-        if (numPoints === 0) {
-          continue;
-        }
+
         refs.push({
           layer,
           points: currentPoints,
-          pointMask,
           numPoints,
+          pointLayers,
           data,
         });
       }
@@ -612,22 +619,26 @@ export class WebGLPointsController extends WebGLControllerBase {
     const newBufferSliceStates: PointsBufferSliceState[] = [];
     for (let i = 0; i < refs.length; i++) {
       const ref = refs[i]!;
-      const { pointMask, numPoints } = ref;
+      const pointIds = ref.data.getIds();
+      const pointMask =
+        ref.pointLayers !== undefined
+          ? pointIds.map((id) => ref.pointLayers!.get(id) === ref.layer.id)
+          : undefined;
+      const filteredPointIds =
+        pointMask !== undefined
+          ? pointIds.filter((_, j) => pointMask[j])
+          : pointIds;
       const bufferSliceState = this._bufferSliceStates[i];
       const bufferSliceChanged =
         buffersResized ||
         bufferSliceState === undefined ||
         bufferSliceState.offset !== offset ||
-        bufferSliceState.numPoints !== numPoints ||
+        bufferSliceState.numPoints !== ref.numPoints ||
+        bufferSliceState.pointLayers !== ref.pointLayers ||
         bufferSliceState.ref.layer.id !== ref.layer.id ||
         bufferSliceState.ref.points.id !== ref.points.id ||
         bufferSliceState.ref.numPoints !== ref.numPoints ||
-        bufferSliceState.ref.data !== ref.data ||
-        !deepEqual(bufferSliceState.pointMask, pointMask); // check this last, to reduce complexity
-      let pointIds = ref.data.getIds();
-      if (pointMask !== undefined) {
-        pointIds = pointIds.filter((_, j) => pointMask[j]);
-      }
+        bufferSliceState.ref.data !== ref.data;
       let dataBounds = bufferSliceState?.dataBounds;
       // x/y
       if (bufferSliceChanged || dataBounds === undefined) {
@@ -662,7 +673,7 @@ export class WebGLPointsController extends WebGLControllerBase {
         )
       ) {
         const markerData = await MarkerDataUtils.loadMarkerData(
-          pointIds,
+          filteredPointIds,
           ref.points.pointMarker,
           markerMaps,
           defaultPointMarker,
@@ -724,7 +735,7 @@ export class WebGLPointsController extends WebGLControllerBase {
           sizeFactor *= ref.layer.transform.scale;
         }
         const sizeData = await SizeDataUtils.loadSizeData(
-          pointIds,
+          filteredPointIds,
           ref.points.pointSize,
           sizeMaps,
           defaultPointSize,
@@ -767,10 +778,10 @@ export class WebGLPointsController extends WebGLControllerBase {
           ref.points.visibility === false ||
           ref.points.opacity === 0
         ) {
-          colorData = new Uint32Array(numPoints).fill(0);
+          colorData = new Uint32Array(ref.numPoints).fill(0);
         } else {
           const visibilityData = await VisibilityDataUtils.loadVisibilityData(
-            pointIds,
+            filteredPointIds,
             ref.points.pointVisibility,
             visibilityMaps,
             defaultPointVisibility,
@@ -779,7 +790,7 @@ export class WebGLPointsController extends WebGLControllerBase {
           );
           signal?.throwIfAborted();
           const opacityData = await OpacityDataUtils.loadOpacityData(
-            pointIds,
+            filteredPointIds,
             ref.points.pointOpacity,
             opacityMaps,
             defaultPointOpacity,
@@ -788,7 +799,7 @@ export class WebGLPointsController extends WebGLControllerBase {
           );
           signal?.throwIfAborted();
           colorData = await ColorDataUtils.loadColorData(
-            pointIds,
+            filteredPointIds,
             ref.points.pointColor,
             colorMaps,
             defaultPointColor,
@@ -810,15 +821,15 @@ export class WebGLPointsController extends WebGLControllerBase {
           this.gl,
           this.gl.ARRAY_BUFFER,
           this._buffers.object,
-          new Uint16Array(numPoints).fill(i),
+          new Uint16Array(ref.numPoints).fill(i),
           { offset },
         );
       }
       newBufferSliceStates.push({
         ref,
         offset,
-        pointMask,
-        numPoints,
+        numPoints: ref.numPoints,
+        pointLayers: ref.pointLayers,
         dataBounds,
         current: {
           layer: {
@@ -846,7 +857,7 @@ export class WebGLPointsController extends WebGLControllerBase {
         ),
         i * 8,
       );
-      offset += numPoints;
+      offset += ref.numPoints;
     }
     WebGLUtils.loadBuffer(
       this.gl,
@@ -895,8 +906,8 @@ export class WebGLPointsController extends WebGLControllerBase {
 type PointsRef = {
   layer: Layer;
   points: Points;
-  pointMask: boolean[] | undefined;
   numPoints: number;
+  pointLayers: Map<number, string | undefined> | undefined;
   data: PointsData;
 };
 
@@ -912,10 +923,10 @@ type PointsBufferSliceState = {
   ref: PointsRef;
   /** Element offset (point count) within each shared vertex buffer */
   offset: number;
-  /** Mask indicating which points belong to the current buffer slice */
-  pointMask: boolean[] | undefined;
   /** Number of points in this slice */
   numPoints: number;
+  /** Map of point IDs to their corresponding layer IDs */
+  pointLayers: Map<number, string | undefined> | undefined;
   /** Axis-aligned bounding box of all points in data-space coordinates */
   dataBounds: Rect;
   /** Snapshot of model values at the time of the last buffer upload */

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -617,8 +617,9 @@ export class WebGLPointsController extends WebGLControllerBase {
       const bufferSliceChanged =
         buffersResized ||
         bufferSliceState === undefined ||
-        bufferSliceState.numPoints !== numPoints ||
         bufferSliceState.offset !== offset ||
+        bufferSliceState.pointMask !== pointMask ||
+        bufferSliceState.numPoints !== numPoints ||
         bufferSliceState.ref.layer.id !== ref.layer.id ||
         bufferSliceState.ref.points.id !== ref.points.id ||
         bufferSliceState.ref.numPoints !== ref.numPoints ||
@@ -816,6 +817,7 @@ export class WebGLPointsController extends WebGLControllerBase {
       newBufferSliceStates.push({
         ref,
         offset,
+        pointMask,
         numPoints,
         dataBounds,
         current: {
@@ -910,6 +912,8 @@ type PointsBufferSliceState = {
   ref: PointsRef;
   /** Element offset (point count) within each shared vertex buffer */
   offset: number;
+  /** Mask indicating which points belong to the current buffer slice */
+  pointMask: boolean[] | undefined;
   /** Number of points in this slice */
   numPoints: number;
   /** Axis-aligned bounding box of all points in data-space coordinates */

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -835,8 +835,8 @@ export class WebGLPointsController extends WebGLControllerBase {
           layer: {
             visibility: ref.layer.visibility,
             opacity: ref.layer.opacity,
-            transform: structuredClone(ref.layer.transform),
             pointSizeFactor: ref.layer.pointSizeFactor,
+            transform: structuredClone(ref.layer.transform),
           },
           points: {
             layer: structuredClone(ref.points.layer),
@@ -847,8 +847,8 @@ export class WebGLPointsController extends WebGLControllerBase {
             pointColor: structuredClone(ref.points.pointColor),
             pointVisibility: structuredClone(ref.points.pointVisibility),
             pointOpacity: structuredClone(ref.points.pointOpacity),
-            transform: structuredClone(ref.points.transform),
             pointSizeFactor: ref.points.pointSizeFactor,
+            transform: structuredClone(ref.points.transform),
           },
         },
         dataBounds,
@@ -928,7 +928,7 @@ type PointsBufferSliceState = {
   config: {
     layer: Pick<
       Layer,
-      "visibility" | "opacity" | "transform" | "pointSizeFactor"
+      "visibility" | "opacity" | "pointSizeFactor" | "transform"
     >;
     points: Pick<
       Points,
@@ -940,8 +940,8 @@ type PointsBufferSliceState = {
       | "pointColor"
       | "pointVisibility"
       | "pointOpacity"
-      | "transform"
       | "pointSizeFactor"
+      | "transform"
     >;
   };
   dataBounds: Rect;

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -631,7 +631,11 @@ export class WebGLPointsController extends WebGLControllerBase {
         bufferSliceState.ref.points.id !== ref.points.id ||
         bufferSliceState.ref.numPoints !== ref.numPoints ||
         // check config.points.layer instead of ref.pointLayers
-        !deepEqual(bufferSliceState.config.points.layer, ref.points.layer);
+        !deepEqual(bufferSliceState.config.points.layer, ref.points.layer) ||
+        !deepEqual(
+          bufferSliceState.ref.points.dataSource,
+          ref.points.dataSource,
+        );
       let dataBounds =
         bufferSliceState !== undefined && !bufferSliceChanged
           ? bufferSliceState.dataBounds

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -547,10 +547,12 @@ export class WebGLPointsController extends WebGLControllerBase {
               tableIds.map((id, i) => [id, tableLayers[i]]),
             );
           } catch (error) {
-            console.error(
-              `Failed to load point layers for points with ID '${currentPoints.id}'`,
-              error,
-            );
+            if (!signal?.aborted) {
+              console.error(
+                `Failed to load point layers for points with ID '${currentPoints.id}'`,
+                error,
+              );
+            }
             failedPoints.add(currentPoints.id);
             continue;
           } finally {

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -618,12 +618,12 @@ export class WebGLPointsController extends WebGLControllerBase {
         buffersResized ||
         bufferSliceState === undefined ||
         bufferSliceState.offset !== offset ||
-        bufferSliceState.pointMask !== pointMask ||
         bufferSliceState.numPoints !== numPoints ||
         bufferSliceState.ref.layer.id !== ref.layer.id ||
         bufferSliceState.ref.points.id !== ref.points.id ||
         bufferSliceState.ref.numPoints !== ref.numPoints ||
-        bufferSliceState.ref.data !== ref.data;
+        bufferSliceState.ref.data !== ref.data ||
+        !deepEqual(bufferSliceState.pointMask, pointMask); // check this last, to reduce complexity
       let pointIds = ref.data.getIds();
       if (pointMask !== undefined) {
         pointIds = pointIds.filter((_, j) => pointMask[j]);

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -916,7 +916,7 @@ type PointsRef = {
  * Tracks the current GPU buffer state for a single points object's
  * slice within the shared vertex buffers
  *
- * Used for incremental updates: by comparing `current` against the new
+ * Used for incremental updates: by comparing `config` against the new
  * model values, only changed attributes are re-uploaded to the GPU.
  */
 type PointsBufferSliceState = {

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -493,28 +493,32 @@ export class WebGLPointsController extends WebGLControllerBase {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
     const refs: PointsRef[] = [];
-    const failedPoints = new Set<string>();
+    const dataCache = new Map<string, PointsData | undefined>();
     const pointLayersCache = new Map<string, Map<number, string> | undefined>();
     for (const layer of layers) {
       for (const currentPoints of points.filter(
-        (points) =>
-          !failedPoints.has(points.id) &&
-          (points.layer === layer.id || typeof points.layer !== "string"),
+        (x) => x.layer === layer.id || typeof x.layer !== "string",
       )) {
         let data;
-        try {
-          data = await getPoints(currentPoints.id, { signal });
-        } catch (error) {
-          if (!signal?.aborted) {
-            console.error(
-              `Failed to load points with ID '${currentPoints.id}'`,
-              error,
-            );
+        if (dataCache.has(currentPoints.id)) {
+          data = dataCache.get(currentPoints.id);
+        } else {
+          try {
+            data = await getPoints(currentPoints.id, { signal });
+          } catch (error) {
+            if (!signal?.aborted) {
+              console.error(
+                `Failed to load points with ID '${currentPoints.id}'`,
+                error,
+              );
+            }
+          } finally {
+            signal?.throwIfAborted();
           }
-          failedPoints.add(currentPoints.id);
+          dataCache.set(currentPoints.id, data);
+        }
+        if (data === undefined) {
           continue;
-        } finally {
-          signal?.throwIfAborted();
         }
 
         let numPoints = data.getSize();

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -503,11 +503,14 @@ export class WebGLPointsController extends WebGLControllerBase {
         if (data === undefined) {
           try {
             data = await loadPoints(currentPoints.id, { signal });
+            signal?.throwIfAborted();
           } catch (error) {
-            console.error(
-              `Failed to load points with ID '${currentPoints.id}'`,
-              error,
-            );
+            if (!signal?.aborted) {
+              console.error(
+                `Failed to load points with ID '${currentPoints.id}'`,
+                error,
+              );
+            }
             continue;
           } finally {
             signal?.throwIfAborted();
@@ -524,17 +527,28 @@ export class WebGLPointsController extends WebGLControllerBase {
           !pointLayersCache.has(currentPoints.id) &&
           typeof currentPoints.layer !== "string"
         ) {
-          const tableData = await loadTable(currentPoints.layer.table, {
-            signal,
-          });
-          signal?.throwIfAborted();
-          const tableIds = tableData.getIds();
-          signal?.throwIfAborted();
-          const tableLayers = await tableData.loadValues<string>(
-            currentPoints.layer.column,
-            { signal },
-          );
-          signal?.throwIfAborted();
+          let tableIds, tableLayers;
+          try {
+            const tableData = await loadTable(currentPoints.layer.table, {
+              signal,
+            });
+            signal?.throwIfAborted();
+            tableIds = tableData.getIds();
+            signal?.throwIfAborted();
+            tableLayers = await tableData.loadValues<string>(
+              currentPoints.layer.column,
+              { signal },
+            );
+            signal?.throwIfAborted();
+          } catch (error) {
+            console.error(
+              `Failed to load point layers for points with ID '${currentPoints.id}'`,
+              error,
+            );
+            continue;
+          } finally {
+            signal?.throwIfAborted();
+          }
           pointLayers = new Map(tableIds.map((id, i) => [id, tableLayers[i]]));
           pointLayersCache.set(currentPoints.id, pointLayers);
         }

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -243,8 +243,8 @@ export class WebGLPointsController extends WebGLControllerBase {
    * @param colorMaps - Project-global color maps
    * @param visibilityMaps - Project-global visibility maps
    * @param opacityMaps - Project-global opacity maps
-   * @param loadPoints - Async loader for points data
-   * @param loadTable - Async loader for table data
+   * @param getPoints - Async getter for points data
+   * @param getTable - Async getter for table data
    * @param options - Optional abort signal
    */
   async synchronize(
@@ -255,11 +255,11 @@ export class WebGLPointsController extends WebGLControllerBase {
     colorMaps: DefaultMap<Color>[],
     visibilityMaps: DefaultMap<boolean>[],
     opacityMaps: DefaultMap<number>[],
-    loadPoints: (
+    getPoints: (
       pointsId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<PointsData>,
-    loadTable: (
+    getTable: (
       tableId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<TableData>,
@@ -267,7 +267,8 @@ export class WebGLPointsController extends WebGLControllerBase {
   ): Promise<void> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    const refs = await this._loadPoints(layers, points, loadPoints, loadTable, {
+
+    const refs = await this._loadPoints(layers, points, getPoints, getTable, {
       signal,
     });
     signal?.throwIfAborted();
@@ -277,12 +278,14 @@ export class WebGLPointsController extends WebGLControllerBase {
       );
       refs.length = WebGLPointsController._maxNumObjects;
     }
+
     let buffersResized = false;
     const n = refs.reduce((accum, ref) => accum + ref.numPoints, 0);
     if (this._currentBufferSize !== n) {
       this._resizePointBuffers(n);
       buffersResized = true;
     }
+
     this._bufferSliceStates = await this._loadPointBuffers(
       refs,
       markerMaps,
@@ -291,7 +294,7 @@ export class WebGLPointsController extends WebGLControllerBase {
       visibilityMaps,
       opacityMaps,
       buffersResized,
-      loadTable,
+      getTable,
       { signal },
     );
     signal?.throwIfAborted();
@@ -477,11 +480,11 @@ export class WebGLPointsController extends WebGLControllerBase {
   private async _loadPoints(
     layers: Layer[],
     points: Points[],
-    loadPoints: (
+    getPoints: (
       pointsId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<PointsData>,
-    loadTable: (
+    getTable: (
       tableId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<TableData>,
@@ -490,38 +493,28 @@ export class WebGLPointsController extends WebGLControllerBase {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
     const refs: PointsRef[] = [];
-    const dataCache = new Map<string, PointsData>();
-    const pointLayersCache = new Map<
-      string, // JSON-serialized layer config
-      Map<number, string | undefined> | undefined
-    >();
     const failedPoints = new Set<string>();
+    const pointLayersCache = new Map<string, Map<number, string> | undefined>();
     for (const layer of layers) {
       for (const currentPoints of points.filter(
         (points) =>
           !failedPoints.has(points.id) &&
           (points.layer === layer.id || typeof points.layer !== "string"),
       )) {
-        let data: PointsData | undefined;
-        if (dataCache.has(currentPoints.id)) {
-          data = dataCache.get(currentPoints.id)!;
-        } else {
-          try {
-            data = await loadPoints(currentPoints.id, { signal });
-            signal?.throwIfAborted();
-          } catch (error) {
-            if (!signal?.aborted) {
-              console.error(
-                `Failed to load points with ID '${currentPoints.id}'`,
-                error,
-              );
-            }
-            failedPoints.add(currentPoints.id);
-            continue;
-          } finally {
-            signal?.throwIfAborted();
+        let data;
+        try {
+          data = await getPoints(currentPoints.id, { signal });
+        } catch (error) {
+          if (!signal?.aborted) {
+            console.error(
+              `Failed to load points with ID '${currentPoints.id}'`,
+              error,
+            );
           }
-          dataCache.set(currentPoints.id, data);
+          failedPoints.add(currentPoints.id);
+          continue;
+        } finally {
+          signal?.throwIfAborted();
         }
 
         let numPoints = data.getSize();
@@ -529,14 +522,14 @@ export class WebGLPointsController extends WebGLControllerBase {
           continue;
         }
 
-        let pointLayers: Map<number, string | undefined> | undefined;
+        let pointLayers: Map<number, string> | undefined;
         if (typeof currentPoints.layer !== "string") {
-          const pointLayersCacheKey = JSON.stringify(currentPoints.layer);
+          const pointLayersCacheKey = `${currentPoints.layer.table}:${currentPoints.layer.column}`;
           if (pointLayersCache.has(pointLayersCacheKey)) {
             pointLayers = pointLayersCache.get(pointLayersCacheKey);
           } else {
             try {
-              const tableData = await loadTable(currentPoints.layer.table, {
+              const tableData = await getTable(currentPoints.layer.table, {
                 signal,
               });
               signal?.throwIfAborted();
@@ -548,21 +541,22 @@ export class WebGLPointsController extends WebGLControllerBase {
               );
               signal?.throwIfAborted();
               pointLayers = new Map(
-                tableIds.map((id, i) => [id, tableLayers[i]]),
+                tableIds.map((id, i) => [id, tableLayers[i]!]),
               );
             } catch (error) {
               if (!signal?.aborted) {
                 console.error(
-                  `Failed to load point layers for points with ID '${currentPoints.id}'`,
+                  `Failed to load layers from table ${currentPoints.layer.table}`,
                   error,
                 );
               }
-              failedPoints.add(currentPoints.id);
-              continue;
             } finally {
               signal?.throwIfAborted();
             }
             pointLayersCache.set(pointLayersCacheKey, pointLayers);
+          }
+          if (pointLayers === undefined) {
+            continue;
           }
         }
 
@@ -576,11 +570,11 @@ export class WebGLPointsController extends WebGLControllerBase {
         }
 
         refs.push({
+          data,
           layer,
           points: currentPoints,
           numPoints,
           pointLayers,
-          data,
         });
       }
     }
@@ -633,13 +627,15 @@ export class WebGLPointsController extends WebGLControllerBase {
         buffersResized ||
         bufferSliceState === undefined ||
         bufferSliceState.offset !== offset ||
-        bufferSliceState.numPoints !== ref.numPoints ||
-        bufferSliceState.pointLayers !== ref.pointLayers ||
         bufferSliceState.ref.layer.id !== ref.layer.id ||
         bufferSliceState.ref.points.id !== ref.points.id ||
         bufferSliceState.ref.numPoints !== ref.numPoints ||
-        bufferSliceState.ref.data !== ref.data;
-      let dataBounds = bufferSliceState?.dataBounds;
+        // check config.points.layer instead of ref.pointLayers
+        !deepEqual(bufferSliceState.config.points.layer, ref.points.layer);
+      let dataBounds =
+        bufferSliceState !== undefined && !bufferSliceChanged
+          ? bufferSliceState.dataBounds
+          : undefined;
       // x/y
       if (bufferSliceChanged || dataBounds === undefined) {
         let [xData, yData] = await ref.data.loadCoordinates({ signal });
@@ -668,7 +664,7 @@ export class WebGLPointsController extends WebGLControllerBase {
       if (
         bufferSliceChanged ||
         !deepEqual(
-          bufferSliceState.current.points.pointMarker,
+          bufferSliceState.config.points.pointMarker,
           ref.points.pointMarker,
         )
       ) {
@@ -692,16 +688,16 @@ export class WebGLPointsController extends WebGLControllerBase {
       // size
       if (
         bufferSliceChanged ||
-        bufferSliceState.current.layer.pointSizeFactor !==
+        bufferSliceState.config.layer.pointSizeFactor !==
           ref.layer.pointSizeFactor ||
-        bufferSliceState.current.points.pointSizeFactor !==
-          ref.points.pointSizeFactor ||
-        bufferSliceState.current.layer.transform.scale !==
+        bufferSliceState.config.layer.transform.scale !==
           ref.layer.transform.scale ||
-        bufferSliceState.current.points.transform.scale !==
+        bufferSliceState.config.points.pointSizeFactor !==
+          ref.points.pointSizeFactor ||
+        bufferSliceState.config.points.transform.scale !==
           ref.points.transform.scale ||
         !deepEqual(
-          bufferSliceState.current.points.pointSize,
+          bufferSliceState.config.points.pointSize,
           ref.points.pointSize,
         )
       ) {
@@ -754,20 +750,20 @@ export class WebGLPointsController extends WebGLControllerBase {
       // color, visibility, opacity
       if (
         bufferSliceChanged ||
-        bufferSliceState.current.layer.visibility !== ref.layer.visibility ||
-        bufferSliceState.current.layer.opacity !== ref.layer.opacity ||
-        bufferSliceState.current.points.visibility !== ref.points.visibility ||
-        bufferSliceState.current.points.opacity !== ref.points.opacity ||
+        bufferSliceState.config.layer.visibility !== ref.layer.visibility ||
+        bufferSliceState.config.layer.opacity !== ref.layer.opacity ||
+        bufferSliceState.config.points.visibility !== ref.points.visibility ||
+        bufferSliceState.config.points.opacity !== ref.points.opacity ||
         !deepEqual(
-          bufferSliceState.current.points.pointVisibility,
+          bufferSliceState.config.points.pointVisibility,
           ref.points.pointVisibility,
         ) ||
         !deepEqual(
-          bufferSliceState.current.points.pointOpacity,
+          bufferSliceState.config.points.pointOpacity,
           ref.points.pointOpacity,
         ) ||
         !deepEqual(
-          bufferSliceState.current.points.pointColor,
+          bufferSliceState.config.points.pointColor,
           ref.points.pointColor,
         )
       ) {
@@ -826,19 +822,17 @@ export class WebGLPointsController extends WebGLControllerBase {
         );
       }
       newBufferSliceStates.push({
-        ref,
         offset,
-        numPoints: ref.numPoints,
-        pointLayers: ref.pointLayers,
-        dataBounds,
-        current: {
+        ref,
+        config: {
           layer: {
             visibility: ref.layer.visibility,
             opacity: ref.layer.opacity,
-            pointSizeFactor: ref.layer.pointSizeFactor,
             transform: structuredClone(ref.layer.transform),
+            pointSizeFactor: ref.layer.pointSizeFactor,
           },
           points: {
+            layer: structuredClone(ref.points.layer),
             visibility: ref.points.visibility,
             opacity: ref.points.opacity,
             pointMarker: structuredClone(ref.points.pointMarker),
@@ -846,10 +840,11 @@ export class WebGLPointsController extends WebGLControllerBase {
             pointColor: structuredClone(ref.points.pointColor),
             pointVisibility: structuredClone(ref.points.pointVisibility),
             pointOpacity: structuredClone(ref.points.pointOpacity),
-            pointSizeFactor: ref.points.pointSizeFactor,
             transform: structuredClone(ref.points.transform),
+            pointSizeFactor: ref.points.pointSizeFactor,
           },
         },
+        dataBounds,
       });
       objectsUBOData.set(
         TransformUtils.transposeAsGLMat2x4(
@@ -902,13 +897,12 @@ export class WebGLPointsController extends WebGLControllerBase {
   }
 }
 
-/** Binding of a points data object to a specific layer */
 type PointsRef = {
+  data: PointsData;
   layer: Layer;
   points: Points;
   numPoints: number;
-  pointLayers: Map<number, string | undefined> | undefined;
-  data: PointsData;
+  pointLayers: Map<number, string> | undefined;
 };
 
 /**
@@ -919,24 +913,19 @@ type PointsRef = {
  * model values, only changed attributes are re-uploaded to the GPU.
  */
 type PointsBufferSliceState = {
-  /** Reference to the points object this slice represents */
-  ref: PointsRef;
   /** Element offset (point count) within each shared vertex buffer */
   offset: number;
-  /** Number of points in this slice */
-  numPoints: number;
-  /** Map of point IDs to their corresponding layer IDs */
-  pointLayers: Map<number, string | undefined> | undefined;
-  /** Axis-aligned bounding box of all points in data-space coordinates */
-  dataBounds: Rect;
+  /** Reference to the points object this slice represents */
+  ref: PointsRef;
   /** Snapshot of model values at the time of the last buffer upload */
-  current: {
+  config: {
     layer: Pick<
       Layer,
-      "visibility" | "opacity" | "pointSizeFactor" | "transform"
+      "visibility" | "opacity" | "transform" | "pointSizeFactor"
     >;
     points: Pick<
       Points,
+      | "layer"
       | "visibility"
       | "opacity"
       | "pointMarker"
@@ -944,8 +933,9 @@ type PointsBufferSliceState = {
       | "pointColor"
       | "pointVisibility"
       | "pointOpacity"
-      | "pointSizeFactor"
       | "transform"
+      | "pointSizeFactor"
     >;
   };
+  dataBounds: Rect;
 };

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -326,7 +326,7 @@ export class WebGLShapesController extends WebGLControllerBase {
     const refs: ShapesRef[] = [];
     const dataCache = new Map<string, ShapesData>();
     const shapeLayersCache = new Map<
-      string,
+      string, // JSON-serialized layer config
       Map<number, string | undefined> | undefined
     >();
     const failedShapes = new Set<string>();
@@ -336,8 +336,10 @@ export class WebGLShapesController extends WebGLControllerBase {
           !failedShapes.has(shapes.id) &&
           (shapes.layer === layer.id || typeof shapes.layer !== "string"),
       )) {
-        let data = dataCache.get(currentShapes.id);
-        if (data === undefined) {
+        let data: ShapesData | undefined;
+        if (dataCache.has(currentShapes.id)) {
+          data = dataCache.get(currentShapes.id)!;
+        } else {
           try {
             data = await loadShapes(currentShapes.id, { signal });
             signal?.throwIfAborted();
@@ -355,58 +357,63 @@ export class WebGLShapesController extends WebGLControllerBase {
           }
           dataCache.set(currentShapes.id, data);
         }
+
         let numShapes = data.getSize();
         if (numShapes === 0) {
           continue;
         }
-        let shapeLayers = shapeLayersCache.get(currentShapes.id);
-        if (
-          shapeLayers === undefined &&
-          !shapeLayersCache.has(currentShapes.id) &&
-          typeof currentShapes.layer !== "string"
-        ) {
-          try {
-            const tableData = await loadTable(currentShapes.layer.table, {
-              signal,
-            });
-            signal?.throwIfAborted();
-            const tableIds = tableData.getIds();
-            signal?.throwIfAborted();
-            const tableLayers = await tableData.loadValues<string>(
-              currentShapes.layer.column,
-              { signal },
-            );
-            signal?.throwIfAborted();
-            shapeLayers = new Map(
-              tableIds.map((id, i) => [id, tableLayers[i]]),
-            );
-          } catch (error) {
-            if (!signal?.aborted) {
-              console.error(
-                `Failed to load shape layers for shapes with ID '${currentShapes.id}'`,
-                error,
+
+        let shapeLayers: Map<number, string | undefined> | undefined;
+        if (typeof currentShapes.layer !== "string") {
+          const shapeLayersCacheKey = JSON.stringify(currentShapes.layer);
+          if (shapeLayersCache.has(shapeLayersCacheKey)) {
+            shapeLayers = shapeLayersCache.get(shapeLayersCacheKey);
+          } else {
+            try {
+              const tableData = await loadTable(currentShapes.layer.table, {
+                signal,
+              });
+              signal?.throwIfAborted();
+              const tableIds = tableData.getIds();
+              signal?.throwIfAborted();
+              const tableLayers = await tableData.loadValues<string>(
+                currentShapes.layer.column,
+                { signal },
               );
+              signal?.throwIfAborted();
+              shapeLayers = new Map(
+                tableIds.map((id, i) => [id, tableLayers[i]]),
+              );
+            } catch (error) {
+              if (!signal?.aborted) {
+                console.error(
+                  `Failed to load shape layers for shapes with ID '${currentShapes.id}'`,
+                  error,
+                );
+              }
+              failedShapes.add(currentShapes.id);
+              continue;
+            } finally {
+              signal?.throwIfAborted();
             }
-            failedShapes.add(currentShapes.id);
-            continue;
-          } finally {
-            signal?.throwIfAborted();
+            shapeLayersCache.set(shapeLayersCacheKey, shapeLayers);
           }
-          shapeLayersCache.set(currentShapes.id, shapeLayers);
         }
-        let shapeMask: boolean[] | undefined;
-        if (numShapes > 0 && shapeLayers !== undefined) {
-          shapeMask = data.getIds().map((x) => shapeLayers.get(x) === layer.id);
-          numShapes = shapeMask.reduce((accum, x) => accum + (x ? 1 : 0), 0);
+
+        if (shapeLayers !== undefined) {
+          numShapes = data
+            .getIds()
+            .filter((id) => shapeLayers.get(id) === layer.id).length;
+          if (numShapes === 0) {
+            continue;
+          }
         }
-        if (numShapes === 0) {
-          continue;
-        }
+
         refs.push({
           layer,
           shapes: currentShapes,
-          shapeMask,
           numShapes,
+          shapeLayers,
           data,
         });
       }
@@ -469,20 +476,24 @@ export class WebGLShapesController extends WebGLControllerBase {
     signal?.throwIfAborted();
     const newGLShapes = [];
     for (const ref of refs) {
-      const { shapeMask, numShapes } = ref;
       const glShapes = glShapesByRef.get(ref);
-      let shapeIds = ref.data.getIds();
-      if (shapeMask !== undefined) {
-        shapeIds = shapeIds.filter((_, j) => shapeMask[j]);
-      }
+      const shapeIds = ref.data.getIds();
+      const shapeMask =
+        ref.shapeLayers !== undefined
+          ? shapeIds.map((id) => ref.shapeLayers!.get(id) === ref.layer.id)
+          : undefined;
+      const filteredShapeIds =
+        shapeMask !== undefined
+          ? shapeIds.filter((_, j) => shapeMask[j])
+          : shapeIds;
       let dataBounds = glShapes?.dataBounds;
       let scanlineDataTexture = glShapes?.scanlineDataTexture;
       if (
         glShapes === undefined ||
+        glShapes.numShapes !== ref.numShapes ||
+        glShapes.shapeLayers !== ref.shapeLayers ||
         dataBounds === undefined ||
-        scanlineDataTexture === undefined ||
-        glShapes.numShapes !== numShapes ||
-        !deepEqual(glShapes.shapeMask, shapeMask) // check this last, to reduce complexity
+        scanlineDataTexture === undefined
       ) {
         let multiPolygons = await ref.data.loadMultiPolygons({ signal });
         signal?.throwIfAborted();
@@ -499,6 +510,8 @@ export class WebGLShapesController extends WebGLControllerBase {
       let shapeFillColorsTexture = glShapes?.shapeFillColorsTexture;
       if (
         glShapes === undefined ||
+        glShapes.numShapes !== ref.numShapes ||
+        glShapes.shapeLayers !== ref.shapeLayers ||
         shapeFillColorsTexture === undefined ||
         glShapes.current.layer.visibility !== ref.layer.visibility ||
         glShapes.current.layer.opacity !== ref.layer.opacity ||
@@ -519,7 +532,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       ) {
         shapeFillColorsTexture = await this._createShapeFillColorsTexture(
           ref,
-          shapeIds,
+          filteredShapeIds,
           colorMaps,
           visibilityMaps,
           opacityMaps,
@@ -531,6 +544,8 @@ export class WebGLShapesController extends WebGLControllerBase {
       let shapeStrokeColorsTexture = glShapes?.shapeStrokeColorsTexture;
       if (
         glShapes === undefined ||
+        glShapes.numShapes !== ref.numShapes ||
+        glShapes.shapeLayers !== ref.shapeLayers ||
         shapeStrokeColorsTexture === undefined ||
         glShapes.current.layer.visibility !== ref.layer.visibility ||
         glShapes.current.layer.opacity !== ref.layer.opacity ||
@@ -551,7 +566,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       ) {
         shapeStrokeColorsTexture = await this._createShapeStrokeColorsTexture(
           ref,
-          shapeIds,
+          filteredShapeIds,
           colorMaps,
           visibilityMaps,
           opacityMaps,
@@ -562,8 +577,8 @@ export class WebGLShapesController extends WebGLControllerBase {
       }
       newGLShapes.push({
         ref,
-        shapeMask,
-        numShapes,
+        numShapes: ref.numShapes,
+        shapeLayers: ref.shapeLayers,
         dataBounds,
         scanlineDataTexture,
         shapeFillColorsTexture,
@@ -1048,8 +1063,8 @@ export class WebGLShapesController extends WebGLControllerBase {
 type ShapesRef = {
   layer: Layer;
   shapes: Shapes;
-  shapeMask: boolean[] | undefined;
   numShapes: number;
+  shapeLayers: Map<number, string | undefined> | undefined;
   data: ShapesData;
 };
 
@@ -1063,10 +1078,10 @@ type ShapesRef = {
 type GLShapes = {
   /** Reference to the shapes object this GPU state represents */
   ref: ShapesRef;
-  /** Mask indicating which shapes belong to the current texture */
-  shapeMask: boolean[] | undefined;
   /** Number of shapes in the object at the time the textures were built */
   numShapes: number;
+  /** Map of shape IDs to their corresponding layer IDs */
+  shapeLayers: Map<number, string | undefined> | undefined;
   /** Axis-aligned bounding box of all shapes in data-space coordinates */
   dataBounds: Rect;
   /** Scanline data texture (RGBA32F); `undefined` while being regenerated */

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -149,8 +149,8 @@ export class WebGLShapesController extends WebGLControllerBase {
    * @param colorMaps - Project-global color maps for {@link GroupByConfig} resolution
    * @param visibilityMaps - Project-global visibility maps
    * @param opacityMaps - Project-global opacity maps
-   * @param loadShapes - Async loader for shapes data
-   * @param loadTable - Async loader for table data
+   * @param getShapes - Async getter for shapes data
+   * @param getTable - Async getter for table data
    * @param options - Optional abort signal
    */
   async synchronize(
@@ -159,11 +159,11 @@ export class WebGLShapesController extends WebGLControllerBase {
     colorMaps: DefaultMap<Color>[],
     visibilityMaps: DefaultMap<boolean>[],
     opacityMaps: DefaultMap<number>[],
-    loadShapes: (
+    getShapes: (
       shapesId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<ShapesData>,
-    loadTable: (
+    getTable: (
       tableId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<TableData>,
@@ -171,18 +171,21 @@ export class WebGLShapesController extends WebGLControllerBase {
   ): Promise<void> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    const refs = await this._loadShapes(layers, shapes, loadShapes, loadTable, {
+
+    const refs = await this._loadShapes(layers, shapes, getShapes, getTable, {
       signal,
     });
     signal?.throwIfAborted();
+
     const glShapesByRef = this._cleanGLShapes(refs);
+
     this._glShapes = await this._createOrUpdateGLShapes(
       refs,
       glShapesByRef,
       colorMaps,
       visibilityMaps,
       opacityMaps,
-      loadTable,
+      getTable,
       { signal },
     );
     signal?.throwIfAborted();
@@ -311,11 +314,11 @@ export class WebGLShapesController extends WebGLControllerBase {
   private async _loadShapes(
     layers: Layer[],
     shapes: Shapes[],
-    loadShapes: (
+    getShapes: (
       shapesId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<ShapesData>,
-    loadTable: (
+    getTable: (
       tableId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<TableData>,
@@ -324,38 +327,28 @@ export class WebGLShapesController extends WebGLControllerBase {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
     const refs: ShapesRef[] = [];
-    const dataCache = new Map<string, ShapesData>();
-    const shapeLayersCache = new Map<
-      string, // JSON-serialized layer config
-      Map<number, string | undefined> | undefined
-    >();
     const failedShapes = new Set<string>();
+    const shapeLayersCache = new Map<string, Map<number, string> | undefined>();
     for (const layer of layers) {
       for (const currentShapes of shapes.filter(
         (shapes) =>
           !failedShapes.has(shapes.id) &&
           (shapes.layer === layer.id || typeof shapes.layer !== "string"),
       )) {
-        let data: ShapesData | undefined;
-        if (dataCache.has(currentShapes.id)) {
-          data = dataCache.get(currentShapes.id)!;
-        } else {
-          try {
-            data = await loadShapes(currentShapes.id, { signal });
-            signal?.throwIfAborted();
-          } catch (error) {
-            if (!signal?.aborted) {
-              console.error(
-                `Failed to load shapes with ID '${currentShapes.id}'`,
-                error,
-              );
-            }
-            failedShapes.add(currentShapes.id);
-            continue;
-          } finally {
-            signal?.throwIfAborted();
+        let data;
+        try {
+          data = await getShapes(currentShapes.id, { signal });
+        } catch (error) {
+          if (!signal?.aborted) {
+            console.error(
+              `Failed to load shapes with ID '${currentShapes.id}'`,
+              error,
+            );
           }
-          dataCache.set(currentShapes.id, data);
+          failedShapes.add(currentShapes.id);
+          continue;
+        } finally {
+          signal?.throwIfAborted();
         }
 
         let numShapes = data.getSize();
@@ -363,14 +356,14 @@ export class WebGLShapesController extends WebGLControllerBase {
           continue;
         }
 
-        let shapeLayers: Map<number, string | undefined> | undefined;
+        let shapeLayers: Map<number, string> | undefined;
         if (typeof currentShapes.layer !== "string") {
-          const shapeLayersCacheKey = JSON.stringify(currentShapes.layer);
+          const shapeLayersCacheKey = `${currentShapes.layer.table}:${currentShapes.layer.column}`;
           if (shapeLayersCache.has(shapeLayersCacheKey)) {
             shapeLayers = shapeLayersCache.get(shapeLayersCacheKey);
           } else {
             try {
-              const tableData = await loadTable(currentShapes.layer.table, {
+              const tableData = await getTable(currentShapes.layer.table, {
                 signal,
               });
               signal?.throwIfAborted();
@@ -382,21 +375,22 @@ export class WebGLShapesController extends WebGLControllerBase {
               );
               signal?.throwIfAborted();
               shapeLayers = new Map(
-                tableIds.map((id, i) => [id, tableLayers[i]]),
+                tableIds.map((id, i) => [id, tableLayers[i]!]),
               );
             } catch (error) {
               if (!signal?.aborted) {
                 console.error(
-                  `Failed to load shape layers for shapes with ID '${currentShapes.id}'`,
+                  `Failed to load layers from table ${currentShapes.layer.table}`,
                   error,
                 );
               }
-              failedShapes.add(currentShapes.id);
-              continue;
             } finally {
               signal?.throwIfAborted();
             }
             shapeLayersCache.set(shapeLayersCacheKey, shapeLayers);
+          }
+          if (shapeLayers === undefined) {
+            continue;
           }
         }
 
@@ -410,11 +404,11 @@ export class WebGLShapesController extends WebGLControllerBase {
         }
 
         refs.push({
+          data,
           layer,
           shapes: currentShapes,
           numShapes,
           shapeLayers,
-          data,
         });
       }
     }
@@ -437,7 +431,10 @@ export class WebGLShapesController extends WebGLControllerBase {
       const ref = refs.find(
         (ref) =>
           ref.layer.id === glShapes.ref.layer.id &&
-          ref.shapes.id === glShapes.ref.shapes.id,
+          ref.shapes.id === glShapes.ref.shapes.id &&
+          ref.numShapes === glShapes.ref.numShapes &&
+          // check config.shapes.layer instead of ref.shapeLayers
+          deepEqual(ref.shapes.layer, glShapes.config.shapes.layer),
       );
       if (ref !== undefined) {
         glShapesByRef.set(ref, glShapes);
@@ -490,10 +487,10 @@ export class WebGLShapesController extends WebGLControllerBase {
       let scanlineDataTexture = glShapes?.scanlineDataTexture;
       if (
         glShapes === undefined ||
-        glShapes.numShapes !== ref.numShapes ||
-        glShapes.shapeLayers !== ref.shapeLayers ||
         dataBounds === undefined ||
-        scanlineDataTexture === undefined
+        scanlineDataTexture === undefined ||
+        glShapes.config.layer.transform !== ref.layer.transform ||
+        glShapes.config.shapes.transform !== ref.shapes.transform
       ) {
         let multiPolygons = await ref.data.loadMultiPolygons({ signal });
         signal?.throwIfAborted();
@@ -510,23 +507,21 @@ export class WebGLShapesController extends WebGLControllerBase {
       let shapeFillColorsTexture = glShapes?.shapeFillColorsTexture;
       if (
         glShapes === undefined ||
-        glShapes.numShapes !== ref.numShapes ||
-        glShapes.shapeLayers !== ref.shapeLayers ||
         shapeFillColorsTexture === undefined ||
-        glShapes.current.layer.visibility !== ref.layer.visibility ||
-        glShapes.current.layer.opacity !== ref.layer.opacity ||
-        glShapes.current.shapes.visibility !== ref.shapes.visibility ||
-        glShapes.current.shapes.opacity !== ref.shapes.opacity ||
+        glShapes.config.layer.visibility !== ref.layer.visibility ||
+        glShapes.config.layer.opacity !== ref.layer.opacity ||
+        glShapes.config.shapes.visibility !== ref.shapes.visibility ||
+        glShapes.config.shapes.opacity !== ref.shapes.opacity ||
         !deepEqual(
-          glShapes.current.shapes.shapeFillVisibility,
+          glShapes.config.shapes.shapeFillVisibility,
           ref.shapes.shapeFillVisibility,
         ) ||
         !deepEqual(
-          glShapes.current.shapes.shapeFillOpacity,
+          glShapes.config.shapes.shapeFillOpacity,
           ref.shapes.shapeFillOpacity,
         ) ||
         !deepEqual(
-          glShapes.current.shapes.shapeFillColor,
+          glShapes.config.shapes.shapeFillColor,
           ref.shapes.shapeFillColor,
         )
       ) {
@@ -544,23 +539,21 @@ export class WebGLShapesController extends WebGLControllerBase {
       let shapeStrokeColorsTexture = glShapes?.shapeStrokeColorsTexture;
       if (
         glShapes === undefined ||
-        glShapes.numShapes !== ref.numShapes ||
-        glShapes.shapeLayers !== ref.shapeLayers ||
         shapeStrokeColorsTexture === undefined ||
-        glShapes.current.layer.visibility !== ref.layer.visibility ||
-        glShapes.current.layer.opacity !== ref.layer.opacity ||
-        glShapes.current.shapes.visibility !== ref.shapes.visibility ||
-        glShapes.current.shapes.opacity !== ref.shapes.opacity ||
+        glShapes.config.layer.visibility !== ref.layer.visibility ||
+        glShapes.config.layer.opacity !== ref.layer.opacity ||
+        glShapes.config.shapes.visibility !== ref.shapes.visibility ||
+        glShapes.config.shapes.opacity !== ref.shapes.opacity ||
         !deepEqual(
-          glShapes.current.shapes.shapeStrokeVisibility,
+          glShapes.config.shapes.shapeStrokeVisibility,
           ref.shapes.shapeStrokeVisibility,
         ) ||
         !deepEqual(
-          glShapes.current.shapes.shapeStrokeOpacity,
+          glShapes.config.shapes.shapeStrokeOpacity,
           ref.shapes.shapeStrokeOpacity,
         ) ||
         !deepEqual(
-          glShapes.current.shapes.shapeStrokeColor,
+          glShapes.config.shapes.shapeStrokeColor,
           ref.shapes.shapeStrokeColor,
         )
       ) {
@@ -577,18 +570,14 @@ export class WebGLShapesController extends WebGLControllerBase {
       }
       newGLShapes.push({
         ref,
-        numShapes: ref.numShapes,
-        shapeLayers: ref.shapeLayers,
-        dataBounds,
-        scanlineDataTexture,
-        shapeFillColorsTexture,
-        shapeStrokeColorsTexture,
-        current: {
+        config: {
           layer: {
             visibility: ref.layer.visibility,
             opacity: ref.layer.opacity,
+            transform: structuredClone(ref.layer.transform),
           },
           shapes: {
+            layer: structuredClone(ref.shapes.layer),
             visibility: ref.shapes.visibility,
             opacity: ref.shapes.opacity,
             shapeFillColor: structuredClone(ref.shapes.shapeFillColor),
@@ -601,8 +590,13 @@ export class WebGLShapesController extends WebGLControllerBase {
               ref.shapes.shapeStrokeVisibility,
             ),
             shapeStrokeOpacity: structuredClone(ref.shapes.shapeStrokeOpacity),
+            transform: structuredClone(ref.shapes.transform),
           },
         },
+        dataBounds,
+        scanlineDataTexture,
+        shapeFillColorsTexture,
+        shapeStrokeColorsTexture,
       });
     }
     return newGLShapes;
@@ -1078,23 +1072,12 @@ type ShapesRef = {
 type GLShapes = {
   /** Reference to the shapes object this GPU state represents */
   ref: ShapesRef;
-  /** Number of shapes in the object at the time the textures were built */
-  numShapes: number;
-  /** Map of shape IDs to their corresponding layer IDs */
-  shapeLayers: Map<number, string | undefined> | undefined;
-  /** Axis-aligned bounding box of all shapes in data-space coordinates */
-  dataBounds: Rect;
-  /** Scanline data texture (RGBA32F); `undefined` while being regenerated */
-  scanlineDataTexture?: WebGLTexture;
-  /** Per-shape fill color texture (R32UI) */
-  shapeFillColorsTexture: WebGLTexture;
-  /** Per-shape stroke color texture (R32UI) */
-  shapeStrokeColorsTexture: WebGLTexture;
   /** Snapshot of model values at the time of the last texture upload */
-  current: {
-    layer: Pick<Layer, "visibility" | "opacity">;
+  config: {
+    layer: Pick<Layer, "visibility" | "opacity" | "transform">;
     shapes: Pick<
       Shapes,
+      | "layer"
       | "visibility"
       | "opacity"
       | "shapeFillColor"
@@ -1103,8 +1086,17 @@ type GLShapes = {
       | "shapeStrokeColor"
       | "shapeStrokeVisibility"
       | "shapeStrokeOpacity"
+      | "transform"
     >;
   };
+  /** Axis-aligned bounding box of all shapes in data-space coordinates */
+  dataBounds: Rect;
+  /** Scanline data texture (RGBA32F); `undefined` while being regenerated */
+  scanlineDataTexture?: WebGLTexture;
+  /** Per-shape fill color texture (R32UI) */
+  shapeFillColorsTexture: WebGLTexture;
+  /** Per-shape stroke color texture (R32UI) */
+  shapeStrokeColorsTexture: WebGLTexture;
 };
 
 /** A single horizontal scanline containing shape intersection data */

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -329,9 +329,12 @@ export class WebGLShapesController extends WebGLControllerBase {
       string,
       Map<number, string | undefined> | undefined
     >();
+    const failedShapes = new Set<string>();
     for (const layer of layers) {
       for (const currentShapes of shapes.filter(
-        (x) => x.layer === layer.id || typeof x.layer !== "string",
+        (shapes) =>
+          !failedShapes.has(shapes.id) &&
+          (shapes.layer === layer.id || typeof shapes.layer !== "string"),
       )) {
         let data = dataCache.get(currentShapes.id);
         if (data === undefined) {
@@ -345,6 +348,7 @@ export class WebGLShapesController extends WebGLControllerBase {
                 error,
               );
             }
+            failedShapes.add(currentShapes.id);
             continue;
           } finally {
             signal?.throwIfAborted();
@@ -361,19 +365,21 @@ export class WebGLShapesController extends WebGLControllerBase {
           !shapeLayersCache.has(currentShapes.id) &&
           typeof currentShapes.layer !== "string"
         ) {
-          let tableIds, tableLayers;
           try {
             const tableData = await loadTable(currentShapes.layer.table, {
               signal,
             });
             signal?.throwIfAborted();
-            tableIds = tableData.getIds();
+            const tableIds = tableData.getIds();
             signal?.throwIfAborted();
-            tableLayers = await tableData.loadValues<string>(
+            const tableLayers = await tableData.loadValues<string>(
               currentShapes.layer.column,
               { signal },
             );
             signal?.throwIfAborted();
+            shapeLayers = new Map(
+              tableIds.map((id, i) => [id, tableLayers[i]]),
+            );
           } catch (error) {
             if (!signal?.aborted) {
               console.error(
@@ -381,11 +387,11 @@ export class WebGLShapesController extends WebGLControllerBase {
                 error,
               );
             }
+            failedShapes.add(currentShapes.id);
             continue;
           } finally {
             signal?.throwIfAborted();
           }
-          shapeLayers = new Map(tableIds.map((id, i) => [id, tableLayers[i]]));
           shapeLayersCache.set(currentShapes.id, shapeLayers);
         }
         let shapeMask: boolean[] | undefined;

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -327,28 +327,32 @@ export class WebGLShapesController extends WebGLControllerBase {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
     const refs: ShapesRef[] = [];
-    const failedShapes = new Set<string>();
+    const dataCache = new Map<string, ShapesData | undefined>();
     const shapeLayersCache = new Map<string, Map<number, string> | undefined>();
     for (const layer of layers) {
       for (const currentShapes of shapes.filter(
-        (shapes) =>
-          !failedShapes.has(shapes.id) &&
-          (shapes.layer === layer.id || typeof shapes.layer !== "string"),
+        (x) => x.layer === layer.id || typeof x.layer !== "string",
       )) {
         let data;
-        try {
-          data = await getShapes(currentShapes.id, { signal });
-        } catch (error) {
-          if (!signal?.aborted) {
-            console.error(
-              `Failed to load shapes with ID '${currentShapes.id}'`,
-              error,
-            );
+        if (dataCache.has(currentShapes.id)) {
+          data = dataCache.get(currentShapes.id);
+        } else {
+          try {
+            data = await getShapes(currentShapes.id, { signal });
+          } catch (error) {
+            if (!signal?.aborted) {
+              console.error(
+                `Failed to load shapes with ID '${currentShapes.id}'`,
+                error,
+              );
+            }
+          } finally {
+            signal?.throwIfAborted();
           }
-          failedShapes.add(currentShapes.id);
+          dataCache.set(currentShapes.id, data);
+        }
+        if (data === undefined) {
           continue;
-        } finally {
-          signal?.throwIfAborted();
         }
 
         let numShapes = data.getSize();

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -489,9 +489,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       if (
         glShapes === undefined ||
         dataBounds === undefined ||
-        scanlineDataTexture === undefined ||
-        glShapes.config.layer.transform !== ref.layer.transform ||
-        glShapes.config.shapes.transform !== ref.shapes.transform
+        scanlineDataTexture === undefined
       ) {
         let multiPolygons = await ref.data.loadMultiPolygons({ signal });
         signal?.throwIfAborted();
@@ -575,7 +573,6 @@ export class WebGLShapesController extends WebGLControllerBase {
           layer: {
             visibility: ref.layer.visibility,
             opacity: ref.layer.opacity,
-            transform: structuredClone(ref.layer.transform),
           },
           shapes: {
             layer: structuredClone(ref.shapes.layer),
@@ -591,7 +588,6 @@ export class WebGLShapesController extends WebGLControllerBase {
               ref.shapes.shapeStrokeVisibility,
             ),
             shapeStrokeOpacity: structuredClone(ref.shapes.shapeStrokeOpacity),
-            transform: structuredClone(ref.shapes.transform),
           },
         },
         dataBounds,
@@ -1075,7 +1071,7 @@ type GLShapes = {
   ref: ShapesRef;
   /** Snapshot of model values at the time of the last texture upload */
   config: {
-    layer: Pick<Layer, "visibility" | "opacity" | "transform">;
+    layer: Pick<Layer, "visibility" | "opacity">;
     shapes: Pick<
       Shapes,
       | "layer"
@@ -1087,7 +1083,6 @@ type GLShapes = {
       | "shapeStrokeColor"
       | "shapeStrokeVisibility"
       | "shapeStrokeOpacity"
-      | "transform"
     >;
   };
   /** Axis-aligned bounding box of all shapes in data-space coordinates */

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -481,6 +481,7 @@ export class WebGLShapesController extends WebGLControllerBase {
         glShapes === undefined ||
         dataBounds === undefined ||
         scanlineDataTexture === undefined ||
+        glShapes.shapeMask !== shapeMask ||
         glShapes.numShapes !== numShapes
       ) {
         let multiPolygons = await ref.data.loadMultiPolygons({ signal });
@@ -561,6 +562,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       }
       newGLShapes.push({
         ref,
+        shapeMask,
         numShapes,
         dataBounds,
         scanlineDataTexture,
@@ -1061,6 +1063,8 @@ type ShapesRef = {
 type GLShapes = {
   /** Reference to the shapes object this GPU state represents */
   ref: ShapesRef;
+  /** Mask indicating which shapes belong to the current texture */
+  shapeMask: boolean[] | undefined;
   /** Number of shapes in the object at the time the textures were built */
   numShapes: number;
   /** Axis-aligned bounding box of all shapes in data-space coordinates */

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -324,13 +324,17 @@ export class WebGLShapesController extends WebGLControllerBase {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
     const refs: ShapesRef[] = [];
+    const dataCache = new Map<string, ShapesData>();
+    const shapeLayersCache = new Map<
+      string,
+      Map<number, string | undefined> | undefined
+    >();
     for (const layer of layers) {
-      for (const currentShapes of shapes) {
-        if (
-          currentShapes.layer === layer.id ||
-          typeof currentShapes.layer !== "string"
-        ) {
-          let data;
+      for (const currentShapes of shapes.filter(
+        (x) => x.layer === layer.id || typeof x.layer !== "string",
+      )) {
+        let data = dataCache.get(currentShapes.id);
+        if (data === undefined) {
           try {
             data = await loadShapes(currentShapes.id, { signal });
           } catch (error) {
@@ -338,45 +342,51 @@ export class WebGLShapesController extends WebGLControllerBase {
               `Failed to load shapes with ID '${currentShapes.id}'`,
               error,
             );
+            continue;
+          } finally {
+            signal?.throwIfAborted();
           }
-          signal?.throwIfAborted();
-          if (data !== undefined) {
-            let numShapes = data.getSize();
-            let shapeMask: boolean[] | undefined;
-            if (numShapes > 0 && typeof currentShapes.layer !== "string") {
-              const tableData = await loadTable(currentShapes.layer.table, {
-                signal,
-              });
-              signal?.throwIfAborted();
-              const tableIds = tableData.getIds();
-              signal?.throwIfAborted();
-              const tableLayers = await tableData.loadValues<string>(
-                currentShapes.layer.column,
-                { signal },
-              );
-              signal?.throwIfAborted();
-              const shapeLayers = new Map(
-                tableIds.map((id, i) => [id, tableLayers[i]!]),
-              );
-              shapeMask = data
-                .getIds()
-                .map((shapeId) => shapeLayers.get(shapeId) === layer.id);
-              numShapes = shapeMask.reduce(
-                (accum, include) => accum + (include ? 1 : 0),
-                0,
-              );
-            }
-            if (numShapes > 0) {
-              refs.push({
-                layer,
-                shapes: currentShapes,
-                shapeMask,
-                numShapes,
-                data,
-              });
-            }
-          }
+          dataCache.set(currentShapes.id, data);
         }
+        let numShapes = data.getSize();
+        if (numShapes === 0) {
+          continue;
+        }
+        let shapeLayers = shapeLayersCache.get(currentShapes.id);
+        if (
+          shapeLayers === undefined &&
+          !shapeLayersCache.has(currentShapes.id) &&
+          typeof currentShapes.layer !== "string"
+        ) {
+          const tableData = await loadTable(currentShapes.layer.table, {
+            signal,
+          });
+          signal?.throwIfAborted();
+          const tableIds = tableData.getIds();
+          signal?.throwIfAborted();
+          const tableLayers = await tableData.loadValues<string>(
+            currentShapes.layer.column,
+            { signal },
+          );
+          signal?.throwIfAborted();
+          shapeLayers = new Map(tableIds.map((id, i) => [id, tableLayers[i]]));
+          shapeLayersCache.set(currentShapes.id, shapeLayers);
+        }
+        let shapeMask: boolean[] | undefined;
+        if (numShapes > 0 && shapeLayers !== undefined) {
+          shapeMask = data.getIds().map((x) => shapeLayers.get(x) === layer.id);
+          numShapes = shapeMask.reduce((accum, x) => accum + (x ? 1 : 0), 0);
+        }
+        if (numShapes === 0) {
+          continue;
+        }
+        refs.push({
+          layer,
+          shapes: currentShapes,
+          shapeMask,
+          numShapes,
+          data,
+        });
       }
     }
     return refs;

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -434,7 +434,8 @@ export class WebGLShapesController extends WebGLControllerBase {
           ref.shapes.id === glShapes.ref.shapes.id &&
           ref.numShapes === glShapes.ref.numShapes &&
           // check config.shapes.layer instead of ref.shapeLayers
-          deepEqual(ref.shapes.layer, glShapes.config.shapes.layer),
+          deepEqual(ref.shapes.layer, glShapes.config.shapes.layer) &&
+          deepEqual(ref.shapes.dataSource, glShapes.ref.shapes.dataSource),
       );
       if (ref !== undefined) {
         glShapesByRef.set(ref, glShapes);

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -1055,7 +1055,7 @@ type ShapesRef = {
   layer: Layer;
   shapes: Shapes;
   numShapes: number;
-  shapeLayers: Map<number, string | undefined> | undefined;
+  shapeLayers: Map<number, string> | undefined;
   data: ShapesData;
 };
 

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -481,8 +481,8 @@ export class WebGLShapesController extends WebGLControllerBase {
         glShapes === undefined ||
         dataBounds === undefined ||
         scanlineDataTexture === undefined ||
-        glShapes.shapeMask !== shapeMask ||
-        glShapes.numShapes !== numShapes
+        glShapes.numShapes !== numShapes ||
+        !deepEqual(glShapes.shapeMask, shapeMask) // check this last, to reduce complexity
       ) {
         let multiPolygons = await ref.data.loadMultiPolygons({ signal });
         signal?.throwIfAborted();

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -302,7 +302,7 @@ export class WebGLShapesController extends WebGLControllerBase {
   }
 
   /**
-   * Loads shapes data for every layer configuration matching the given layers
+   * Loads shapes data for every layer
    *
    * Objects that fail to load are logged and skipped.
    *
@@ -1010,7 +1010,7 @@ export class WebGLShapesController extends WebGLControllerBase {
   }
 }
 
-/** Binding of a shapes data object to a specific layer and layer configuration */
+/** Binding of a shapes data object to a specific layer */
 type ShapesRef = {
   layer: Layer;
   shapes: Shapes;

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -475,7 +475,7 @@ export class WebGLShapesController extends WebGLControllerBase {
         glShapes === undefined ||
         dataBounds === undefined ||
         scanlineDataTexture === undefined ||
-        glShapes.numShapes !== ref.numShapes
+        glShapes.numShapes !== numShapes
       ) {
         let multiPolygons = await ref.data.loadMultiPolygons({ signal });
         signal?.throwIfAborted();

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -337,11 +337,14 @@ export class WebGLShapesController extends WebGLControllerBase {
         if (data === undefined) {
           try {
             data = await loadShapes(currentShapes.id, { signal });
+            signal?.throwIfAborted();
           } catch (error) {
-            console.error(
-              `Failed to load shapes with ID '${currentShapes.id}'`,
-              error,
-            );
+            if (!signal?.aborted) {
+              console.error(
+                `Failed to load shapes with ID '${currentShapes.id}'`,
+                error,
+              );
+            }
             continue;
           } finally {
             signal?.throwIfAborted();
@@ -358,17 +361,30 @@ export class WebGLShapesController extends WebGLControllerBase {
           !shapeLayersCache.has(currentShapes.id) &&
           typeof currentShapes.layer !== "string"
         ) {
-          const tableData = await loadTable(currentShapes.layer.table, {
-            signal,
-          });
-          signal?.throwIfAborted();
-          const tableIds = tableData.getIds();
-          signal?.throwIfAborted();
-          const tableLayers = await tableData.loadValues<string>(
-            currentShapes.layer.column,
-            { signal },
-          );
-          signal?.throwIfAborted();
+          let tableIds, tableLayers;
+          try {
+            const tableData = await loadTable(currentShapes.layer.table, {
+              signal,
+            });
+            signal?.throwIfAborted();
+            tableIds = tableData.getIds();
+            signal?.throwIfAborted();
+            tableLayers = await tableData.loadValues<string>(
+              currentShapes.layer.column,
+              { signal },
+            );
+            signal?.throwIfAborted();
+          } catch (error) {
+            if (!signal?.aborted) {
+              console.error(
+                `Failed to load shape layers for shapes with ID '${currentShapes.id}'`,
+                error,
+              );
+            }
+            continue;
+          } finally {
+            signal?.throwIfAborted();
+          }
           shapeLayers = new Map(tableIds.map((id, i) => [id, tableLayers[i]]));
           shapeLayersCache.set(currentShapes.id, shapeLayers);
         }

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -12,7 +12,7 @@ import {
   defaultShapeStrokeVisibility,
 } from "../model/constants";
 import { type Layer } from "../model/layer";
-import { type Shapes, type ShapesLayerConfig } from "../model/shapes";
+import { type Shapes } from "../model/shapes";
 import {
   type Color,
   type DefaultMap,
@@ -171,7 +171,9 @@ export class WebGLShapesController extends WebGLControllerBase {
   ): Promise<void> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    const refs = await this._loadShapes(layers, shapes, loadShapes, { signal });
+    const refs = await this._loadShapes(layers, shapes, loadShapes, loadTable, {
+      signal,
+    });
     signal?.throwIfAborted();
     const glShapesByRef = this._cleanGLShapes(refs);
     this._glShapes = await this._createOrUpdateGLShapes(
@@ -313,6 +315,10 @@ export class WebGLShapesController extends WebGLControllerBase {
       shapesId: string,
       options?: { signal?: AbortSignal },
     ) => Promise<ShapesData>,
+    loadTable: (
+      tableId: string,
+      options?: { signal?: AbortSignal },
+    ) => Promise<TableData>,
     options?: { signal?: AbortSignal },
   ): Promise<ShapesRef[]> {
     const { signal } = options ?? {};
@@ -320,11 +326,10 @@ export class WebGLShapesController extends WebGLControllerBase {
     const refs: ShapesRef[] = [];
     for (const layer of layers) {
       for (const currentShapes of shapes) {
-        for (let i = 0; i < currentShapes.layerConfigs.length; i++) {
-          const layerConfig = currentShapes.layerConfigs[i]!;
-          if (layerConfig.layer !== layer.id) {
-            continue;
-          }
+        if (
+          currentShapes.layer === layer.id ||
+          typeof currentShapes.layer !== "string"
+        ) {
           let data;
           try {
             data = await loadShapes(currentShapes.id, { signal });
@@ -335,14 +340,41 @@ export class WebGLShapesController extends WebGLControllerBase {
             );
           }
           signal?.throwIfAborted();
-          if (data !== undefined && data.getSize() > 0) {
-            refs.push({
-              layer,
-              shapes: currentShapes,
-              layerConfig,
-              layerConfigIndex: i,
-              data,
-            });
+          if (data !== undefined) {
+            let numShapes = data.getSize();
+            let shapeMask: boolean[] | undefined;
+            if (numShapes > 0 && typeof currentShapes.layer !== "string") {
+              const tableData = await loadTable(currentShapes.layer.table, {
+                signal,
+              });
+              signal?.throwIfAborted();
+              const tableIds = tableData.getIds();
+              signal?.throwIfAborted();
+              const tableLayers = await tableData.loadValues<string>(
+                currentShapes.layer.column,
+                { signal },
+              );
+              signal?.throwIfAborted();
+              const shapeLayers = new Map(
+                tableIds.map((id, i) => [id, tableLayers[i]!]),
+              );
+              shapeMask = data
+                .getIds()
+                .map((shapeId) => shapeLayers.get(shapeId) === layer.id);
+              numShapes = shapeMask.reduce(
+                (accum, include) => accum + (include ? 1 : 0),
+                0,
+              );
+            }
+            if (numShapes > 0) {
+              refs.push({
+                layer,
+                shapes: currentShapes,
+                shapeMask,
+                numShapes,
+                data,
+              });
+            }
           }
         }
       }
@@ -366,8 +398,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       const ref = refs.find(
         (ref) =>
           ref.layer.id === glShapes.ref.layer.id &&
-          ref.shapes.id === glShapes.ref.shapes.id &&
-          ref.layerConfigIndex === glShapes.ref.layerConfigIndex,
+          ref.shapes.id === glShapes.ref.shapes.id,
       );
       if (ref !== undefined) {
         glShapesByRef.set(ref, glShapes);
@@ -406,18 +437,25 @@ export class WebGLShapesController extends WebGLControllerBase {
     signal?.throwIfAborted();
     const newGLShapes = [];
     for (const ref of refs) {
-      const numShapes = ref.data.getSize();
+      const { shapeMask, numShapes } = ref;
       const glShapes = glShapesByRef.get(ref);
+      let shapeIds = ref.data.getIds();
+      if (shapeMask !== undefined) {
+        shapeIds = shapeIds.filter((_, j) => shapeMask[j]);
+      }
       let dataBounds = glShapes?.dataBounds;
       let scanlineDataTexture = glShapes?.scanlineDataTexture;
       if (
         glShapes === undefined ||
         dataBounds === undefined ||
         scanlineDataTexture === undefined ||
-        glShapes.numShapes !== numShapes
+        glShapes.numShapes !== ref.numShapes
       ) {
-        const multiPolygons = await ref.data.loadMultiPolygons({ signal });
+        let multiPolygons = await ref.data.loadMultiPolygons({ signal });
         signal?.throwIfAborted();
+        if (shapeMask !== undefined) {
+          multiPolygons = multiPolygons.filter((_, j) => shapeMask[j]);
+        }
         dataBounds = WebGLShapesController._getDataBounds(multiPolygons);
         scanlineDataTexture = this._createScanlineDataTexture(
           multiPolygons,
@@ -448,6 +486,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       ) {
         shapeFillColorsTexture = await this._createShapeFillColorsTexture(
           ref,
+          shapeIds,
           colorMaps,
           visibilityMaps,
           opacityMaps,
@@ -479,6 +518,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       ) {
         shapeStrokeColorsTexture = await this._createShapeStrokeColorsTexture(
           ref,
+          shapeIds,
           colorMaps,
           visibilityMaps,
           opacityMaps,
@@ -567,6 +607,7 @@ export class WebGLShapesController extends WebGLControllerBase {
    */
   private async _createShapeFillColorsTexture(
     ref: ShapesRef,
+    shapeIds: number[],
     colorMaps: DefaultMap<Color>[],
     visibilityMaps: DefaultMap<boolean>[],
     opacityMaps: DefaultMap<number>[],
@@ -587,10 +628,10 @@ export class WebGLShapesController extends WebGLControllerBase {
       ref.shapes.visibility === false ||
       ref.shapes.opacity === 0
     ) {
-      colorData = new Uint32Array(ref.data.getSize()).fill(0);
+      colorData = new Uint32Array(shapeIds.length).fill(0);
     } else {
       const visibilityData = await VisibilityDataUtils.loadVisibilityData(
-        ref.data.getIds(),
+        shapeIds,
         ref.shapes.shapeFillVisibility,
         visibilityMaps,
         defaultShapeFillVisibility,
@@ -599,7 +640,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       );
       signal?.throwIfAborted();
       const opacityData = await OpacityDataUtils.loadOpacityData(
-        ref.data.getIds(),
+        shapeIds,
         ref.shapes.shapeFillOpacity,
         opacityMaps,
         defaultShapeFillOpacity,
@@ -612,7 +653,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       );
       signal?.throwIfAborted();
       colorData = await ColorDataUtils.loadColorData(
-        ref.data.getIds(),
+        shapeIds,
         ref.shapes.shapeFillColor,
         colorMaps,
         defaultShapeFillColor,
@@ -641,6 +682,7 @@ export class WebGLShapesController extends WebGLControllerBase {
    */
   private async _createShapeStrokeColorsTexture(
     ref: ShapesRef,
+    shapeIds: number[],
     colorMaps: DefaultMap<Color>[],
     visibilityMaps: DefaultMap<boolean>[],
     opacityMaps: DefaultMap<number>[],
@@ -661,10 +703,10 @@ export class WebGLShapesController extends WebGLControllerBase {
       ref.shapes.visibility === false ||
       ref.shapes.opacity === 0
     ) {
-      colorData = new Uint32Array(ref.data.getSize()).fill(0);
+      colorData = new Uint32Array(shapeIds.length).fill(0);
     } else {
       const visibilityData = await VisibilityDataUtils.loadVisibilityData(
-        ref.data.getIds(),
+        shapeIds,
         ref.shapes.shapeStrokeVisibility,
         visibilityMaps,
         defaultShapeStrokeVisibility,
@@ -673,7 +715,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       );
       signal?.throwIfAborted();
       const opacityData = await OpacityDataUtils.loadOpacityData(
-        ref.data.getIds(),
+        shapeIds,
         ref.shapes.shapeStrokeOpacity,
         opacityMaps,
         defaultShapeStrokeOpacity,
@@ -686,7 +728,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       );
       signal?.throwIfAborted();
       colorData = await ColorDataUtils.loadColorData(
-        ref.data.getIds(),
+        shapeIds,
         ref.shapes.shapeStrokeColor,
         colorMaps,
         defaultShapeStrokeColor,
@@ -972,8 +1014,8 @@ export class WebGLShapesController extends WebGLControllerBase {
 type ShapesRef = {
   layer: Layer;
   shapes: Shapes;
-  layerConfig: ShapesLayerConfig;
-  layerConfigIndex: number;
+  shapeMask: boolean[] | undefined;
+  numShapes: number;
   data: ShapesData;
 };
 

--- a/packages/@tissuumaps-core/src/model/base.ts
+++ b/packages/@tissuumaps-core/src/model/base.ts
@@ -15,7 +15,7 @@ export interface RawModel {}
 /**
  * A {@link RawModel} with {@link modelDefaults} applied
  */
-export type Model = Omit<object, keyof RawModel> &
+export type Model = object &
   Required<Pick<RawModel, keyof typeof modelDefaults>> &
   Omit<RawModel, keyof typeof modelDefaults>;
 
@@ -32,9 +32,9 @@ export function createModel(rawModel: RawModel): Model {
 /**
  * Default values for {@link RawDataObject}
  */
-export const dataObjectDefaults = {
-  ...modelDefaults,
-} as const satisfies Partial<RawDataObject<RawDataSource<string>>>;
+export const dataObjectDefaults = {} as const satisfies Partial<
+  RawDataObject<RawDataSource<string>>
+>;
 
 /**
  * A named, identifiable data object backed by a data source
@@ -55,10 +55,7 @@ export interface RawDataObject<
 /**
  * A {@link RawDataObject} with {@link dataObjectDefaults} applied
  */
-export type DataObject<TDataSource extends DataSource<string>> = Omit<
-  Model,
-  keyof RawDataObject<TDataSource>
-> &
+export type DataObject<TDataSource extends DataSource<string>> = Model &
   Required<Pick<RawDataObject<TDataSource>, keyof typeof dataObjectDefaults>> &
   Omit<RawDataObject<TDataSource>, keyof typeof dataObjectDefaults>;
 
@@ -84,7 +81,6 @@ export function createDataObject<
  * Default values for {@link RawRenderedDataObject}
  */
 export const renderedDataObjectDefaults = {
-  ...dataObjectDefaults,
   visibility: true,
   opacity: 1,
   flip: false,
@@ -138,20 +134,18 @@ export interface RawRenderedDataObject<
 /**
  * A {@link RawRenderedDataObject} with {@link renderedDataObjectDefaults} applied
  */
-export type RenderedDataObject<TDataSource extends DataSource<string>> = Omit<
-  DataObject<TDataSource>,
-  keyof RawRenderedDataObject<TDataSource>
-> &
-  Required<
-    Pick<
+export type RenderedDataObject<TDataSource extends DataSource<string>> =
+  DataObject<TDataSource> &
+    Required<
+      Pick<
+        RawRenderedDataObject<TDataSource>,
+        keyof typeof renderedDataObjectDefaults
+      >
+    > &
+    Omit<
       RawRenderedDataObject<TDataSource>,
       keyof typeof renderedDataObjectDefaults
-    >
-  > &
-  Omit<
-    RawRenderedDataObject<TDataSource>,
-    keyof typeof renderedDataObjectDefaults
-  >;
+    >;
 
 /**
  * Creates a {@link RenderedDataObject} from a {@link RawRenderedDataObject} by applying {@link renderedDataObjectDefaults}
@@ -175,9 +169,9 @@ export function createRenderedDataObject<
 /**
  * Default values for {@link RawSingleLayerDataObject}
  */
-export const singleLayerDataObjectDefaults = {
-  ...renderedDataObjectDefaults,
-} as const satisfies Partial<RawSingleLayerDataObject<RawDataSource<string>>>;
+export const singleLayerDataObjectDefaults = {} as const satisfies Partial<
+  RawSingleLayerDataObject<RawDataSource<string>>
+>;
 
 /**
  * A data object that can be rendered on a single layer
@@ -193,10 +187,7 @@ export interface RawSingleLayerDataObject<
  * A {@link RawSingleLayerDataObject} with {@link singleLayerDataObjectDefaults} applied
  */
 export type SingleLayerDataObject<TDataSource extends DataSource<string>> =
-  Omit<
-    RenderedDataObject<TDataSource>,
-    keyof RawSingleLayerDataObject<TDataSource>
-  > &
+  Omit<RenderedDataObject<TDataSource>, "layer"> &
     Required<
       Pick<
         RawSingleLayerDataObject<TDataSource>,
@@ -230,9 +221,9 @@ export function createSingleLayerDataObject<
 /**
  * Default values for {@link RawDataSource}
  */
-export const dataSourceDefaults = {
-  ...modelDefaults,
-} as const satisfies Partial<RawDataSource<string>>;
+export const dataSourceDefaults = {} as const satisfies Partial<
+  RawDataSource<string>
+>;
 
 /**
  * A data source for data objects
@@ -257,10 +248,7 @@ export interface RawDataSource<TType extends string = string> extends RawModel {
 /**
  * A {@link RawDataSource} with {@link dataSourceDefaults} applied
  */
-export type DataSource<TType extends string = string> = Omit<
-  Model,
-  keyof RawDataSource<TType>
-> &
+export type DataSource<TType extends string = string> = Model &
   Required<Pick<RawDataSource<TType>, keyof typeof dataSourceDefaults>> &
   Omit<RawDataSource<TType>, keyof typeof dataSourceDefaults>;
 

--- a/packages/@tissuumaps-core/src/model/base.ts
+++ b/packages/@tissuumaps-core/src/model/base.ts
@@ -15,15 +15,9 @@ export interface RawModel {}
 /**
  * A {@link RawModel} with {@link modelDefaults} applied
  */
-export type Model = object &
+export type Model = Omit<object, keyof RawModel> &
   Required<Pick<RawModel, keyof typeof modelDefaults>> &
-  Omit<
-    RawModel,
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof object
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents,@typescript-eslint/no-duplicate-type-constituents
-    | keyof typeof modelDefaults
-  >;
+  Omit<RawModel, keyof typeof modelDefaults>;
 
 /**
  * Creates a {@link Model} from a {@link RawModel} by applying {@link modelDefaults}
@@ -61,15 +55,12 @@ export interface RawDataObject<
 /**
  * A {@link RawDataObject} with {@link dataObjectDefaults} applied
  */
-export type DataObject<TDataSource extends DataSource<string>> = Model &
+export type DataObject<TDataSource extends DataSource<string>> = Omit<
+  Model,
+  keyof RawDataObject<TDataSource>
+> &
   Required<Pick<RawDataObject<TDataSource>, keyof typeof dataObjectDefaults>> &
-  Omit<
-    RawDataObject<TDataSource>,
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof Model
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents,@typescript-eslint/no-duplicate-type-constituents
-    | keyof typeof dataObjectDefaults
-  >;
+  Omit<RawDataObject<TDataSource>, keyof typeof dataObjectDefaults>;
 
 /**
  * Creates a {@link DataObject} from a {@link RawDataObject} by applying {@link dataObjectDefaults}
@@ -147,18 +138,20 @@ export interface RawRenderedDataObject<
 /**
  * A {@link RawRenderedDataObject} with {@link renderedDataObjectDefaults} applied
  */
-export type RenderedDataObject<TDataSource extends DataSource<string>> =
-  DataObject<TDataSource> &
-    Required<
-      Pick<
-        RawRenderedDataObject<TDataSource>,
-        keyof typeof renderedDataObjectDefaults
-      >
-    > &
-    Omit<
+export type RenderedDataObject<TDataSource extends DataSource<string>> = Omit<
+  DataObject<TDataSource>,
+  keyof RawRenderedDataObject<TDataSource>
+> &
+  Required<
+    Pick<
       RawRenderedDataObject<TDataSource>,
-      keyof DataObject<TDataSource> | keyof typeof renderedDataObjectDefaults
-    >;
+      keyof typeof renderedDataObjectDefaults
+    >
+  > &
+  Omit<
+    RawRenderedDataObject<TDataSource>,
+    keyof typeof renderedDataObjectDefaults
+  >;
 
 /**
  * Creates a {@link RenderedDataObject} from a {@link RawRenderedDataObject} by applying {@link renderedDataObjectDefaults}
@@ -200,7 +193,10 @@ export interface RawSingleLayerDataObject<
  * A {@link RawSingleLayerDataObject} with {@link singleLayerDataObjectDefaults} applied
  */
 export type SingleLayerDataObject<TDataSource extends DataSource<string>> =
-  RenderedDataObject<TDataSource> &
+  Omit<
+    RenderedDataObject<TDataSource>,
+    keyof RawSingleLayerDataObject<TDataSource>
+  > &
     Required<
       Pick<
         RawSingleLayerDataObject<TDataSource>,
@@ -209,8 +205,7 @@ export type SingleLayerDataObject<TDataSource extends DataSource<string>> =
     > &
     Omit<
       RawSingleLayerDataObject<TDataSource>,
-      | keyof RenderedDataObject<TDataSource>
-      | keyof typeof singleLayerDataObjectDefaults
+      keyof typeof singleLayerDataObjectDefaults
     >;
 
 /**
@@ -262,15 +257,12 @@ export interface RawDataSource<TType extends string = string> extends RawModel {
 /**
  * A {@link RawDataSource} with {@link dataSourceDefaults} applied
  */
-export type DataSource<TType extends string = string> = Model &
+export type DataSource<TType extends string = string> = Omit<
+  Model,
+  keyof RawDataSource<TType>
+> &
   Required<Pick<RawDataSource<TType>, keyof typeof dataSourceDefaults>> &
-  Omit<
-    RawDataSource<TType>,
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof Model
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents,@typescript-eslint/no-duplicate-type-constituents
-    | keyof typeof dataSourceDefaults
-  >;
+  Omit<RawDataSource<TType>, keyof typeof dataSourceDefaults>;
 
 /**
  * Creates a {@link DataSource} from a {@link RawDataSource} by applying {@link dataSourceDefaults}

--- a/packages/@tissuumaps-core/src/model/base.ts
+++ b/packages/@tissuumaps-core/src/model/base.ts
@@ -38,9 +38,9 @@ export function createModel(rawModel: RawModel): Model {
 /**
  * Default values for {@link RawDataObject}
  */
-export const dataObjectDefaults = {} as const satisfies Partial<
-  RawDataObject<RawDataSource<string>>
->;
+export const dataObjectDefaults = {
+  ...modelDefaults,
+} as const satisfies Partial<RawDataObject<RawDataSource<string>>>;
 
 /**
  * A named, identifiable data object backed by a data source
@@ -93,22 +93,28 @@ export function createDataObject<
  * Default values for {@link RawRenderedDataObject}
  */
 export const renderedDataObjectDefaults = {
+  ...dataObjectDefaults,
   visibility: true,
   opacity: 1,
   flip: false,
   transform: identityTransform,
-  layerConfigs: [],
-} as const satisfies Partial<
-  RawRenderedDataObject<RawDataSource<string>, RawLayerConfig>
->;
+} as const satisfies Partial<RawRenderedDataObject<RawDataSource<string>>>;
 
 /**
  * A data object that can be rendered on one or more layers
  */
 export interface RawRenderedDataObject<
   TRawDataSource extends RawDataSource<string>,
-  TRawLayerConfig extends RawLayerConfig,
 > extends RawDataObject<TRawDataSource> {
+  /**
+   * Layer ID
+   *
+   * Can be specified as:
+   * - An ID of an existing Layer
+   * - A table column holding the layer ID values for each item
+   */
+  layer: string | { table: string; column: string };
+
   /**
    * Data object visibility
    *
@@ -136,32 +142,23 @@ export interface RawRenderedDataObject<
    * @defaultValue {@link renderedDataObjectDefaults.transform}
    */
   transform?: SimilarityTransform;
-
-  /**
-   * Layer configurations specifying how this data object is displayed on each layer
-   *
-   * @defaultValue {@link renderedDataObjectDefaults.layerConfigs}
-   */
-  layerConfigs?: TRawLayerConfig[];
 }
 
 /**
  * A {@link RawRenderedDataObject} with {@link renderedDataObjectDefaults} applied
  */
-export type RenderedDataObject<
-  TDataSource extends DataSource<string>,
-  TLayerConfig extends LayerConfig,
-> = DataObject<TDataSource> &
-  Required<
-    Pick<
-      RawRenderedDataObject<TDataSource, TLayerConfig>,
-      keyof typeof renderedDataObjectDefaults
-    >
-  > &
-  Omit<
-    RawRenderedDataObject<TDataSource, TLayerConfig>,
-    keyof DataObject<TDataSource> | keyof typeof renderedDataObjectDefaults
-  >;
+export type RenderedDataObject<TDataSource extends DataSource<string>> =
+  DataObject<TDataSource> &
+    Required<
+      Pick<
+        RawRenderedDataObject<TDataSource>,
+        keyof typeof renderedDataObjectDefaults
+      >
+    > &
+    Omit<
+      RawRenderedDataObject<TDataSource>,
+      keyof DataObject<TDataSource> | keyof typeof renderedDataObjectDefaults
+    >;
 
 /**
  * Creates a {@link RenderedDataObject} from a {@link RawRenderedDataObject} by applying {@link renderedDataObjectDefaults}
@@ -172,25 +169,75 @@ export type RenderedDataObject<
 export function createRenderedDataObject<
   TType extends string,
   TRawDataSource extends RawDataSource<TType>,
-  TRawLayerConfig extends RawLayerConfig,
 >(
-  rawRenderedDataObject: RawRenderedDataObject<TRawDataSource, TRawLayerConfig>,
-): RenderedDataObject<DataSource<TType>, LayerConfig> {
+  rawRenderedDataObject: RawRenderedDataObject<TRawDataSource>,
+): RenderedDataObject<DataSource<TType>> {
   return {
     ...createDataObject(rawRenderedDataObject),
     ...structuredClone(renderedDataObjectDefaults),
     ...structuredClone(rawRenderedDataObject),
-    layerConfigs:
-      rawRenderedDataObject.layerConfigs?.map(createLayerConfig) ?? [],
+  };
+}
+
+/**
+ * Default values for {@link RawSingleLayerDataObject}
+ */
+export const singleLayerDataObjectDefaults = {
+  ...renderedDataObjectDefaults,
+} as const satisfies Partial<RawSingleLayerDataObject<RawDataSource<string>>>;
+
+/**
+ * A data object that can be rendered on a single layer
+ */
+export interface RawSingleLayerDataObject<
+  TRawDataSource extends RawDataSource<string>,
+> extends RawRenderedDataObject<TRawDataSource> {
+  /** Layer ID */
+  layer: string;
+}
+
+/**
+ * A {@link RawSingleLayerDataObject} with {@link singleLayerDataObjectDefaults} applied
+ */
+export type SingleLayerDataObject<TDataSource extends DataSource<string>> =
+  RenderedDataObject<TDataSource> &
+    Required<
+      Pick<
+        RawSingleLayerDataObject<TDataSource>,
+        keyof typeof singleLayerDataObjectDefaults
+      >
+    > &
+    Omit<
+      RawSingleLayerDataObject<TDataSource>,
+      | keyof RenderedDataObject<TDataSource>
+      | keyof typeof singleLayerDataObjectDefaults
+    >;
+
+/**
+ * Creates a {@link SingleLayerDataObject} from a {@link RawSingleLayerDataObject} by applying {@link singleLayerDataObjectDefaults}
+ *
+ * @param rawSingleLayerDataObject - The raw single-layer data object
+ * @returns The complete single-layer data object with default values applied
+ */
+export function createSingleLayerDataObject<
+  TType extends string,
+  TRawDataSource extends RawDataSource<TType>,
+>(
+  rawSingleLayerDataObject: RawSingleLayerDataObject<TRawDataSource>,
+): SingleLayerDataObject<DataSource<TType>> {
+  return {
+    ...createRenderedDataObject(rawSingleLayerDataObject),
+    ...structuredClone(singleLayerDataObjectDefaults),
+    ...structuredClone(rawSingleLayerDataObject),
   };
 }
 
 /**
  * Default values for {@link RawDataSource}
  */
-export const dataSourceDefaults = {} as const satisfies Partial<
-  RawDataSource<string>
->;
+export const dataSourceDefaults = {
+  ...modelDefaults,
+} as const satisfies Partial<RawDataSource<string>>;
 
 /**
  * A data source for data objects
@@ -238,51 +285,5 @@ export function createDataSource<TType extends string>(
     ...createModel(rawDataSource),
     ...structuredClone(dataSourceDefaults),
     ...structuredClone(rawDataSource),
-  };
-}
-/**
- * Default values for {@link RawLayerConfig}
- */
-export const layerConfigDefaults =
-  {} as const satisfies Partial<RawLayerConfig>;
-
-/**
- * A layer-specific display configuration for rendered data objects
- */
-export interface RawLayerConfig extends RawModel {
-  /**
-   * Layer ID
-   *
-   * Can be specified as:
-   * - An ID of an existing Layer
-   * - A table column holding the layer ID values for each item
-   */
-  layer: string | { table: string; column: string };
-}
-
-/**
- * A {@link RawLayerConfig} with {@link layerConfigDefaults} applied
- */
-export type LayerConfig = Model &
-  Required<Pick<RawLayerConfig, keyof typeof layerConfigDefaults>> &
-  Omit<
-    RawLayerConfig,
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof Model
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents,@typescript-eslint/no-duplicate-type-constituents
-    | keyof typeof layerConfigDefaults
-  >;
-
-/**
- * Creates a {@link LayerConfig} from a {@link RawLayerConfig} by applying {@link layerConfigDefaults}
- *
- * @param rawLayerConfig - The raw layer configuration
- * @returns The complete layer configuration with default values applied
- */
-export function createLayerConfig(rawLayerConfig: RawLayerConfig): LayerConfig {
-  return {
-    ...createModel(rawLayerConfig),
-    ...structuredClone(layerConfigDefaults),
-    ...structuredClone(rawLayerConfig),
   };
 }

--- a/packages/@tissuumaps-core/src/model/image.ts
+++ b/packages/@tissuumaps-core/src/model/image.ts
@@ -27,13 +27,12 @@ export interface RawImage extends RawSingleLayerDataObject<
 /**
  * A {@link RawImage} with {@link imageDefaults} applied
  */
-export type Image = SingleLayerDataObject<ImageDataSource<string>> &
+export type Image = Omit<
+  SingleLayerDataObject<ImageDataSource<string>>,
+  keyof RawImage
+> &
   Required<Pick<RawImage, keyof typeof imageDefaults>> &
-  Omit<
-    RawImage,
-    | keyof SingleLayerDataObject<ImageDataSource<string>>
-    | keyof typeof imageDefaults
-  >;
+  Omit<RawImage, keyof typeof imageDefaults>;
 
 /**
  * Creates a {@link Image} from a {@link RawImage} by applying {@link imageDefaults}
@@ -68,16 +67,14 @@ export interface RawImageDataSource<
 /**
  * A {@link RawImageDataSource} with {@link imageDataSourceDefaults} applied
  */
-export type ImageDataSource<TType extends string = string> = DataSource<TType> &
+export type ImageDataSource<TType extends string = string> = Omit<
+  DataSource<TType>,
+  keyof RawImageDataSource<TType>
+> &
   Required<
     Pick<RawImageDataSource<TType>, keyof typeof imageDataSourceDefaults>
   > &
-  Omit<
-    RawImageDataSource<TType>,
-    | keyof DataSource<TType>
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof typeof imageDataSourceDefaults
-  >;
+  Omit<RawImageDataSource<TType>, keyof typeof imageDataSourceDefaults>;
 
 /**
  * Creates a {@link ImageDataSource} from a {@link RawImageDataSource} by applying {@link imageDataSourceDefaults}

--- a/packages/@tissuumaps-core/src/model/image.ts
+++ b/packages/@tissuumaps-core/src/model/image.ts
@@ -5,16 +5,12 @@ import {
   type SingleLayerDataObject,
   createDataSource,
   createSingleLayerDataObject,
-  dataSourceDefaults,
-  singleLayerDataObjectDefaults,
 } from "./base";
 
 /**
  * Default values for {@link RawImage}
  */
-export const imageDefaults = {
-  ...singleLayerDataObjectDefaults,
-} as const satisfies Partial<RawImage>;
+export const imageDefaults = {} as const satisfies Partial<RawImage>;
 
 /**
  * A two-dimensional raster image
@@ -27,10 +23,7 @@ export interface RawImage extends RawSingleLayerDataObject<
 /**
  * A {@link RawImage} with {@link imageDefaults} applied
  */
-export type Image = Omit<
-  SingleLayerDataObject<ImageDataSource<string>>,
-  keyof RawImage
-> &
+export type Image = SingleLayerDataObject<ImageDataSource<string>> &
   Required<Pick<RawImage, keyof typeof imageDefaults>> &
   Omit<RawImage, keyof typeof imageDefaults>;
 
@@ -52,9 +45,9 @@ export function createImage(rawImage: RawImage): Image {
 /**
  * Default values for {@link RawImageDataSource}
  */
-export const imageDataSourceDefaults = {
-  ...dataSourceDefaults,
-} as const satisfies Partial<RawImageDataSource<string>>;
+export const imageDataSourceDefaults = {} as const satisfies Partial<
+  RawImageDataSource<string>
+>;
 
 /**
  * A data source for two-dimensional raster images
@@ -67,10 +60,7 @@ export interface RawImageDataSource<
 /**
  * A {@link RawImageDataSource} with {@link imageDataSourceDefaults} applied
  */
-export type ImageDataSource<TType extends string = string> = Omit<
-  DataSource<TType>,
-  keyof RawImageDataSource<TType>
-> &
+export type ImageDataSource<TType extends string = string> = DataSource<TType> &
   Required<
     Pick<RawImageDataSource<TType>, keyof typeof imageDataSourceDefaults>
   > &

--- a/packages/@tissuumaps-core/src/model/image.ts
+++ b/packages/@tissuumaps-core/src/model/image.ts
@@ -1,41 +1,37 @@
 import {
   type DataSource,
-  type LayerConfig,
   type RawDataSource,
-  type RawLayerConfig,
-  type RawRenderedDataObject,
-  type RenderedDataObject,
+  type RawSingleLayerDataObject,
+  type SingleLayerDataObject,
   createDataSource,
-  createLayerConfig,
-  createRenderedDataObject,
+  createSingleLayerDataObject,
+  dataSourceDefaults,
+  singleLayerDataObjectDefaults,
 } from "./base";
 
 /**
  * Default values for {@link RawImage}
  */
-export const imageDefaults = {} as const satisfies Partial<RawImage>;
+export const imageDefaults = {
+  ...singleLayerDataObjectDefaults,
+} as const satisfies Partial<RawImage>;
 
 /**
  * A two-dimensional raster image
  */
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface RawImage extends RawRenderedDataObject<
-  RawImageDataSource<string>,
-  RawImageLayerConfig
+export interface RawImage extends RawSingleLayerDataObject<
+  RawImageDataSource<string>
 > {}
 
 /**
  * A {@link RawImage} with {@link imageDefaults} applied
  */
-export type Image = RenderedDataObject<
-  ImageDataSource<string>,
-  ImageLayerConfig
-> &
+export type Image = SingleLayerDataObject<ImageDataSource<string>> &
   Required<Pick<RawImage, keyof typeof imageDefaults>> &
   Omit<
     RawImage,
-    | keyof RenderedDataObject<ImageDataSource<string>, ImageLayerConfig>
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
+    | keyof SingleLayerDataObject<ImageDataSource<string>>
     | keyof typeof imageDefaults
   >;
 
@@ -47,20 +43,19 @@ export type Image = RenderedDataObject<
  */
 export function createImage(rawImage: RawImage): Image {
   return {
-    ...createRenderedDataObject(rawImage),
+    ...createSingleLayerDataObject(rawImage),
     ...structuredClone(imageDefaults),
     ...structuredClone(rawImage),
     dataSource: createImageDataSource(rawImage.dataSource),
-    layerConfigs: rawImage.layerConfigs?.map(createImageLayerConfig) ?? [],
   };
 }
 
 /**
  * Default values for {@link RawImageDataSource}
  */
-export const imageDataSourceDefaults = {} as const satisfies Partial<
-  RawImageDataSource<string>
->;
+export const imageDataSourceDefaults = {
+  ...dataSourceDefaults,
+} as const satisfies Partial<RawImageDataSource<string>>;
 
 /**
  * A data source for two-dimensional raster images
@@ -97,49 +92,5 @@ export function createImageDataSource<TType extends string>(
     ...createDataSource(rawImageDataSource),
     ...structuredClone(imageDataSourceDefaults),
     ...structuredClone(rawImageDataSource),
-  };
-}
-
-/**
- * Default values for {@link RawImageLayerConfig}
- */
-export const imageLayerConfigDefaults =
-  {} as const satisfies Partial<RawImageLayerConfig>;
-
-/**
- * A layer-specific display configuration for two-dimensional raster images
- */
-export interface RawImageLayerConfig extends RawLayerConfig {
-  /**
-   * Layer ID
-   */
-  layer: string;
-}
-
-/**
- * A {@link RawImageLayerConfig} with {@link imageLayerConfigDefaults} applied
- */
-export type ImageLayerConfig = LayerConfig &
-  Required<Pick<RawImageLayerConfig, keyof typeof imageLayerConfigDefaults>> &
-  Omit<
-    RawImageLayerConfig,
-    | keyof LayerConfig
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof typeof imageLayerConfigDefaults
-  >;
-
-/**
- * Creates a {@link ImageLayerConfig} from a {@link RawImageLayerConfig} by applying {@link imageLayerConfigDefaults}
- *
- * @param rawImageLayerConfig - The raw image layer configuration
- * @returns The complete image layer configuration with default values applied
- */
-export function createImageLayerConfig(
-  rawImageLayerConfig: RawImageLayerConfig,
-): ImageLayerConfig {
-  return {
-    ...createLayerConfig(rawImageLayerConfig),
-    ...structuredClone(imageLayerConfigDefaults),
-    ...structuredClone(rawImageLayerConfig),
   };
 }

--- a/packages/@tissuumaps-core/src/model/labels.ts
+++ b/packages/@tissuumaps-core/src/model/labels.ts
@@ -1,13 +1,12 @@
 import {
   type DataSource,
-  type LayerConfig,
   type RawDataSource,
-  type RawLayerConfig,
-  type RawRenderedDataObject,
-  type RenderedDataObject,
+  type RawSingleLayerDataObject,
+  type SingleLayerDataObject,
   createDataSource,
-  createLayerConfig,
-  createRenderedDataObject,
+  createSingleLayerDataObject,
+  dataSourceDefaults,
+  singleLayerDataObjectDefaults,
 } from "./base";
 import {
   type ColorConfig,
@@ -24,6 +23,7 @@ import {
  * Default values for {@link RawLabels}
  */
 export const labelsDefaults = {
+  ...singleLayerDataObjectDefaults,
   labelColor: { random: { palette: defaultLabelColorPalette } },
   labelVisibility: { constant: { value: defaultLabelVisibility } },
   labelOpacity: { constant: { value: defaultLabelOpacity } },
@@ -32,9 +32,8 @@ export const labelsDefaults = {
 /**
  * A two-dimensional label mask
  */
-export interface RawLabels extends RawRenderedDataObject<
-  RawLabelsDataSource<string>,
-  RawLabelsLayerConfig
+export interface RawLabels extends RawSingleLayerDataObject<
+  RawLabelsDataSource<string>
 > {
   /**
    * Label color
@@ -61,14 +60,11 @@ export interface RawLabels extends RawRenderedDataObject<
 /**
  * A {@link RawLabels} with {@link labelsDefaults} applied
  */
-export type Labels = RenderedDataObject<
-  LabelsDataSource<string>,
-  LabelsLayerConfig
-> &
+export type Labels = SingleLayerDataObject<LabelsDataSource<string>> &
   Required<Pick<RawLabels, keyof typeof labelsDefaults>> &
   Omit<
     RawLabels,
-    | keyof RenderedDataObject<LabelsDataSource<string>, LabelsLayerConfig>
+    | keyof SingleLayerDataObject<LabelsDataSource<string>>
     | keyof typeof labelsDefaults
   >;
 
@@ -80,20 +76,19 @@ export type Labels = RenderedDataObject<
  */
 export function createLabels(rawLabels: RawLabels): Labels {
   return {
-    ...createRenderedDataObject(rawLabels),
+    ...createSingleLayerDataObject(rawLabels),
     ...structuredClone(labelsDefaults),
     ...structuredClone(rawLabels),
     dataSource: createLabelsDataSource(rawLabels.dataSource),
-    layerConfigs: rawLabels.layerConfigs?.map(createLabelsLayerConfig) ?? [],
   };
 }
 
 /**
  * Default values for {@link RawLabelsDataSource}
  */
-export const labelsDataSourceDefaults = {} as const satisfies Partial<
-  RawLabelsDataSource<string>
->;
+export const labelsDataSourceDefaults = {
+  ...dataSourceDefaults,
+} as const satisfies Partial<RawLabelsDataSource<string>>;
 
 /**
  * A data source for two-dimensional label masks
@@ -131,49 +126,5 @@ export function createLabelsDataSource<TType extends string>(
     ...createDataSource(rawLabelsDataSource),
     ...structuredClone(labelsDataSourceDefaults),
     ...structuredClone(rawLabelsDataSource),
-  };
-}
-
-/**
- * Default values for {@link RawLabelsLayerConfig}
- */
-export const labelsLayerConfigDefaults =
-  {} as const satisfies Partial<RawLabelsLayerConfig>;
-
-/**
- * A layer-specific display configuration for two-dimensional label masks
- */
-export interface RawLabelsLayerConfig extends RawLayerConfig {
-  /**
-   * Layer ID
-   */
-  layer: string;
-}
-
-/**
- * A {@link RawLabelsLayerConfig} with {@link labelsLayerConfigDefaults} applied
- */
-export type LabelsLayerConfig = LayerConfig &
-  Required<Pick<RawLabelsLayerConfig, keyof typeof labelsLayerConfigDefaults>> &
-  Omit<
-    RawLabelsLayerConfig,
-    | keyof LayerConfig
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof typeof labelsLayerConfigDefaults
-  >;
-
-/**
- * Creates a {@link LabelsLayerConfig} from a {@link RawLabelsLayerConfig} by applying {@link labelsLayerConfigDefaults}
- *
- * @param rawLabelsLayerConfig - The raw labels layer configuration
- * @returns The complete labels layer configuration with default values applied
- */
-export function createLabelsLayerConfig(
-  rawLabelsLayerConfig: RawLabelsLayerConfig,
-): LabelsLayerConfig {
-  return {
-    ...createLayerConfig(rawLabelsLayerConfig),
-    ...structuredClone(labelsLayerConfigDefaults),
-    ...structuredClone(rawLabelsLayerConfig),
   };
 }

--- a/packages/@tissuumaps-core/src/model/labels.ts
+++ b/packages/@tissuumaps-core/src/model/labels.ts
@@ -5,8 +5,6 @@ import {
   type SingleLayerDataObject,
   createDataSource,
   createSingleLayerDataObject,
-  dataSourceDefaults,
-  singleLayerDataObjectDefaults,
 } from "./base";
 import {
   type ColorConfig,
@@ -23,7 +21,6 @@ import {
  * Default values for {@link RawLabels}
  */
 export const labelsDefaults = {
-  ...singleLayerDataObjectDefaults,
   labelColor: { random: { palette: defaultLabelColorPalette } },
   labelVisibility: { constant: { value: defaultLabelVisibility } },
   labelOpacity: { constant: { value: defaultLabelOpacity } },
@@ -60,10 +57,7 @@ export interface RawLabels extends RawSingleLayerDataObject<
 /**
  * A {@link RawLabels} with {@link labelsDefaults} applied
  */
-export type Labels = Omit<
-  SingleLayerDataObject<LabelsDataSource<string>>,
-  keyof RawLabels
-> &
+export type Labels = SingleLayerDataObject<LabelsDataSource<string>> &
   Required<Pick<RawLabels, keyof typeof labelsDefaults>> &
   Omit<RawLabels, keyof typeof labelsDefaults>;
 
@@ -85,9 +79,9 @@ export function createLabels(rawLabels: RawLabels): Labels {
 /**
  * Default values for {@link RawLabelsDataSource}
  */
-export const labelsDataSourceDefaults = {
-  ...dataSourceDefaults,
-} as const satisfies Partial<RawLabelsDataSource<string>>;
+export const labelsDataSourceDefaults = {} as const satisfies Partial<
+  RawLabelsDataSource<string>
+>;
 
 /**
  * A data source for two-dimensional label masks
@@ -100,14 +94,12 @@ export interface RawLabelsDataSource<
 /**
  * A {@link RawLabelsDataSource} with {@link labelsDataSourceDefaults} applied
  */
-export type LabelsDataSource<TType extends string = string> = Omit<
-  DataSource<TType>,
-  keyof RawLabelsDataSource<TType>
-> &
-  Required<
-    Pick<RawLabelsDataSource<TType>, keyof typeof labelsDataSourceDefaults>
-  > &
-  Omit<RawLabelsDataSource<TType>, keyof typeof labelsDataSourceDefaults>;
+export type LabelsDataSource<TType extends string = string> =
+  DataSource<TType> &
+    Required<
+      Pick<RawLabelsDataSource<TType>, keyof typeof labelsDataSourceDefaults>
+    > &
+    Omit<RawLabelsDataSource<TType>, keyof typeof labelsDataSourceDefaults>;
 
 /**
  * Creates a {@link LabelsDataSource} from a {@link RawLabelsDataSource} by applying {@link labelsDataSourceDefaults}

--- a/packages/@tissuumaps-core/src/model/labels.ts
+++ b/packages/@tissuumaps-core/src/model/labels.ts
@@ -60,13 +60,12 @@ export interface RawLabels extends RawSingleLayerDataObject<
 /**
  * A {@link RawLabels} with {@link labelsDefaults} applied
  */
-export type Labels = SingleLayerDataObject<LabelsDataSource<string>> &
+export type Labels = Omit<
+  SingleLayerDataObject<LabelsDataSource<string>>,
+  keyof RawLabels
+> &
   Required<Pick<RawLabels, keyof typeof labelsDefaults>> &
-  Omit<
-    RawLabels,
-    | keyof SingleLayerDataObject<LabelsDataSource<string>>
-    | keyof typeof labelsDefaults
-  >;
+  Omit<RawLabels, keyof typeof labelsDefaults>;
 
 /**
  * Creates a {@link Labels} from a {@link RawLabels} by applying {@link labelsDefaults}
@@ -101,17 +100,14 @@ export interface RawLabelsDataSource<
 /**
  * A {@link RawLabelsDataSource} with {@link labelsDataSourceDefaults} applied
  */
-export type LabelsDataSource<TType extends string = string> =
-  DataSource<TType> &
-    Required<
-      Pick<RawLabelsDataSource<TType>, keyof typeof labelsDataSourceDefaults>
-    > &
-    Omit<
-      RawLabelsDataSource<TType>,
-      | keyof DataSource<TType>
-      // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-      | keyof typeof labelsDataSourceDefaults
-    >;
+export type LabelsDataSource<TType extends string = string> = Omit<
+  DataSource<TType>,
+  keyof RawLabelsDataSource<TType>
+> &
+  Required<
+    Pick<RawLabelsDataSource<TType>, keyof typeof labelsDataSourceDefaults>
+  > &
+  Omit<RawLabelsDataSource<TType>, keyof typeof labelsDataSourceDefaults>;
 
 /**
  * Creates a {@link LabelsDataSource} from a {@link RawLabelsDataSource} by applying {@link labelsDataSourceDefaults}

--- a/packages/@tissuumaps-core/src/model/layer.ts
+++ b/packages/@tissuumaps-core/src/model/layer.ts
@@ -64,13 +64,9 @@ export interface RawLayer extends RawModel {
 /**
  * A {@link RawLayer} with {@link layerDefaults} applied
  */
-export type Layer = Model &
+export type Layer = Omit<Model, keyof RawLayer> &
   Required<Pick<RawLayer, keyof typeof layerDefaults>> &
-  Omit<
-    RawLayer,
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    keyof Model | keyof typeof layerDefaults
-  >;
+  Omit<RawLayer, keyof typeof layerDefaults>;
 
 /**
  * Creates a {@link Layer} from a {@link RawLayer} by applying {@link layerDefaults}

--- a/packages/@tissuumaps-core/src/model/layer.ts
+++ b/packages/@tissuumaps-core/src/model/layer.ts
@@ -1,4 +1,4 @@
-import { type Model, type RawModel, createModel, modelDefaults } from "./base";
+import { type Model, type RawModel, createModel } from "./base";
 import { identityTransform } from "./constants";
 import { type SimilarityTransform } from "./types";
 
@@ -6,7 +6,6 @@ import { type SimilarityTransform } from "./types";
  * Default values for {@link RawLayer}
  */
 export const layerDefaults = {
-  ...modelDefaults,
   transform: identityTransform,
   visibility: true,
   opacity: 1,
@@ -64,7 +63,7 @@ export interface RawLayer extends RawModel {
 /**
  * A {@link RawLayer} with {@link layerDefaults} applied
  */
-export type Layer = Omit<Model, keyof RawLayer> &
+export type Layer = Model &
   Required<Pick<RawLayer, keyof typeof layerDefaults>> &
   Omit<RawLayer, keyof typeof layerDefaults>;
 

--- a/packages/@tissuumaps-core/src/model/layer.ts
+++ b/packages/@tissuumaps-core/src/model/layer.ts
@@ -1,4 +1,4 @@
-import { type Model, type RawModel, createModel } from "./base";
+import { type Model, type RawModel, createModel, modelDefaults } from "./base";
 import { identityTransform } from "./constants";
 import { type SimilarityTransform } from "./types";
 
@@ -6,6 +6,7 @@ import { type SimilarityTransform } from "./types";
  * Default values for {@link RawLayer}
  */
 export const layerDefaults = {
+  ...modelDefaults,
   transform: identityTransform,
   visibility: true,
   opacity: 1,

--- a/packages/@tissuumaps-core/src/model/points.ts
+++ b/packages/@tissuumaps-core/src/model/points.ts
@@ -5,8 +5,6 @@ import {
   type RenderedDataObject,
   createDataSource,
   createRenderedDataObject,
-  dataSourceDefaults,
-  renderedDataObjectDefaults,
 } from "./base";
 import {
   type ColorConfig,
@@ -27,7 +25,6 @@ import {
  * Default values for {@link RawPoints}
  */
 export const pointsDefaults = {
-  ...renderedDataObjectDefaults,
   pointMarker: { constant: { value: defaultPointMarker } },
   pointSize: { constant: { value: defaultPointSize } },
   pointColor: { constant: { value: defaultPointColor } },
@@ -93,10 +90,7 @@ export interface RawPoints extends RawRenderedDataObject<
 /**
  * A {@link RawPoints} object with {@link pointsDefaults} applied
  */
-export type Points = Omit<
-  RenderedDataObject<PointsDataSource<string>>,
-  keyof RawPoints
-> &
+export type Points = RenderedDataObject<PointsDataSource<string>> &
   Required<Pick<RawPoints, keyof typeof pointsDefaults>> &
   Omit<RawPoints, keyof typeof pointsDefaults>;
 
@@ -118,9 +112,9 @@ export function createPoints(rawPoints: RawPoints): Points {
 /**
  * Default values for {@link RawPointsDataSource}
  */
-export const pointsDataSourceDefaults = {
-  ...dataSourceDefaults,
-} as const satisfies Partial<RawPointsDataSource<string>>;
+export const pointsDataSourceDefaults = {} as const satisfies Partial<
+  RawPointsDataSource<string>
+>;
 
 /**
  * A data source for two-dimensional point clouds
@@ -133,14 +127,12 @@ export interface RawPointsDataSource<
 /**
  * A {@link RawPointsDataSource} with {@link pointsDataSourceDefaults} applied
  */
-export type PointsDataSource<TType extends string = string> = Omit<
-  DataSource<TType>,
-  keyof RawPointsDataSource<TType>
-> &
-  Required<
-    Pick<RawPointsDataSource<TType>, keyof typeof pointsDataSourceDefaults>
-  > &
-  Omit<RawPointsDataSource<TType>, keyof typeof pointsDataSourceDefaults>;
+export type PointsDataSource<TType extends string = string> =
+  DataSource<TType> &
+    Required<
+      Pick<RawPointsDataSource<TType>, keyof typeof pointsDataSourceDefaults>
+    > &
+    Omit<RawPointsDataSource<TType>, keyof typeof pointsDataSourceDefaults>;
 
 /**
  * Creates a {@link PointsDataSource} from a {@link RawPointsDataSource} by applying {@link pointsDataSourceDefaults}

--- a/packages/@tissuumaps-core/src/model/points.ts
+++ b/packages/@tissuumaps-core/src/model/points.ts
@@ -93,13 +93,12 @@ export interface RawPoints extends RawRenderedDataObject<
 /**
  * A {@link RawPoints} object with {@link pointsDefaults} applied
  */
-export type Points = RenderedDataObject<PointsDataSource<string>> &
+export type Points = Omit<
+  RenderedDataObject<PointsDataSource<string>>,
+  keyof RawPoints
+> &
   Required<Pick<RawPoints, keyof typeof pointsDefaults>> &
-  Omit<
-    RawPoints,
-    | keyof RenderedDataObject<PointsDataSource<string>>
-    | keyof typeof pointsDefaults
-  >;
+  Omit<RawPoints, keyof typeof pointsDefaults>;
 
 /**
  * Creates a {@link Points} from a {@link RawPoints} by applying {@link pointsDefaults}
@@ -134,17 +133,14 @@ export interface RawPointsDataSource<
 /**
  * A {@link RawPointsDataSource} with {@link pointsDataSourceDefaults} applied
  */
-export type PointsDataSource<TType extends string = string> =
-  DataSource<TType> &
-    Required<
-      Pick<RawPointsDataSource<TType>, keyof typeof pointsDataSourceDefaults>
-    > &
-    Omit<
-      RawPointsDataSource<TType>,
-      | keyof DataSource<TType>
-      // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-      | keyof typeof pointsDataSourceDefaults
-    >;
+export type PointsDataSource<TType extends string = string> = Omit<
+  DataSource<TType>,
+  keyof RawPointsDataSource<TType>
+> &
+  Required<
+    Pick<RawPointsDataSource<TType>, keyof typeof pointsDataSourceDefaults>
+  > &
+  Omit<RawPointsDataSource<TType>, keyof typeof pointsDataSourceDefaults>;
 
 /**
  * Creates a {@link PointsDataSource} from a {@link RawPointsDataSource} by applying {@link pointsDataSourceDefaults}

--- a/packages/@tissuumaps-core/src/model/points.ts
+++ b/packages/@tissuumaps-core/src/model/points.ts
@@ -1,13 +1,12 @@
 import {
   type DataSource,
-  type LayerConfig,
   type RawDataSource,
-  type RawLayerConfig,
   type RawRenderedDataObject,
   type RenderedDataObject,
   createDataSource,
-  createLayerConfig,
   createRenderedDataObject,
+  dataSourceDefaults,
+  renderedDataObjectDefaults,
 } from "./base";
 import {
   type ColorConfig,
@@ -28,6 +27,7 @@ import {
  * Default values for {@link RawPoints}
  */
 export const pointsDefaults = {
+  ...renderedDataObjectDefaults,
   pointMarker: { constant: { value: defaultPointMarker } },
   pointSize: { constant: { value: defaultPointSize } },
   pointColor: { constant: { value: defaultPointColor } },
@@ -40,8 +40,7 @@ export const pointsDefaults = {
  * A two-dimensional point cloud
  */
 export interface RawPoints extends RawRenderedDataObject<
-  RawPointsDataSource<string>,
-  RawPointsLayerConfig
+  RawPointsDataSource<string>
 > {
   /**
    * Point marker
@@ -94,14 +93,11 @@ export interface RawPoints extends RawRenderedDataObject<
 /**
  * A {@link RawPoints} object with {@link pointsDefaults} applied
  */
-export type Points = RenderedDataObject<
-  PointsDataSource<string>,
-  PointsLayerConfig
-> &
+export type Points = RenderedDataObject<PointsDataSource<string>> &
   Required<Pick<RawPoints, keyof typeof pointsDefaults>> &
   Omit<
     RawPoints,
-    | keyof RenderedDataObject<PointsDataSource<string>, PointsLayerConfig>
+    | keyof RenderedDataObject<PointsDataSource<string>>
     | keyof typeof pointsDefaults
   >;
 
@@ -117,16 +113,15 @@ export function createPoints(rawPoints: RawPoints): Points {
     ...structuredClone(pointsDefaults),
     ...structuredClone(rawPoints),
     dataSource: createPointsDataSource(rawPoints.dataSource),
-    layerConfigs: rawPoints.layerConfigs?.map(createPointsLayerConfig) ?? [],
   };
 }
 
 /**
  * Default values for {@link RawPointsDataSource}
  */
-export const pointsDataSourceDefaults = {} as const satisfies Partial<
-  RawPointsDataSource<string>
->;
+export const pointsDataSourceDefaults = {
+  ...dataSourceDefaults,
+} as const satisfies Partial<RawPointsDataSource<string>>;
 
 /**
  * A data source for two-dimensional point clouds
@@ -164,45 +159,5 @@ export function createPointsDataSource<TType extends string>(
     ...createDataSource(rawPointsDataSource),
     ...structuredClone(pointsDataSourceDefaults),
     ...structuredClone(rawPointsDataSource),
-  };
-}
-
-/**
- * Default values for {@link RawPointsLayerConfig}
- */
-export const pointsLayerConfigDefaults =
-  {} as const satisfies Partial<RawPointsLayerConfig>;
-
-/**
- * A layer-specific display configuration for two-dimensional point clouds
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface RawPointsLayerConfig extends RawLayerConfig {}
-
-/**
- * A {@link RawPointsLayerConfig} with {@link pointsLayerConfigDefaults} applied
- */
-export type PointsLayerConfig = LayerConfig &
-  Required<Pick<RawPointsLayerConfig, keyof typeof pointsLayerConfigDefaults>> &
-  Omit<
-    RawPointsLayerConfig,
-    | keyof LayerConfig
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof typeof pointsLayerConfigDefaults
-  >;
-
-/**
- * Creates a {@link PointsLayerConfig} from a {@link RawPointsLayerConfig} by applying {@link pointsLayerConfigDefaults}
- *
- * @param rawPointsLayerConfig - The raw points layer configuration
- * @returns The complete points layer configuration with default values applied
- */
-export function createPointsLayerConfig(
-  rawPointsLayerConfig: RawPointsLayerConfig,
-): PointsLayerConfig {
-  return {
-    ...createLayerConfig(rawPointsLayerConfig),
-    ...structuredClone(pointsLayerConfigDefaults),
-    ...structuredClone(rawPointsLayerConfig),
   };
 }

--- a/packages/@tissuumaps-core/src/model/project.ts
+++ b/packages/@tissuumaps-core/src/model/project.ts
@@ -1,4 +1,4 @@
-import { type Model, type RawModel, createModel } from "./base";
+import { type Model, type RawModel, createModel, modelDefaults } from "./base";
 import { defaultRenderOptions, defaultViewerOptions } from "./constants";
 import { type Image, type RawImage, createImage } from "./image";
 import { type Labels, type RawLabels, createLabels } from "./labels";
@@ -18,6 +18,7 @@ import {
  * Default values for {@link RawProject}
  */
 export const projectDefaults = {
+  ...modelDefaults,
   markerMaps: [],
   sizeMaps: [],
   colorMaps: [],

--- a/packages/@tissuumaps-core/src/model/project.ts
+++ b/packages/@tissuumaps-core/src/model/project.ts
@@ -151,12 +151,10 @@ export interface RawProject extends RawModel {
 /**
  * A {@link RawProject} with {@link projectDefaults} applied
  */
-export type Project = Model &
+export type Project = Omit<Model, keyof RawProject> &
   Required<Pick<RawProject, keyof typeof projectDefaults>> &
   Omit<
     RawProject,
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof Model
     | keyof typeof projectDefaults
     | ("layers" | "images" | "labels" | "points" | "shapes" | "tables")
   > & {

--- a/packages/@tissuumaps-core/src/model/project.ts
+++ b/packages/@tissuumaps-core/src/model/project.ts
@@ -1,4 +1,4 @@
-import { type Model, type RawModel, createModel, modelDefaults } from "./base";
+import { type Model, type RawModel, createModel } from "./base";
 import { defaultRenderOptions, defaultViewerOptions } from "./constants";
 import { type Image, type RawImage, createImage } from "./image";
 import { type Labels, type RawLabels, createLabels } from "./labels";
@@ -18,7 +18,6 @@ import {
  * Default values for {@link RawProject}
  */
 export const projectDefaults = {
-  ...modelDefaults,
   markerMaps: [],
   sizeMaps: [],
   colorMaps: [],
@@ -151,7 +150,7 @@ export interface RawProject extends RawModel {
 /**
  * A {@link RawProject} with {@link projectDefaults} applied
  */
-export type Project = Omit<Model, keyof RawProject> &
+export type Project = Model &
   Required<Pick<RawProject, keyof typeof projectDefaults>> &
   Omit<
     RawProject,

--- a/packages/@tissuumaps-core/src/model/shapes.ts
+++ b/packages/@tissuumaps-core/src/model/shapes.ts
@@ -87,13 +87,12 @@ export interface RawShapes extends RawRenderedDataObject<
 /**
  * A {@link RawShapes} object with {@link shapesDefaults} applied
  */
-export type Shapes = RenderedDataObject<ShapesDataSource<string>> &
+export type Shapes = Omit<
+  RenderedDataObject<ShapesDataSource<string>>,
+  keyof RawShapes
+> &
   Required<Pick<RawShapes, keyof typeof shapesDefaults>> &
-  Omit<
-    RawShapes,
-    | keyof RenderedDataObject<ShapesDataSource<string>>
-    | keyof typeof shapesDefaults
-  >;
+  Omit<RawShapes, keyof typeof shapesDefaults>;
 
 /**
  * Creates a {@link Shapes} from a {@link RawShapes} by applying {@link shapesDefaults}
@@ -128,17 +127,14 @@ export interface RawShapesDataSource<
 /**
  * A {@link RawShapesDataSource} with {@link shapesDataSourceDefaults} applied
  */
-export type ShapesDataSource<TType extends string = string> =
-  DataSource<TType> &
-    Required<
-      Pick<RawShapesDataSource<TType>, keyof typeof shapesDataSourceDefaults>
-    > &
-    Omit<
-      RawShapesDataSource<TType>,
-      | keyof DataSource<TType>
-      // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-      | keyof typeof shapesDataSourceDefaults
-    >;
+export type ShapesDataSource<TType extends string = string> = Omit<
+  DataSource<TType>,
+  keyof RawShapesDataSource<TType>
+> &
+  Required<
+    Pick<RawShapesDataSource<TType>, keyof typeof shapesDataSourceDefaults>
+  > &
+  Omit<RawShapesDataSource<TType>, keyof typeof shapesDataSourceDefaults>;
 
 /**
  * Creates a {@link ShapesDataSource} from a {@link RawShapesDataSource} by applying {@link shapesDataSourceDefaults}

--- a/packages/@tissuumaps-core/src/model/shapes.ts
+++ b/packages/@tissuumaps-core/src/model/shapes.ts
@@ -1,13 +1,12 @@
 import {
   type DataSource,
-  type LayerConfig,
   type RawDataSource,
-  type RawLayerConfig,
   type RawRenderedDataObject,
   type RenderedDataObject,
   createDataSource,
-  createLayerConfig,
   createRenderedDataObject,
+  dataSourceDefaults,
+  renderedDataObjectDefaults,
 } from "./base";
 import {
   type ColorConfig,
@@ -27,6 +26,7 @@ import {
  * Default values for {@link RawShapes}
  */
 export const shapesDefaults = {
+  ...renderedDataObjectDefaults,
   shapeFillColor: { constant: { value: defaultShapeFillColor } },
   shapeFillVisibility: { constant: { value: defaultShapeFillVisibility } },
   shapeFillOpacity: { constant: { value: defaultShapeFillOpacity } },
@@ -39,8 +39,7 @@ export const shapesDefaults = {
  * A two-dimensional shape cloud
  */
 export interface RawShapes extends RawRenderedDataObject<
-  RawShapesDataSource<string>,
-  RawShapesLayerConfig
+  RawShapesDataSource<string>
 > {
   /**
    * Shape fill color
@@ -88,14 +87,11 @@ export interface RawShapes extends RawRenderedDataObject<
 /**
  * A {@link RawShapes} object with {@link shapesDefaults} applied
  */
-export type Shapes = RenderedDataObject<
-  ShapesDataSource<string>,
-  ShapesLayerConfig
-> &
+export type Shapes = RenderedDataObject<ShapesDataSource<string>> &
   Required<Pick<RawShapes, keyof typeof shapesDefaults>> &
   Omit<
     RawShapes,
-    | keyof RenderedDataObject<ShapesDataSource<string>, ShapesLayerConfig>
+    | keyof RenderedDataObject<ShapesDataSource<string>>
     | keyof typeof shapesDefaults
   >;
 
@@ -111,16 +107,15 @@ export function createShapes(rawShapes: RawShapes): Shapes {
     ...structuredClone(shapesDefaults),
     ...structuredClone(rawShapes),
     dataSource: createShapesDataSource(rawShapes.dataSource),
-    layerConfigs: rawShapes.layerConfigs?.map(createShapesLayerConfig) ?? [],
   };
 }
 
 /**
  * Default values for {@link RawShapesDataSource}
  */
-export const shapesDataSourceDefaults = {} as const satisfies Partial<
-  RawShapesDataSource<string>
->;
+export const shapesDataSourceDefaults = {
+  ...dataSourceDefaults,
+} as const satisfies Partial<RawShapesDataSource<string>>;
 
 /**
  * A data source for two-dimensional shape clouds
@@ -158,45 +153,5 @@ export function createShapesDataSource<TType extends string>(
     ...createDataSource(rawShapesDataSource),
     ...structuredClone(shapesDataSourceDefaults),
     ...structuredClone(rawShapesDataSource),
-  };
-}
-
-/**
- * Default values for {@link RawShapesLayerConfig}
- */
-export const shapesLayerConfigDefaults =
-  {} as const satisfies Partial<RawShapesLayerConfig>;
-
-/**
- * A layer-specific display configuration for two-dimensional shape clouds
- */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
-export interface RawShapesLayerConfig extends RawLayerConfig {}
-
-/**
- * A {@link RawShapesLayerConfig} with {@link shapesLayerConfigDefaults} applied
- */
-export type ShapesLayerConfig = LayerConfig &
-  Required<Pick<RawShapesLayerConfig, keyof typeof shapesLayerConfigDefaults>> &
-  Omit<
-    RawShapesLayerConfig,
-    | keyof LayerConfig
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof typeof shapesLayerConfigDefaults
-  >;
-
-/**
- * Creates a {@link ShapesLayerConfig} from a {@link RawShapesLayerConfig} by applying {@link shapesLayerConfigDefaults}
- *
- * @param rawShapesLayerConfig - The raw shapes layer configuration
- * @returns The complete shapes layer configuration with default values applied
- */
-export function createShapesLayerConfig(
-  rawShapesLayerConfig: RawShapesLayerConfig,
-): ShapesLayerConfig {
-  return {
-    ...createLayerConfig(rawShapesLayerConfig),
-    ...structuredClone(shapesLayerConfigDefaults),
-    ...structuredClone(rawShapesLayerConfig),
   };
 }

--- a/packages/@tissuumaps-core/src/model/shapes.ts
+++ b/packages/@tissuumaps-core/src/model/shapes.ts
@@ -5,8 +5,6 @@ import {
   type RenderedDataObject,
   createDataSource,
   createRenderedDataObject,
-  dataSourceDefaults,
-  renderedDataObjectDefaults,
 } from "./base";
 import {
   type ColorConfig,
@@ -26,7 +24,6 @@ import {
  * Default values for {@link RawShapes}
  */
 export const shapesDefaults = {
-  ...renderedDataObjectDefaults,
   shapeFillColor: { constant: { value: defaultShapeFillColor } },
   shapeFillVisibility: { constant: { value: defaultShapeFillVisibility } },
   shapeFillOpacity: { constant: { value: defaultShapeFillOpacity } },
@@ -87,10 +84,7 @@ export interface RawShapes extends RawRenderedDataObject<
 /**
  * A {@link RawShapes} object with {@link shapesDefaults} applied
  */
-export type Shapes = Omit<
-  RenderedDataObject<ShapesDataSource<string>>,
-  keyof RawShapes
-> &
+export type Shapes = RenderedDataObject<ShapesDataSource<string>> &
   Required<Pick<RawShapes, keyof typeof shapesDefaults>> &
   Omit<RawShapes, keyof typeof shapesDefaults>;
 
@@ -112,9 +106,9 @@ export function createShapes(rawShapes: RawShapes): Shapes {
 /**
  * Default values for {@link RawShapesDataSource}
  */
-export const shapesDataSourceDefaults = {
-  ...dataSourceDefaults,
-} as const satisfies Partial<RawShapesDataSource<string>>;
+export const shapesDataSourceDefaults = {} as const satisfies Partial<
+  RawShapesDataSource<string>
+>;
 
 /**
  * A data source for two-dimensional shape clouds
@@ -127,14 +121,12 @@ export interface RawShapesDataSource<
 /**
  * A {@link RawShapesDataSource} with {@link shapesDataSourceDefaults} applied
  */
-export type ShapesDataSource<TType extends string = string> = Omit<
-  DataSource<TType>,
-  keyof RawShapesDataSource<TType>
-> &
-  Required<
-    Pick<RawShapesDataSource<TType>, keyof typeof shapesDataSourceDefaults>
-  > &
-  Omit<RawShapesDataSource<TType>, keyof typeof shapesDataSourceDefaults>;
+export type ShapesDataSource<TType extends string = string> =
+  DataSource<TType> &
+    Required<
+      Pick<RawShapesDataSource<TType>, keyof typeof shapesDataSourceDefaults>
+    > &
+    Omit<RawShapesDataSource<TType>, keyof typeof shapesDataSourceDefaults>;
 
 /**
  * Creates a {@link ShapesDataSource} from a {@link RawShapesDataSource} by applying {@link shapesDataSourceDefaults}

--- a/packages/@tissuumaps-core/src/model/table.ts
+++ b/packages/@tissuumaps-core/src/model/table.ts
@@ -5,16 +5,12 @@ import {
   type RawDataSource,
   createDataObject,
   createDataSource,
-  dataObjectDefaults,
-  dataSourceDefaults,
 } from "./base";
 
 /**
  * Default values for {@link RawTable}
  */
-export const tableDefaults = {
-  ...dataObjectDefaults,
-} as const satisfies Partial<RawTable>;
+export const tableDefaults = {} as const satisfies Partial<RawTable>;
 
 /**
  * Tabular data
@@ -25,7 +21,7 @@ export interface RawTable extends RawDataObject<RawTableDataSource<string>> {}
 /**
  * A {@link RawTable} with {@link tableDefaults} applied
  */
-export type Table = Omit<DataObject<TableDataSource<string>>, keyof RawTable> &
+export type Table = DataObject<TableDataSource<string>> &
   Required<Pick<RawTable, keyof typeof tableDefaults>> &
   Omit<RawTable, keyof typeof tableDefaults>;
 
@@ -47,9 +43,9 @@ export function createTable(rawTable: RawTable): Table {
 /**
  * Default values for {@link RawTableDataSource}
  */
-export const tableDataSourceDefaults = {
-  ...dataSourceDefaults,
-} as const satisfies Partial<RawTableDataSource<string>>;
+export const tableDataSourceDefaults = {} as const satisfies Partial<
+  RawTableDataSource<string>
+>;
 
 /**
  * A data source for tabular data
@@ -62,10 +58,7 @@ export interface RawTableDataSource<
 /**
  * A {@link RawTableDataSource} with {@link tableDataSourceDefaults} applied
  */
-export type TableDataSource<TType extends string = string> = Omit<
-  DataSource<TType>,
-  keyof RawTableDataSource<TType>
-> &
+export type TableDataSource<TType extends string = string> = DataSource<TType> &
   Required<
     Pick<RawTableDataSource<TType>, keyof typeof tableDataSourceDefaults>
   > &

--- a/packages/@tissuumaps-core/src/model/table.ts
+++ b/packages/@tissuumaps-core/src/model/table.ts
@@ -25,14 +25,9 @@ export interface RawTable extends RawDataObject<RawTableDataSource<string>> {}
 /**
  * A {@link RawTable} with {@link tableDefaults} applied
  */
-export type Table = DataObject<TableDataSource<string>> &
+export type Table = Omit<DataObject<TableDataSource<string>>, keyof RawTable> &
   Required<Pick<RawTable, keyof typeof tableDefaults>> &
-  Omit<
-    RawTable,
-    | keyof DataObject<TableDataSource<string>>
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof typeof tableDefaults
-  >;
+  Omit<RawTable, keyof typeof tableDefaults>;
 
 /**
  * Creates a {@link Table} from a {@link RawTable} by applying {@link tableDefaults}
@@ -67,16 +62,14 @@ export interface RawTableDataSource<
 /**
  * A {@link RawTableDataSource} with {@link tableDataSourceDefaults} applied
  */
-export type TableDataSource<TType extends string = string> = DataSource<TType> &
+export type TableDataSource<TType extends string = string> = Omit<
+  DataSource<TType>,
+  keyof RawTableDataSource<TType>
+> &
   Required<
     Pick<RawTableDataSource<TType>, keyof typeof tableDataSourceDefaults>
   > &
-  Omit<
-    RawTableDataSource<TType>,
-    | keyof DataSource<TType>
-    // eslint-disable-next-line @typescript-eslint/no-redundant-type-constituents
-    | keyof typeof tableDataSourceDefaults
-  >;
+  Omit<RawTableDataSource<TType>, keyof typeof tableDataSourceDefaults>;
 
 /**
  * Creates a {@link TableDataSource} from a {@link RawTableDataSource} by applying {@link tableDataSourceDefaults}

--- a/packages/@tissuumaps-core/src/model/table.ts
+++ b/packages/@tissuumaps-core/src/model/table.ts
@@ -5,12 +5,16 @@ import {
   type RawDataSource,
   createDataObject,
   createDataSource,
+  dataObjectDefaults,
+  dataSourceDefaults,
 } from "./base";
 
 /**
  * Default values for {@link RawTable}
  */
-export const tableDefaults = {} as const satisfies Partial<RawTable>;
+export const tableDefaults = {
+  ...dataObjectDefaults,
+} as const satisfies Partial<RawTable>;
 
 /**
  * Tabular data
@@ -48,9 +52,9 @@ export function createTable(rawTable: RawTable): Table {
 /**
  * Default values for {@link RawTableDataSource}
  */
-export const tableDataSourceDefaults = {} as const satisfies Partial<
-  RawTableDataSource<string>
->;
+export const tableDataSourceDefaults = {
+  ...dataSourceDefaults,
+} as const satisfies Partial<RawTableDataSource<string>>;
 
 /**
  * A data source for tabular data

--- a/packages/@tissuumaps-viewer/src/adapter.ts
+++ b/packages/@tissuumaps-viewer/src/adapter.ts
@@ -35,23 +35,23 @@ export interface ViewerAdapter {
   viewerAnimationStartOptions: ViewerOptions;
   viewerAnimationFinishOptions: ViewerOptions;
   renderOptions: RenderOptions;
-  loadImage: (
+  getImage: (
     imageId: string,
     options?: { signal?: AbortSignal },
   ) => Promise<ImageData>;
-  loadLabels: (
+  getLabels: (
     labelsId: string,
     options?: { signal?: AbortSignal },
   ) => Promise<LabelsData>;
-  loadPoints: (
+  getPoints: (
     pointsId: string,
     options?: { signal?: AbortSignal },
   ) => Promise<PointsData>;
-  loadShapes: (
+  getShapes: (
     shapesId: string,
     options?: { signal?: AbortSignal },
   ) => Promise<ShapesData>;
-  loadTable: (
+  getTable: (
     tableId: string,
     options?: { signal?: AbortSignal },
   ) => Promise<TableData>;

--- a/packages/@tissuumaps-viewer/src/hooks/useOpenSeadragon.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useOpenSeadragon.ts
@@ -16,8 +16,8 @@ export function useOpenSeadragon(
     viewerOptions,
     viewerAnimationStartOptions,
     viewerAnimationFinishOptions,
-    loadImage,
-    loadLabels,
+    getImage,
+    getLabels,
   } = adapter;
 
   const controllerRef = useRef<OpenSeadragonController | null>(null);
@@ -71,7 +71,7 @@ export function useOpenSeadragon(
     if (controller !== null) {
       console.debug("Synchronizing OpenSeadragon viewer");
       controller
-        .synchronize(layers, images, labels, loadImage, loadLabels, {
+        .synchronize(layers, images, labels, getImage, getLabels, {
           signal: abortController.signal,
           dummyBounds: fallbackBounds(),
         })
@@ -84,15 +84,7 @@ export function useOpenSeadragon(
     return () => {
       abortController.abort();
     };
-  }, [
-    workspace,
-    layers,
-    images,
-    labels,
-    loadImage,
-    loadLabels,
-    fallbackBounds,
-  ]);
+  }, [workspace, layers, images, labels, getImage, getLabels, fallbackBounds]);
 
   return { setViewerElementRef, controllerRef, controllerReady };
 }

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -20,9 +20,9 @@ export function useWebGL(
     visibilityMaps,
     opacityMaps,
     renderOptions,
-    loadPoints,
-    loadShapes,
-    loadTable,
+    getPoints,
+    getShapes,
+    getTable,
   } = adapter;
 
   const controllerRef = useRef<WebGLController | null>(null);
@@ -97,8 +97,8 @@ export function useWebGL(
           colorMaps,
           visibilityMaps,
           opacityMaps,
-          loadPoints,
-          loadTable,
+          getPoints,
+          getTable,
           { signal: abortController.signal },
         )
         .then(
@@ -128,8 +128,8 @@ export function useWebGL(
     visibilityMaps,
     opacityMaps,
     workspace,
-    loadPoints,
-    loadTable,
+    getPoints,
+    getTable,
   ]);
 
   useEffect(() => {
@@ -144,8 +144,8 @@ export function useWebGL(
           colorMaps,
           visibilityMaps,
           opacityMaps,
-          loadShapes,
-          loadTable,
+          getShapes,
+          getTable,
           { signal: abortController.signal },
         )
         .then(
@@ -173,8 +173,8 @@ export function useWebGL(
     visibilityMaps,
     opacityMaps,
     workspace,
-    loadShapes,
-    loadTable,
+    getShapes,
+    getTable,
   ]);
 
   return { controllerRef, controllerReady };


### PR DESCRIPTION
# References and relevant issues

TMAP-314

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- Fix model defaults
- Add SingleLayerDataObject
- Replace LayerConfig by object-level layer setting
- Update rendering logic to enable multi-layer rendering of single objects
- Fix rendering logic to throw on abort and to watch data source and other fields
- several minor bugfixes & improvements

# Use of AI

Copilot was used for autocompletion

# Testing

None

# Further comments

Adding the UI for configuring an object's layer(s) will be tackled in a separate PR.

Example data must be migrated from using `Object.layerConfigs` to using `Object.layer`.