### PR TITLE
feat: add Layer panel, Layer selector and Transform accordion section

### DIFF
--- a/apps/tissuumaps/src/components/panels/ImagesPanel/ImageSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/ImagesPanel/ImageSettingsWidget.tsx
@@ -13,18 +13,33 @@ import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
 import { SimpleSelect } from "@/components/common/simple-select";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { useControlled } from "@/hooks/useControlled";
 import { cn } from "@/lib/utils";
 import { useTissUUmaps } from "@/store";
 
+import { ImageSettingsCategory } from "./category";
+
 export type ImageSettingsWidgetProps = {
   image: Image;
+  activeCategory?: ImageSettingsCategory | null;
+  onActiveCategoryChange?: (
+    newActiveCategory: ImageSettingsCategory | null,
+  ) => void;
   className?: string;
 };
 
 export function ImageSettingsWidget({
   image,
+  activeCategory: controlledActiveCategory,
+  onActiveCategoryChange: setControlledActiveCategory,
   className,
 }: ImageSettingsWidgetProps) {
+  const [activeCategory, setActiveCategory] = useControlled(
+    controlledActiveCategory,
+    setControlledActiveCategory,
+    null,
+  );
+
   return (
     <Fieldset
       className={cn("flex flex-col gap-y-2 border rounded-md p-2", className)}
@@ -32,8 +47,15 @@ export function ImageSettingsWidget({
       <FieldsetLegend className="font-medium text-foreground">
         Settings
       </FieldsetLegend>
-      <Accordion>
-        <AccordionItem value="general">
+      <Accordion
+        value={activeCategory !== null ? [activeCategory] : []}
+        onValueChange={(value) =>
+          setActiveCategory(
+            value.length > 0 ? (value[0] as ImageSettingsCategory) : null,
+          )
+        }
+      >
+        <AccordionItem value={ImageSettingsCategory.general}>
           <AccordionHeader>
             <AccordionTriggerRightDownIcon />
             <AccordionTrigger>General</AccordionTrigger>
@@ -42,7 +64,7 @@ export function ImageSettingsWidget({
             <GeneralImageSettingsWidget image={image} />
           </AccordionPanel>
         </AccordionItem>
-        <AccordionItem value="transform">
+        <AccordionItem value={ImageSettingsCategory.transform}>
           <AccordionHeader>
             <AccordionTriggerRightDownIcon />
             <AccordionTrigger>Transform</AccordionTrigger>

--- a/apps/tissuumaps/src/components/panels/ImagesPanel/ImageSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/ImagesPanel/ImageSettingsWidget.tsx
@@ -13,6 +13,7 @@ import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
 import { SimpleSelect } from "@/components/common/simple-select";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { TransformSettingsWidget } from "@/components/widgets/TransformSettingsWidget";
 import { useControlled } from "@/hooks/useControlled";
 import { cn } from "@/lib/utils";
 import { useTissUUmaps } from "@/store";
@@ -34,6 +35,8 @@ export function ImageSettingsWidget({
   onActiveCategoryChange: setControlledActiveCategory,
   className,
 }: ImageSettingsWidgetProps) {
+  const updateImage = useTissUUmaps((state) => state.updateImage);
+
   const [activeCategory, setActiveCategory] = useControlled(
     controlledActiveCategory,
     setControlledActiveCategory,
@@ -70,7 +73,14 @@ export function ImageSettingsWidget({
             <AccordionTrigger>Transform</AccordionTrigger>
           </AccordionHeader>
           <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
-            <TransformImageSettingsWidget image={image} />
+            <TransformSettingsWidget
+              transform={image.transform}
+              onTransformChange={(transform) =>
+                updateImage(image.id, { transform })
+              }
+              flip={image.flip}
+              onFlipChange={(flip) => updateImage(image.id, { flip })}
+            />
           </AccordionPanel>
         </AccordionItem>
       </Accordion>
@@ -146,119 +156,6 @@ function GeneralImageSettingsWidget({
           }}
         />
       </Field>
-    </div>
-  );
-}
-
-type TransformImageSettingsWidgetProps = {
-  image: Image;
-  className?: string;
-};
-
-function TransformImageSettingsWidget({
-  image,
-  className,
-}: TransformImageSettingsWidgetProps) {
-  const updateImage = useTissUUmaps((state) => state.updateImage);
-
-  return (
-    <div className={className}>
-      <Field>
-        <FieldLabel>Flip</FieldLabel>
-        <div className="flex flex-row items-center gap-x-2">
-          <Switch
-            checked={image.flip}
-            onCheckedChange={(checked) =>
-              updateImage(image.id, { flip: checked })
-            }
-          />
-          {image.flip ? "Yes" : "No"}
-        </div>
-      </Field>
-      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
-        <Field>
-          <FieldLabel>Scale</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={0.1}
-            value={image.transform.scale}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateImage(image.id, {
-                  transform: {
-                    ...image.transform,
-                    scale: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Rotation (&deg;)</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={image.transform.rotation}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateImage(image.id, {
-                  transform: {
-                    ...image.transform,
-                    rotation: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate X</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={image.transform.translation.x}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateImage(image.id, {
-                  transform: {
-                    ...image.transform,
-                    translation: {
-                      ...image.transform.translation,
-                      x: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate Y</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={image.transform.translation.y}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateImage(image.id, {
-                  transform: {
-                    ...image.transform,
-                    translation: {
-                      ...image.transform.translation,
-                      y: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-      </div>
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/ImagesPanel/ImageSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/ImagesPanel/ImageSettingsWidget.tsx
@@ -1,7 +1,16 @@
 import { type Image, MathUtils } from "@tissuumaps/core";
 
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  AccordionTrigger,
+  AccordionTriggerRightDownIcon,
+} from "@/components/common/accordion";
 import { Field, FieldLabel } from "@/components/common/field";
 import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
+import { SimpleSelect } from "@/components/common/simple-select";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import { cn } from "@/lib/utils";
@@ -16,8 +25,6 @@ export function ImageSettingsWidget({
   image,
   className,
 }: ImageSettingsWidgetProps) {
-  const updateImage = useTissUUmaps((state) => state.updateImage);
-
   return (
     <Fieldset
       className={cn("flex flex-col gap-y-2 border rounded-md p-2", className)}
@@ -25,6 +32,44 @@ export function ImageSettingsWidget({
       <FieldsetLegend className="font-medium text-foreground">
         Settings
       </FieldsetLegend>
+      <Accordion>
+        <AccordionItem value="general">
+          <AccordionHeader>
+            <AccordionTriggerRightDownIcon />
+            <AccordionTrigger>General</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
+            <GeneralImageSettingsWidget image={image} />
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value="transform">
+          <AccordionHeader>
+            <AccordionTriggerRightDownIcon />
+            <AccordionTrigger>Transform</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
+            <TransformImageSettingsWidget image={image} />
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </Fieldset>
+  );
+}
+
+type GeneralImageSettingsWidgetProps = {
+  image: Image;
+  className?: string;
+};
+
+function GeneralImageSettingsWidget({
+  image,
+  className,
+}: GeneralImageSettingsWidgetProps) {
+  const layers = useTissUUmaps((state) => state.layers);
+  const updateImage = useTissUUmaps((state) => state.updateImage);
+
+  return (
+    <div className={className}>
       <Field>
         <FieldLabel>Name</FieldLabel>
         <Input
@@ -32,6 +77,20 @@ export function ImageSettingsWidget({
           onChange={(event) =>
             updateImage(image.id, { name: event.target.value })
           }
+        />
+      </Field>
+      <Field>
+        <FieldLabel>Layer</FieldLabel>
+        <SimpleSelect
+          items={layers}
+          itemLabel={(l) => l.name}
+          itemValue={(l) => l.id}
+          value={image.layer}
+          onValueChange={(value) => {
+            if (value !== null) {
+              updateImage(image.id, { layer: value });
+            }
+          }}
         />
       </Field>
       <Field>
@@ -65,6 +124,119 @@ export function ImageSettingsWidget({
           }}
         />
       </Field>
-    </Fieldset>
+    </div>
+  );
+}
+
+type TransformImageSettingsWidgetProps = {
+  image: Image;
+  className?: string;
+};
+
+function TransformImageSettingsWidget({
+  image,
+  className,
+}: TransformImageSettingsWidgetProps) {
+  const updateImage = useTissUUmaps((state) => state.updateImage);
+
+  return (
+    <div className={className}>
+      <Field>
+        <FieldLabel>Flip</FieldLabel>
+        <div className="flex flex-row items-center gap-x-2">
+          <Switch
+            checked={image.flip}
+            onCheckedChange={(checked) =>
+              updateImage(image.id, { flip: checked })
+            }
+          />
+          {image.flip ? "Yes" : "No"}
+        </div>
+      </Field>
+      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
+        <Field>
+          <FieldLabel>Scale</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={0.1}
+            value={image.transform.scale}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateImage(image.id, {
+                  transform: {
+                    ...image.transform,
+                    scale: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Rotation (&deg;)</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={image.transform.rotation}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateImage(image.id, {
+                  transform: {
+                    ...image.transform,
+                    rotation: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate X</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={image.transform.translation.x}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateImage(image.id, {
+                  transform: {
+                    ...image.transform,
+                    translation: {
+                      ...image.transform.translation,
+                      x: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate Y</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={image.transform.translation.y}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateImage(image.id, {
+                  transform: {
+                    ...image.transform,
+                    translation: {
+                      ...image.transform.translation,
+                      y: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+      </div>
+    </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/ImagesPanel/category.ts
+++ b/apps/tissuumaps/src/components/panels/ImagesPanel/category.ts
@@ -1,0 +1,7 @@
+export const ImageSettingsCategory = {
+  general: "general",
+  transform: "transform",
+};
+
+export type ImageSettingsCategory =
+  (typeof ImageSettingsCategory)[keyof typeof ImageSettingsCategory];

--- a/apps/tissuumaps/src/components/panels/ImagesPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ImagesPanel/index.tsx
@@ -150,7 +150,6 @@ function ImageAccordionItem({ image, index }: ImageAccordionItemProps) {
             className="bg-card"
           />
           <ImageSettingsWidget image={image} className="bg-card" />
-          {/* TODO layer configs */}
         </AccordionPanel>
       </AccordionItem>
     </div>

--- a/apps/tissuumaps/src/components/panels/LabelsPanel/LabelsSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/LabelsPanel/LabelsSettingsWidget.tsx
@@ -16,6 +16,7 @@ import {
 } from "@/components/common/accordion";
 import { Field, FieldLabel } from "@/components/common/field";
 import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
+import { SimpleSelect } from "@/components/common/simple-select";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -111,6 +112,16 @@ export function LabelsSettingsWidget({
             <GeneralLabelsSettingsWidget labels={labels} />
           </AccordionPanel>
         </AccordionItem>
+        {/* Transform */}
+        <AccordionItem value={LabelsSettingsCategory.transform}>
+          <AccordionHeader>
+            <AccordionTriggerRightDownIcon />
+            <AccordionTrigger>Transform</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
+            <TransformLabelsSettingsWidget labels={labels} />
+          </AccordionPanel>
+        </AccordionItem>
         {/* Label color */}
         <AccordionItem value={LabelsSettingsCategory.labelColor}>
           <AccordionHeader>
@@ -181,6 +192,7 @@ function GeneralLabelsSettingsWidget({
   labels,
   className,
 }: GeneralLabelsSettingsWidgetProps) {
+  const layers = useTissUUmaps((state) => state.layers);
   const updateLabels = useTissUUmaps((state) => state.updateLabels);
 
   return (
@@ -192,6 +204,20 @@ function GeneralLabelsSettingsWidget({
           onChange={(event) =>
             updateLabels(labels.id, { name: event.target.value })
           }
+        />
+      </Field>
+      <Field>
+        <FieldLabel>Layer</FieldLabel>
+        <SimpleSelect
+          items={layers}
+          itemLabel={(l) => l.name}
+          itemValue={(l) => l.id}
+          value={labels.layer}
+          onValueChange={(value) => {
+            if (value !== null) {
+              updateLabels(labels.id, { layer: value });
+            }
+          }}
         />
       </Field>
       <Field>
@@ -225,6 +251,119 @@ function GeneralLabelsSettingsWidget({
           }}
         />
       </Field>
+    </div>
+  );
+}
+
+type TransformLabelsSettingsWidgetProps = {
+  labels: Labels;
+  className?: string;
+};
+
+function TransformLabelsSettingsWidget({
+  labels,
+  className,
+}: TransformLabelsSettingsWidgetProps) {
+  const updateLabels = useTissUUmaps((state) => state.updateLabels);
+
+  return (
+    <div className={className}>
+      <Field>
+        <FieldLabel>Flip</FieldLabel>
+        <div className="flex flex-row items-center gap-x-2">
+          <Switch
+            checked={labels.flip}
+            onCheckedChange={(checked) =>
+              updateLabels(labels.id, { flip: checked })
+            }
+          />
+          {labels.flip ? "Yes" : "No"}
+        </div>
+      </Field>
+      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
+        <Field>
+          <FieldLabel>Scale</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={0.1}
+            value={labels.transform.scale}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateLabels(labels.id, {
+                  transform: {
+                    ...labels.transform,
+                    scale: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Rotation (&deg;)</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={labels.transform.rotation}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateLabels(labels.id, {
+                  transform: {
+                    ...labels.transform,
+                    rotation: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate X</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={labels.transform.translation.x}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateLabels(labels.id, {
+                  transform: {
+                    ...labels.transform,
+                    translation: {
+                      ...labels.transform.translation,
+                      x: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate Y</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={labels.transform.translation.y}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateLabels(labels.id, {
+                  transform: {
+                    ...labels.transform,
+                    translation: {
+                      ...labels.transform.translation,
+                      y: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+      </div>
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/LabelsPanel/LabelsSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/LabelsPanel/LabelsSettingsWidget.tsx
@@ -19,6 +19,7 @@ import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
 import { SimpleSelect } from "@/components/common/simple-select";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { TransformSettingsWidget } from "@/components/widgets/TransformSettingsWidget";
 import {
   ActiveColorConfigValue,
   ColorConfigSourceToggleGroup,
@@ -119,7 +120,14 @@ export function LabelsSettingsWidget({
             <AccordionTrigger>Transform</AccordionTrigger>
           </AccordionHeader>
           <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
-            <TransformLabelsSettingsWidget labels={labels} />
+            <TransformSettingsWidget
+              transform={labels.transform}
+              onTransformChange={(transform) =>
+                updateLabels(labels.id, { transform })
+              }
+              flip={labels.flip}
+              onFlipChange={(flip) => updateLabels(labels.id, { flip })}
+            />
           </AccordionPanel>
         </AccordionItem>
         {/* Label color */}
@@ -251,119 +259,6 @@ function GeneralLabelsSettingsWidget({
           }}
         />
       </Field>
-    </div>
-  );
-}
-
-type TransformLabelsSettingsWidgetProps = {
-  labels: Labels;
-  className?: string;
-};
-
-function TransformLabelsSettingsWidget({
-  labels,
-  className,
-}: TransformLabelsSettingsWidgetProps) {
-  const updateLabels = useTissUUmaps((state) => state.updateLabels);
-
-  return (
-    <div className={className}>
-      <Field>
-        <FieldLabel>Flip</FieldLabel>
-        <div className="flex flex-row items-center gap-x-2">
-          <Switch
-            checked={labels.flip}
-            onCheckedChange={(checked) =>
-              updateLabels(labels.id, { flip: checked })
-            }
-          />
-          {labels.flip ? "Yes" : "No"}
-        </div>
-      </Field>
-      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
-        <Field>
-          <FieldLabel>Scale</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={0.1}
-            value={labels.transform.scale}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateLabels(labels.id, {
-                  transform: {
-                    ...labels.transform,
-                    scale: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Rotation (&deg;)</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={labels.transform.rotation}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateLabels(labels.id, {
-                  transform: {
-                    ...labels.transform,
-                    rotation: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate X</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={labels.transform.translation.x}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateLabels(labels.id, {
-                  transform: {
-                    ...labels.transform,
-                    translation: {
-                      ...labels.transform.translation,
-                      x: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate Y</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={labels.transform.translation.y}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateLabels(labels.id, {
-                  transform: {
-                    ...labels.transform,
-                    translation: {
-                      ...labels.transform.translation,
-                      y: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-      </div>
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/LabelsPanel/category.ts
+++ b/apps/tissuumaps/src/components/panels/LabelsPanel/category.ts
@@ -1,5 +1,6 @@
 export const LabelsSettingsCategory = {
   general: "general",
+  transform: "transform",
   labelColor: "labelColor",
   labelVisibility: "labelVisibility",
   labelOpacity: "labelOpacity",

--- a/apps/tissuumaps/src/components/panels/LabelsPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/LabelsPanel/index.tsx
@@ -191,7 +191,6 @@ function LabelsAccordionItem({ labels, index }: LabelsAccordionItemProps) {
             }}
             className="bg-card"
           />
-          {/* TODO layer configs */}
           <LabelsSettingsWidget
             labels={labels}
             activeCategory={activeSettingsCategory}

--- a/apps/tissuumaps/src/components/panels/PointsPanel/PointsSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/PointsPanel/PointsSettingsWidget.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/common/accordion";
 import { Field, FieldLabel } from "@/components/common/field";
 import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
+import { SimpleSelect } from "@/components/common/simple-select";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -140,6 +141,16 @@ export function PointsSettingsWidget({
             <GeneralPointsSettingsWidget points={points} />
           </AccordionPanel>
         </AccordionItem>
+        {/* Transform */}
+        <AccordionItem value={PointsSettingsCategory.transform}>
+          <AccordionHeader>
+            <AccordionTriggerRightDownIcon />
+            <AccordionTrigger>Transform</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
+            <TransformPointsSettingsWidget points={points} />
+          </AccordionPanel>
+        </AccordionItem>
         {/* Point marker */}
         <AccordionItem value={PointsSettingsCategory.pointMarker}>
           <AccordionHeader>
@@ -246,6 +257,7 @@ function GeneralPointsSettingsWidget({
   points,
   className,
 }: GeneralPointsSettingsWidgetProps) {
+  const layers = useTissUUmaps((state) => state.layers);
   const updatePoints = useTissUUmaps((state) => state.updatePoints);
 
   return (
@@ -258,6 +270,24 @@ function GeneralPointsSettingsWidget({
             updatePoints(points.id, { name: event.target.value })
           }
         />
+      </Field>
+      <Field>
+        <FieldLabel>Layer</FieldLabel>
+        {typeof points.layer === "string" ? (
+          <SimpleSelect
+            items={layers}
+            itemLabel={(l) => l.name}
+            itemValue={(l) => l.id}
+            value={points.layer}
+            onValueChange={(value) => {
+              if (value !== null) {
+                updatePoints(points.id, { layer: value });
+              }
+            }}
+          />
+        ) : (
+          <Input disabled value={`column: ${points.layer.column}`} readOnly />
+        )}
       </Field>
       <Field>
         <FieldLabel>Visibility</FieldLabel>
@@ -308,6 +338,119 @@ function GeneralPointsSettingsWidget({
           }}
         />
       </Field>
+    </div>
+  );
+}
+
+type TransformPointsSettingsWidgetProps = {
+  points: Points;
+  className?: string;
+};
+
+function TransformPointsSettingsWidget({
+  points,
+  className,
+}: TransformPointsSettingsWidgetProps) {
+  const updatePoints = useTissUUmaps((state) => state.updatePoints);
+
+  return (
+    <div className={className}>
+      <Field>
+        <FieldLabel>Flip</FieldLabel>
+        <div className="flex flex-row items-center gap-x-2">
+          <Switch
+            checked={points.flip}
+            onCheckedChange={(checked) =>
+              updatePoints(points.id, { flip: checked })
+            }
+          />
+          {points.flip ? "Yes" : "No"}
+        </div>
+      </Field>
+      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
+        <Field>
+          <FieldLabel>Scale</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={0.1}
+            value={points.transform.scale}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updatePoints(points.id, {
+                  transform: {
+                    ...points.transform,
+                    scale: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Rotation (&deg;)</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={points.transform.rotation}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updatePoints(points.id, {
+                  transform: {
+                    ...points.transform,
+                    rotation: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate X</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={points.transform.translation.x}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updatePoints(points.id, {
+                  transform: {
+                    ...points.transform,
+                    translation: {
+                      ...points.transform.translation,
+                      x: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate Y</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={points.transform.translation.y}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updatePoints(points.id, {
+                  transform: {
+                    ...points.transform,
+                    translation: {
+                      ...points.transform.translation,
+                      y: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+      </div>
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/PointsPanel/PointsSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/PointsPanel/PointsSettingsWidget.tsx
@@ -22,6 +22,7 @@ import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
 import { SimpleSelect } from "@/components/common/simple-select";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { TransformSettingsWidget } from "@/components/widgets/TransformSettingsWidget";
 import {
   ActiveColorConfigValue,
   ColorConfigSourceToggleGroup,
@@ -148,7 +149,14 @@ export function PointsSettingsWidget({
             <AccordionTrigger>Transform</AccordionTrigger>
           </AccordionHeader>
           <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
-            <TransformPointsSettingsWidget points={points} />
+            <TransformSettingsWidget
+              transform={points.transform}
+              onTransformChange={(transform) =>
+                updatePoints(points.id, { transform })
+              }
+              flip={points.flip}
+              onFlipChange={(flip) => updatePoints(points.id, { flip })}
+            />
           </AccordionPanel>
         </AccordionItem>
         {/* Point marker */}
@@ -338,119 +346,6 @@ function GeneralPointsSettingsWidget({
           }}
         />
       </Field>
-    </div>
-  );
-}
-
-type TransformPointsSettingsWidgetProps = {
-  points: Points;
-  className?: string;
-};
-
-function TransformPointsSettingsWidget({
-  points,
-  className,
-}: TransformPointsSettingsWidgetProps) {
-  const updatePoints = useTissUUmaps((state) => state.updatePoints);
-
-  return (
-    <div className={className}>
-      <Field>
-        <FieldLabel>Flip</FieldLabel>
-        <div className="flex flex-row items-center gap-x-2">
-          <Switch
-            checked={points.flip}
-            onCheckedChange={(checked) =>
-              updatePoints(points.id, { flip: checked })
-            }
-          />
-          {points.flip ? "Yes" : "No"}
-        </div>
-      </Field>
-      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
-        <Field>
-          <FieldLabel>Scale</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={0.1}
-            value={points.transform.scale}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updatePoints(points.id, {
-                  transform: {
-                    ...points.transform,
-                    scale: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Rotation (&deg;)</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={points.transform.rotation}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updatePoints(points.id, {
-                  transform: {
-                    ...points.transform,
-                    rotation: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate X</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={points.transform.translation.x}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updatePoints(points.id, {
-                  transform: {
-                    ...points.transform,
-                    translation: {
-                      ...points.transform.translation,
-                      x: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate Y</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={points.transform.translation.y}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updatePoints(points.id, {
-                  transform: {
-                    ...points.transform,
-                    translation: {
-                      ...points.transform.translation,
-                      y: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-      </div>
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/PointsPanel/category.ts
+++ b/apps/tissuumaps/src/components/panels/PointsPanel/category.ts
@@ -1,5 +1,6 @@
 export const PointsSettingsCategory = {
   general: "general",
+  transform: "transform",
   pointMarker: "pointMarker",
   pointSize: "pointSize",
   pointColor: "pointColor",

--- a/apps/tissuumaps/src/components/panels/PointsPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/PointsPanel/index.tsx
@@ -209,7 +209,6 @@ function PointsAccordionItem({ points, index }: PointsAccordionItemProps) {
             }}
             className="bg-card"
           />
-          {/* TODO layer configs */}
           <PointsSettingsWidget
             points={points}
             activeCategory={activeSettingsCategory}

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/LayerSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/LayerSettingsWidget.tsx
@@ -12,6 +12,7 @@ import { Field, FieldLabel } from "@/components/common/field";
 import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { TransformSettingsWidget } from "@/components/widgets/TransformSettingsWidget";
 import { useControlled } from "@/hooks/useControlled";
 import { cn } from "@/lib/utils";
 import { useTissUUmaps } from "@/store";
@@ -33,6 +34,8 @@ export function LayerSettingsWidget({
   onActiveCategoryChange: setControlledActiveCategory,
   className,
 }: LayerSettingsWidgetProps) {
+  const updateLayer = useTissUUmaps((state) => state.updateLayer);
+
   const [activeCategory, setActiveCategory] = useControlled(
     controlledActiveCategory,
     setControlledActiveCategory,
@@ -69,7 +72,12 @@ export function LayerSettingsWidget({
             <AccordionTrigger>Transform</AccordionTrigger>
           </AccordionHeader>
           <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
-            <TransformLayerSettingsWidget layer={layer} />
+            <TransformSettingsWidget
+              transform={layer.transform}
+              onTransformChange={(transform) =>
+                updateLayer(layer.id, { transform })
+              }
+            />
           </AccordionPanel>
         </AccordionItem>
       </Accordion>
@@ -148,107 +156,6 @@ function GeneralLayerSettingsWidget({
           }}
         />
       </Field>
-    </div>
-  );
-}
-
-type TransformLayerSettingsWidgetProps = {
-  layer: Layer;
-  className?: string;
-};
-
-function TransformLayerSettingsWidget({
-  layer,
-  className,
-}: TransformLayerSettingsWidgetProps) {
-  const updateLayer = useTissUUmaps((state) => state.updateLayer);
-
-  return (
-    <div className={className}>
-      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
-        <Field>
-          <FieldLabel>Scale</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={0.1}
-            value={layer.transform.scale}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateLayer(layer.id, {
-                  transform: {
-                    ...layer.transform,
-                    scale: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Rotation (&deg;)</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={layer.transform.rotation}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateLayer(layer.id, {
-                  transform: {
-                    ...layer.transform,
-                    rotation: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate X</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={layer.transform.translation.x}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateLayer(layer.id, {
-                  transform: {
-                    ...layer.transform,
-                    translation: {
-                      ...layer.transform.translation,
-                      x: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate Y</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={layer.transform.translation.y}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateLayer(layer.id, {
-                  transform: {
-                    ...layer.transform,
-                    translation: {
-                      ...layer.transform.translation,
-                      y: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-      </div>
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/LayerSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/LayerSettingsWidget.tsx
@@ -1,0 +1,254 @@
+import { type Layer, MathUtils } from "@tissuumaps/core";
+
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  AccordionTrigger,
+  AccordionTriggerRightDownIcon,
+} from "@/components/common/accordion";
+import { Field, FieldLabel } from "@/components/common/field";
+import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { useControlled } from "@/hooks/useControlled";
+import { cn } from "@/lib/utils";
+import { useTissUUmaps } from "@/store";
+
+import { LayerSettingsCategory } from "./category";
+
+export type LayerSettingsWidgetProps = {
+  layer: Layer;
+  activeCategory?: LayerSettingsCategory | null;
+  onActiveCategoryChange?: (
+    newActiveCategory: LayerSettingsCategory | null,
+  ) => void;
+  className?: string;
+};
+
+export function LayerSettingsWidget({
+  layer,
+  activeCategory: controlledActiveCategory,
+  onActiveCategoryChange: setControlledActiveCategory,
+  className,
+}: LayerSettingsWidgetProps) {
+  const [activeCategory, setActiveCategory] = useControlled(
+    controlledActiveCategory,
+    setControlledActiveCategory,
+    null,
+  );
+
+  return (
+    <Fieldset
+      className={cn("flex flex-col gap-y-2 border rounded-md p-2", className)}
+    >
+      <FieldsetLegend className="font-medium text-foreground">
+        Settings
+      </FieldsetLegend>
+      <Accordion
+        value={activeCategory !== null ? [activeCategory] : []}
+        onValueChange={(value) =>
+          setActiveCategory(
+            value.length > 0 ? (value[0] as LayerSettingsCategory) : null,
+          )
+        }
+      >
+        <AccordionItem value={LayerSettingsCategory.general}>
+          <AccordionHeader>
+            <AccordionTriggerRightDownIcon />
+            <AccordionTrigger>General</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
+            <GeneralLayerSettingsWidget layer={layer} />
+          </AccordionPanel>
+        </AccordionItem>
+        <AccordionItem value={LayerSettingsCategory.transform}>
+          <AccordionHeader>
+            <AccordionTriggerRightDownIcon />
+            <AccordionTrigger>Transform</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
+            <TransformLayerSettingsWidget layer={layer} />
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
+    </Fieldset>
+  );
+}
+
+type GeneralLayerSettingsWidgetProps = {
+  layer: Layer;
+  className?: string;
+};
+
+function GeneralLayerSettingsWidget({
+  layer,
+  className,
+}: GeneralLayerSettingsWidgetProps) {
+  const updateLayer = useTissUUmaps((state) => state.updateLayer);
+
+  return (
+    <div className={className}>
+      <Field>
+        <FieldLabel>Name</FieldLabel>
+        <Input
+          value={layer.name}
+          onChange={(event) =>
+            updateLayer(layer.id, { name: event.target.value })
+          }
+        />
+      </Field>
+      <Field>
+        <FieldLabel>Visibility</FieldLabel>
+        <div className="flex flex-row items-center gap-x-2">
+          <Switch
+            checked={layer.visibility}
+            onCheckedChange={(checked) =>
+              updateLayer(layer.id, { visibility: checked })
+            }
+          />
+          {layer.visibility ? "Visible" : "Hidden"}
+        </div>
+      </Field>
+      <Field>
+        <FieldLabel>Opacity</FieldLabel>
+        <Input
+          type="number"
+          inputMode="decimal"
+          step={0.05}
+          min={0}
+          max={1}
+          value={layer.opacity}
+          onChange={(event) => {
+            const newValue = event.target.valueAsNumber;
+            if (!isNaN(newValue)) {
+              updateLayer(layer.id, {
+                opacity: MathUtils.clamp(newValue, 0, 1),
+              });
+            }
+          }}
+        />
+      </Field>
+      <Field>
+        <FieldLabel>Point size factor</FieldLabel>
+        <Input
+          type="number"
+          inputMode="decimal"
+          step={0.1}
+          min={0}
+          value={layer.pointSizeFactor}
+          onChange={(event) => {
+            const newValue = event.target.valueAsNumber;
+            if (!isNaN(newValue)) {
+              updateLayer(layer.id, {
+                pointSizeFactor: Math.max(0, newValue),
+              });
+            }
+          }}
+        />
+      </Field>
+    </div>
+  );
+}
+
+type TransformLayerSettingsWidgetProps = {
+  layer: Layer;
+  className?: string;
+};
+
+function TransformLayerSettingsWidget({
+  layer,
+  className,
+}: TransformLayerSettingsWidgetProps) {
+  const updateLayer = useTissUUmaps((state) => state.updateLayer);
+
+  return (
+    <div className={className}>
+      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
+        <Field>
+          <FieldLabel>Scale</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={0.1}
+            value={layer.transform.scale}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateLayer(layer.id, {
+                  transform: {
+                    ...layer.transform,
+                    scale: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Rotation (&deg;)</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={layer.transform.rotation}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateLayer(layer.id, {
+                  transform: {
+                    ...layer.transform,
+                    rotation: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate X</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={layer.transform.translation.x}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateLayer(layer.id, {
+                  transform: {
+                    ...layer.transform,
+                    translation: {
+                      ...layer.transform.translation,
+                      x: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate Y</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={layer.transform.translation.y}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateLayer(layer.id, {
+                  transform: {
+                    ...layer.transform,
+                    translation: {
+                      ...layer.transform.translation,
+                      y: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+      </div>
+    </div>
+  );
+}

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/category.ts
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/category.ts
@@ -1,0 +1,7 @@
+export const LayerSettingsCategory = {
+  general: "general",
+  transform: "transform",
+};
+
+export type LayerSettingsCategory =
+  (typeof LayerSettingsCategory)[keyof typeof LayerSettingsCategory];

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/index.tsx
@@ -1,0 +1,190 @@
+import { DragDropProvider } from "@dnd-kit/react";
+import { isSortable, useSortable } from "@dnd-kit/react/sortable";
+import {
+  EyeIcon,
+  EyeOffIcon,
+  GripVertical,
+  PlusIcon,
+  Trash2Icon,
+} from "lucide-react";
+import { useMemo } from "react";
+
+import { type Layer, MathUtils, createLayer } from "@tissuumaps/core";
+
+import {
+  Accordion,
+  AccordionHeader,
+  AccordionItem,
+  AccordionPanel,
+  AccordionTrigger,
+  AccordionTriggerUpDownIcon,
+} from "@/components/common/accordion";
+import { Button } from "@/components/ui/button";
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from "@/components/ui/input-group";
+import { cn } from "@/lib/utils";
+import { useTissUUmaps } from "@/store";
+
+import { LayerSettingsWidget } from "./LayerSettingsWidget";
+
+export type LayersWidgetProps = {
+  className?: string;
+};
+
+export function LayersWidget({ className }: LayersWidgetProps) {
+  const layers = useTissUUmaps((state) => state.layers);
+  const addLayer = useTissUUmaps((state) => state.addLayer);
+  const moveLayer = useTissUUmaps((state) => state.moveLayer);
+
+  return (
+    <div className={cn("flex flex-col gap-y-2", className)}>
+      <DragDropProvider
+        onDragEnd={(event) => {
+          const { source, canceled } = event.operation;
+          if (isSortable(source) && !canceled) {
+            moveLayer(source.id as string, source.index);
+          }
+        }}
+      >
+        <Accordion multiple className="gap-y-2">
+          {layers.map((layer, index) => (
+            <LayerAccordionItem key={layer.id} layer={layer} index={index} />
+          ))}
+        </Accordion>
+      </DragDropProvider>
+      <Button
+        variant="outline"
+        className="w-full"
+        onClick={() => {
+          const layer = createLayer({
+            id: crypto.randomUUID(),
+            name: `Layer ${layers.length + 1}`,
+          });
+          addLayer(layer);
+        }}
+      >
+        <PlusIcon className="size-4" />
+        Add
+      </Button>
+    </div>
+  );
+}
+
+function useLayerObjects(layerId: string) {
+  const images = useTissUUmaps((state) => state.images);
+  const labels = useTissUUmaps((state) => state.labels);
+  const points = useTissUUmaps((state) => state.points);
+  const shapes = useTissUUmaps((state) => state.shapes);
+
+  return useMemo(() => {
+    const names: string[] = [];
+    for (const image of images) {
+      if (image.layer === layerId) names.push(image.name);
+    }
+    for (const l of labels) {
+      if (l.layer === layerId) names.push(l.name);
+    }
+    for (const p of points) {
+      if (p.layer === layerId) names.push(p.name);
+    }
+    for (const s of shapes) {
+      if (s.layer === layerId) names.push(s.name);
+    }
+    return names;
+  }, [layerId, images, labels, points, shapes]);
+}
+
+type LayerAccordionItemProps = {
+  layer: Layer;
+  index: number;
+};
+
+function LayerAccordionItem({ layer, index }: LayerAccordionItemProps) {
+  const updateLayer = useTissUUmaps((state) => state.updateLayer);
+  const deleteLayer = useTissUUmaps((state) => state.deleteLayer);
+
+  const objectNames = useLayerObjects(layer.id);
+  const hasObjects = objectNames.length > 0;
+
+  const { ref, handleRef } = useSortable({ id: layer.id, index });
+
+  return (
+    <div ref={ref}>
+      <AccordionItem className="border rounded-md bg-sidebar p-2">
+        <AccordionHeader>
+          <GripVertical ref={handleRef} />
+          <div className="flex-1 w-full">
+            <AccordionTrigger className="w-full cursor-pointer">
+              {layer.name}
+              {hasObjects && (
+                <span className="ml-1 text-xs text-muted-foreground">
+                  ({objectNames.length})
+                </span>
+              )}
+            </AccordionTrigger>
+          </div>
+          <div className="ml-auto flex flex-row items-center gap-x-2">
+            <InputGroup className="w-20">
+              <InputGroupAddon>&alpha;</InputGroupAddon>
+              <InputGroupInput
+                type="number"
+                inputMode="decimal"
+                step={0.05}
+                min={0}
+                max={1}
+                value={layer.opacity}
+                onChange={(event) => {
+                  const newValue = event.target.valueAsNumber;
+                  if (!isNaN(newValue)) {
+                    updateLayer(layer.id, {
+                      opacity: MathUtils.clamp(newValue, 0, 1),
+                    });
+                  }
+                }}
+              />
+            </InputGroup>
+            <Button
+              variant="ghost"
+              onClick={() =>
+                updateLayer(layer.id, { visibility: !layer.visibility })
+              }
+            >
+              {layer.visibility ? <EyeIcon /> : <EyeOffIcon />}
+            </Button>
+            <Button
+              variant="ghost"
+              disabled={hasObjects}
+              onClick={() => {
+                // TODO replace by dialog overlay
+                if (
+                  window.confirm("Are you sure you want to delete this layer?")
+                ) {
+                  deleteLayer(layer.id);
+                }
+              }}
+              title={
+                hasObjects
+                  ? "Cannot delete a layer that contains objects"
+                  : "Delete layer"
+              }
+            >
+              <Trash2Icon />
+            </Button>
+          </div>
+          <AccordionTriggerUpDownIcon />
+        </AccordionHeader>
+        <AccordionPanel className="pt-2 flex flex-col gap-y-2">
+          {hasObjects && (
+            <div className="text-xs text-muted-foreground px-1">
+              {objectNames.join(", ")}
+            </div>
+          )}
+          <LayerSettingsWidget layer={layer} className="bg-card" />
+        </AccordionPanel>
+      </AccordionItem>
+    </div>
+  );
+}

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/LayersWidget/index.tsx
@@ -113,7 +113,10 @@ function LayerAccordionItem({ layer, index }: LayerAccordionItemProps) {
 
   return (
     <div ref={ref}>
-      <AccordionItem className="border rounded-md bg-sidebar p-2">
+      <AccordionItem
+        value={layer.id}
+        className="border rounded-md bg-sidebar p-2"
+      >
         <AccordionHeader>
           <GripVertical ref={handleRef} />
           <div className="flex-1 w-full">

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
@@ -13,6 +13,7 @@ import { Input } from "@/components/ui/input";
 import { useProjectDownload } from "@/hooks/useProjectDownload";
 import { useTissUUmaps } from "@/store";
 
+import { LayersWidget } from "./LayersWidget";
 import { ProjectSettingsDialog } from "./ProjectSettingsDialog";
 
 export type ProjectPanelProps = {
@@ -123,6 +124,8 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
           />
         </Field>
       </div>
+      <h3 className="mt-4 mb-2 font-medium text-foreground">Project Layers</h3>
+      <LayersWidget />
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useRef } from "react";
 
 import { Field, FieldControl, FieldLabel } from "@/components/common/field";
+import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -124,8 +125,12 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
           />
         </Field>
       </div>
-      <h3 className="mt-4 mb-2 font-medium text-foreground">Project Layers</h3>
-      <LayersWidget />
+      <Fieldset className="mt-4 flex flex-col gap-y-2">
+        <FieldsetLegend className="font-medium text-foreground">
+          Project Layers
+        </FieldsetLegend>
+        <LayersWidget />
+      </Fieldset>
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/ShapesPanel/ShapesSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/ShapesPanel/ShapesSettingsWidget.tsx
@@ -22,6 +22,7 @@ import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
 import { SimpleSelect } from "@/components/common/simple-select";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
+import { TransformSettingsWidget } from "@/components/widgets/TransformSettingsWidget";
 import {
   ActiveColorConfigValue,
   ColorConfigSourceToggleGroup,
@@ -146,7 +147,14 @@ export function ShapesSettingsWidget({
             <AccordionTrigger>Transform</AccordionTrigger>
           </AccordionHeader>
           <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
-            <TransformShapesSettingsWidget shapes={shapes} />
+            <TransformSettingsWidget
+              transform={shapes.transform}
+              onTransformChange={(transform) =>
+                updateShapes(shapes.id, { transform })
+              }
+              flip={shapes.flip}
+              onFlipChange={(flip) => updateShapes(shapes.id, { flip })}
+            />
           </AccordionPanel>
         </AccordionItem>
         {/* Shape fill color */}
@@ -342,119 +350,6 @@ function GeneralShapesSettingsWidget({
           }}
         />
       </Field>
-    </div>
-  );
-}
-
-type TransformShapesSettingsWidgetProps = {
-  shapes: Shapes;
-  className?: string;
-};
-
-function TransformShapesSettingsWidget({
-  shapes,
-  className,
-}: TransformShapesSettingsWidgetProps) {
-  const updateShapes = useTissUUmaps((state) => state.updateShapes);
-
-  return (
-    <div className={className}>
-      <Field>
-        <FieldLabel>Flip</FieldLabel>
-        <div className="flex flex-row items-center gap-x-2">
-          <Switch
-            checked={shapes.flip}
-            onCheckedChange={(checked) =>
-              updateShapes(shapes.id, { flip: checked })
-            }
-          />
-          {shapes.flip ? "Yes" : "No"}
-        </div>
-      </Field>
-      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
-        <Field>
-          <FieldLabel>Scale</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={0.1}
-            value={shapes.transform.scale}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateShapes(shapes.id, {
-                  transform: {
-                    ...shapes.transform,
-                    scale: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Rotation (&deg;)</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={shapes.transform.rotation}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateShapes(shapes.id, {
-                  transform: {
-                    ...shapes.transform,
-                    rotation: parseFloat(e.target.value),
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate X</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={shapes.transform.translation.x}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateShapes(shapes.id, {
-                  transform: {
-                    ...shapes.transform,
-                    translation: {
-                      ...shapes.transform.translation,
-                      x: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-        <Field>
-          <FieldLabel>Translate Y</FieldLabel>
-          <Input
-            type="number"
-            inputMode="decimal"
-            step={1}
-            value={shapes.transform.translation.y}
-            onChange={(e) => {
-              if (e.target.value !== "") {
-                updateShapes(shapes.id, {
-                  transform: {
-                    ...shapes.transform,
-                    translation: {
-                      ...shapes.transform.translation,
-                      y: parseFloat(e.target.value),
-                    },
-                  },
-                });
-              }
-            }}
-          />
-        </Field>
-      </div>
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/ShapesPanel/ShapesSettingsWidget.tsx
+++ b/apps/tissuumaps/src/components/panels/ShapesPanel/ShapesSettingsWidget.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/common/accordion";
 import { Field, FieldLabel } from "@/components/common/field";
 import { Fieldset, FieldsetLegend } from "@/components/common/fieldset";
+import { SimpleSelect } from "@/components/common/simple-select";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
 import {
@@ -136,6 +137,16 @@ export function ShapesSettingsWidget({
           </AccordionHeader>
           <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
             <GeneralShapesSettingsWidget shapes={shapes} />
+          </AccordionPanel>
+        </AccordionItem>
+        {/* Transform */}
+        <AccordionItem value={ShapesSettingsCategory.transform}>
+          <AccordionHeader>
+            <AccordionTriggerRightDownIcon />
+            <AccordionTrigger>Transform</AccordionTrigger>
+          </AccordionHeader>
+          <AccordionPanel className="flex flex-col p-2 pl-6 pb-4 gap-2">
+            <TransformShapesSettingsWidget shapes={shapes} />
           </AccordionPanel>
         </AccordionItem>
         {/* Shape fill color */}
@@ -268,6 +279,7 @@ function GeneralShapesSettingsWidget({
   shapes,
   className,
 }: GeneralShapesSettingsWidgetProps) {
+  const layers = useTissUUmaps((state) => state.layers);
   const updateShapes = useTissUUmaps((state) => state.updateShapes);
 
   return (
@@ -280,6 +292,24 @@ function GeneralShapesSettingsWidget({
             updateShapes(shapes.id, { name: event.target.value })
           }
         />
+      </Field>
+      <Field>
+        <FieldLabel>Layer</FieldLabel>
+        {typeof shapes.layer === "string" ? (
+          <SimpleSelect
+            items={layers}
+            itemLabel={(l) => l.name}
+            itemValue={(l) => l.id}
+            value={shapes.layer}
+            onValueChange={(value) => {
+              if (value !== null) {
+                updateShapes(shapes.id, { layer: value });
+              }
+            }}
+          />
+        ) : (
+          <Input disabled value={`column: ${shapes.layer.column}`} readOnly />
+        )}
       </Field>
       <Field>
         <FieldLabel>Visibility</FieldLabel>
@@ -312,6 +342,119 @@ function GeneralShapesSettingsWidget({
           }}
         />
       </Field>
+    </div>
+  );
+}
+
+type TransformShapesSettingsWidgetProps = {
+  shapes: Shapes;
+  className?: string;
+};
+
+function TransformShapesSettingsWidget({
+  shapes,
+  className,
+}: TransformShapesSettingsWidgetProps) {
+  const updateShapes = useTissUUmaps((state) => state.updateShapes);
+
+  return (
+    <div className={className}>
+      <Field>
+        <FieldLabel>Flip</FieldLabel>
+        <div className="flex flex-row items-center gap-x-2">
+          <Switch
+            checked={shapes.flip}
+            onCheckedChange={(checked) =>
+              updateShapes(shapes.id, { flip: checked })
+            }
+          />
+          {shapes.flip ? "Yes" : "No"}
+        </div>
+      </Field>
+      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
+        <Field>
+          <FieldLabel>Scale</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={0.1}
+            value={shapes.transform.scale}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateShapes(shapes.id, {
+                  transform: {
+                    ...shapes.transform,
+                    scale: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Rotation (&deg;)</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={shapes.transform.rotation}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateShapes(shapes.id, {
+                  transform: {
+                    ...shapes.transform,
+                    rotation: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate X</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={shapes.transform.translation.x}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateShapes(shapes.id, {
+                  transform: {
+                    ...shapes.transform,
+                    translation: {
+                      ...shapes.transform.translation,
+                      x: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate Y</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={shapes.transform.translation.y}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                updateShapes(shapes.id, {
+                  transform: {
+                    ...shapes.transform,
+                    translation: {
+                      ...shapes.transform.translation,
+                      y: parseFloat(e.target.value),
+                    },
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+      </div>
     </div>
   );
 }

--- a/apps/tissuumaps/src/components/panels/ShapesPanel/category.ts
+++ b/apps/tissuumaps/src/components/panels/ShapesPanel/category.ts
@@ -1,5 +1,6 @@
 export const ShapesSettingsCategory = {
   general: "general",
+  transform: "transform",
   shapeFillColor: "shapeFillColor",
   shapeFillVisibility: "shapeFillVisibility",
   shapeFillOpacity: "shapeFillOpacity",

--- a/apps/tissuumaps/src/components/panels/ShapesPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ShapesPanel/index.tsx
@@ -191,7 +191,6 @@ function ShapesAccordionItem({ shapes, index }: ShapesAccordionItemProps) {
             }}
             className="bg-card"
           />
-          {/* TODO layer configs */}
           <ShapesSettingsWidget
             shapes={shapes}
             activeCategory={activeSettingsCategory}

--- a/apps/tissuumaps/src/components/widgets/TransformSettingsWidget/index.tsx
+++ b/apps/tissuumaps/src/components/widgets/TransformSettingsWidget/index.tsx
@@ -39,10 +39,11 @@ export function TransformSettingsWidget({
             step={0.1}
             value={transform.scale}
             onChange={(e) => {
-              if (e.target.value !== "") {
+              const newValue = e.target.valueAsNumber;
+              if (!isNaN(newValue)) {
                 onTransformChange({
                   ...transform,
-                  scale: parseFloat(e.target.value),
+                  scale: newValue,
                 });
               }
             }}
@@ -56,10 +57,11 @@ export function TransformSettingsWidget({
             step={1}
             value={transform.rotation}
             onChange={(e) => {
-              if (e.target.value !== "") {
+              const newValue = e.target.valueAsNumber;
+              if (!isNaN(newValue)) {
                 onTransformChange({
                   ...transform,
-                  rotation: parseFloat(e.target.value),
+                  rotation: newValue,
                 });
               }
             }}
@@ -73,12 +75,13 @@ export function TransformSettingsWidget({
             step={1}
             value={transform.translation.x}
             onChange={(e) => {
-              if (e.target.value !== "") {
+              const newValue = e.target.valueAsNumber;
+              if (!isNaN(newValue)) {
                 onTransformChange({
                   ...transform,
                   translation: {
                     ...transform.translation,
-                    x: parseFloat(e.target.value),
+                    x: newValue,
                   },
                 });
               }
@@ -93,12 +96,13 @@ export function TransformSettingsWidget({
             step={1}
             value={transform.translation.y}
             onChange={(e) => {
-              if (e.target.value !== "") {
+              const newValue = e.target.valueAsNumber;
+              if (!isNaN(newValue)) {
                 onTransformChange({
                   ...transform,
                   translation: {
                     ...transform.translation,
-                    y: parseFloat(e.target.value),
+                    y: newValue,
                   },
                 });
               }

--- a/apps/tissuumaps/src/components/widgets/TransformSettingsWidget/index.tsx
+++ b/apps/tissuumaps/src/components/widgets/TransformSettingsWidget/index.tsx
@@ -1,0 +1,111 @@
+import { type SimilarityTransform } from "@tissuumaps/core";
+
+import { Field, FieldLabel } from "@/components/common/field";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+
+export type TransformSettingsWidgetProps = {
+  transform: SimilarityTransform;
+  onTransformChange: (transform: SimilarityTransform) => void;
+  flip?: boolean;
+  onFlipChange?: (flip: boolean) => void;
+  className?: string;
+};
+
+export function TransformSettingsWidget({
+  transform,
+  onTransformChange,
+  flip,
+  onFlipChange,
+  className,
+}: TransformSettingsWidgetProps) {
+  return (
+    <div className={className}>
+      {onFlipChange !== undefined && (
+        <Field>
+          <FieldLabel>Flip</FieldLabel>
+          <div className="flex flex-row items-center gap-x-2">
+            <Switch checked={flip} onCheckedChange={onFlipChange} />
+            {flip ? "Yes" : "No"}
+          </div>
+        </Field>
+      )}
+      <div className="grid grid-cols-2 gap-x-2 gap-y-2">
+        <Field>
+          <FieldLabel>Scale</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={0.1}
+            value={transform.scale}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                onTransformChange({
+                  ...transform,
+                  scale: parseFloat(e.target.value),
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Rotation (&deg;)</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={transform.rotation}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                onTransformChange({
+                  ...transform,
+                  rotation: parseFloat(e.target.value),
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate X</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={transform.translation.x}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                onTransformChange({
+                  ...transform,
+                  translation: {
+                    ...transform.translation,
+                    x: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>Translate Y</FieldLabel>
+          <Input
+            type="number"
+            inputMode="decimal"
+            step={1}
+            value={transform.translation.y}
+            onChange={(e) => {
+              if (e.target.value !== "") {
+                onTransformChange({
+                  ...transform,
+                  translation: {
+                    ...transform.translation,
+                    y: parseFloat(e.target.value),
+                  },
+                });
+              }
+            }}
+          />
+        </Field>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
# References and relevant issues

# Type of change

- [x] Improvement (non-breaking change which modifies an existing feature)

# List of changes made

- Added a Layer selector field in the General section of all object settings panels (Images, Points, Shapes, Labels)
- Added a dedicated Transform accordion section (Flip, Scale, Rotation, Translate X/Y) to all object settings panels, moved out from General
- Added `transform` to `PointsSettingsCategory`, `ShapesSettingsCategory` and `LabelsSettingsCategory` enums
- Created `ImagesPanel/category.ts` with `ImageSettingsCategory` enum
- Refactored `ImageSettingsWidget` to use accordion sections (General, Transform) consistent with other panels
- Removed stale `TODO layer configs` comments from `ImagesPanel`, `PointsPanel`, `ShapesPanel` and `LabelsPanel`
- Added `layers` widget in project panel

# Screenshot of the fix

<img width="370" height="363" alt="image" src="https://github.com/user-attachments/assets/e62860e9-9271-4d40-be4f-78ab8839b8e9" />

<img width="368" height="305" alt="image" src="https://github.com/user-attachments/assets/d1d020b9-b63d-4781-995d-eee2881004f0" />


# Use of AI

Claude Opus 4.6 was used.

# Testing

- Rebuild needed
- Open each panel (Images, Points, Shapes, Labels), expand an object's settings and verify:
  - General section contains Name, Layer, Visibility and Opacity fields
  - Transform section contains Flip, Scale, Rotation, Translate X and Translate Y fields

# Further comments