### PR TITLE
fix: Use integer type for OME-Zarr channel, slice, and timepoint fields

### DIFF
--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
@@ -25,13 +25,13 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
       },
       // TODO path
       c: {
-        type: "number",
+        type: "integer",
       },
       z: {
-        type: "number",
+        type: "integer",
       },
       t: {
-        type: "number",
+        type: "integer",
       },
     },
     required: ["url"], // TODO ... or path


### PR DESCRIPTION
# References and relevant issues

N/A

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# List of changes made

- Changed JSON Schema type for `c`, `z`, and `t` properties from `"number"` to `"integer"` in `OMEZarrImageDataProvider`, so that the form inputs only accept whole numbers for Channel, Z-slice, and Timepoint.

# Use of AI

This PR was created with the assistance of Claude Code (Claude Opus 4.6).

# Testing

- Open the OME-Zarr data source form and verify that Channel, Z-slice, and Timepoint inputs only accept integer values (no decimals).

# Further comments

N/A