### PR TITLE
perf(core): yield to the event loop during point and shape marshalling

### DIFF
--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -29,6 +29,7 @@ import {
 import { type PointsData } from "../storage/points";
 import { type TableData } from "../storage/table";
 import { type Rect } from "../types";
+import { AsyncUtils } from "../utils/AsyncUtils";
 import { TransformUtils } from "../utils/TransformUtils";
 import { WebGLUtils } from "../utils/WebGLUtils";
 import { ColorDataUtils } from "../utils/data/ColorDataUtils";
@@ -517,12 +518,7 @@ export class WebGLPointsController extends WebGLControllerBase {
           }
           dataCache.set(currentPoints.id, data);
         }
-        if (data === undefined) {
-          continue;
-        }
-
-        let numPoints = data.getSize();
-        if (numPoints === 0) {
+        if (data === undefined || data.getSize() === 0) {
           continue;
         }
 
@@ -567,21 +563,41 @@ export class WebGLPointsController extends WebGLControllerBase {
           }
         }
 
+        const pointIds = data.getIds();
+        let pointMask: boolean[] | undefined;
+        let filteredPointIds: number[];
         if (pointLayers !== undefined) {
-          numPoints = data
-            .getIds()
-            .filter((id) => pointLayers.get(id) === layer.id).length;
-          if (numPoints === 0) {
+          const newPointMask = new Array<boolean>(pointIds.length);
+          const newFilteredPointIds: number[] = [];
+          await AsyncUtils.forEach(
+            pointIds,
+            (id, i) => {
+              const include = pointLayers.get(id) === layer.id;
+              newPointMask[i] = include;
+              if (include) {
+                newFilteredPointIds.push(id);
+              }
+            },
+            { signal },
+          );
+          signal?.throwIfAborted();
+          if (newFilteredPointIds.length === 0) {
             continue;
           }
+          pointMask = newPointMask;
+          filteredPointIds = newFilteredPointIds;
+        } else {
+          pointMask = undefined;
+          filteredPointIds = pointIds;
         }
 
         refs.push({
           data,
           layer,
           points: currentPoints,
-          numPoints,
-          pointLayers,
+          numPoints: filteredPointIds.length,
+          pointMask,
+          filteredPointIds,
         });
       }
     }
@@ -620,15 +636,7 @@ export class WebGLPointsController extends WebGLControllerBase {
     const newBufferSliceStates: PointsBufferSliceState[] = [];
     for (let i = 0; i < refs.length; i++) {
       const ref = refs[i]!;
-      const pointIds = ref.data.getIds();
-      const pointMask =
-        ref.pointLayers !== undefined
-          ? pointIds.map((id) => ref.pointLayers!.get(id) === ref.layer.id)
-          : undefined;
-      const filteredPointIds =
-        pointMask !== undefined
-          ? pointIds.filter((_, j) => pointMask[j])
-          : pointIds;
+      const { pointMask, filteredPointIds } = ref;
       const bufferSliceState = this._bufferSliceStates[i];
       const bufferSliceChanged =
         buffersResized ||
@@ -637,7 +645,7 @@ export class WebGLPointsController extends WebGLControllerBase {
         bufferSliceState.ref.layer.id !== ref.layer.id ||
         bufferSliceState.ref.points.id !== ref.points.id ||
         bufferSliceState.ref.numPoints !== ref.numPoints ||
-        // check config.points.layer instead of ref.pointLayers
+        // check config.points.layer instead of ref.pointMask and ref.filteredPointIds
         !deepEqual(bufferSliceState.config.points.layer, ref.points.layer) ||
         !deepEqual(
           bufferSliceState.ref.points.dataSource,
@@ -925,7 +933,8 @@ type PointsRef = {
   layer: Layer;
   points: Points;
   numPoints: number;
-  pointLayers: Map<number, string> | undefined;
+  pointMask: boolean[] | undefined;
+  filteredPointIds: number[];
 };
 
 /**

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -21,6 +21,7 @@ import {
 import { type ShapesData } from "../storage/shapes";
 import { type TableData } from "../storage/table";
 import { type MultiPolygon, type Rect, type Vertex } from "../types";
+import { AsyncUtils } from "../utils/AsyncUtils";
 import { MathUtils } from "../utils/MathUtils";
 import { TransformUtils } from "../utils/TransformUtils";
 import { WebGLUtils } from "../utils/WebGLUtils";
@@ -351,12 +352,7 @@ export class WebGLShapesController extends WebGLControllerBase {
           }
           dataCache.set(currentShapes.id, data);
         }
-        if (data === undefined) {
-          continue;
-        }
-
-        let numShapes = data.getSize();
-        if (numShapes === 0) {
+        if (data === undefined || data.getSize() === 0) {
           continue;
         }
 
@@ -401,21 +397,41 @@ export class WebGLShapesController extends WebGLControllerBase {
           }
         }
 
+        const shapeIds = data.getIds();
+        let shapeMask: boolean[] | undefined;
+        let filteredShapeIds: number[];
         if (shapeLayers !== undefined) {
-          numShapes = data
-            .getIds()
-            .filter((id) => shapeLayers.get(id) === layer.id).length;
-          if (numShapes === 0) {
+          const newShapeMask = new Array<boolean>(shapeIds.length);
+          const newFilteredShapeIds: number[] = [];
+          await AsyncUtils.forEach(
+            shapeIds,
+            (id, i) => {
+              const include = shapeLayers.get(id) === layer.id;
+              newShapeMask[i] = include;
+              if (include) {
+                newFilteredShapeIds.push(id);
+              }
+            },
+            { signal },
+          );
+          signal?.throwIfAborted();
+          if (newFilteredShapeIds.length === 0) {
             continue;
           }
+          shapeMask = newShapeMask;
+          filteredShapeIds = newFilteredShapeIds;
+        } else {
+          shapeMask = undefined;
+          filteredShapeIds = shapeIds;
         }
 
         refs.push({
           data,
           layer,
           shapes: currentShapes,
-          numShapes,
-          shapeLayers,
+          numShapes: filteredShapeIds.length,
+          shapeMask,
+          filteredShapeIds,
         });
       }
     }
@@ -440,7 +456,7 @@ export class WebGLShapesController extends WebGLControllerBase {
           ref.layer.id === glShapes.ref.layer.id &&
           ref.shapes.id === glShapes.ref.shapes.id &&
           ref.numShapes === glShapes.ref.numShapes &&
-          // check config.shapes.layer instead of ref.shapeLayers
+          // check config.shapes.layer instead of ref.shapeMask and ref.filteredShapeIds
           deepEqual(ref.shapes.layer, glShapes.config.shapes.layer) &&
           deepEqual(ref.shapes.dataSource, glShapes.ref.shapes.dataSource),
       );
@@ -482,15 +498,7 @@ export class WebGLShapesController extends WebGLControllerBase {
     const newGLShapes = [];
     for (const ref of refs) {
       const glShapes = glShapesByRef.get(ref);
-      const shapeIds = ref.data.getIds();
-      const shapeMask =
-        ref.shapeLayers !== undefined
-          ? shapeIds.map((id) => ref.shapeLayers!.get(id) === ref.layer.id)
-          : undefined;
-      const filteredShapeIds =
-        shapeMask !== undefined
-          ? shapeIds.filter((_, j) => shapeMask[j])
-          : shapeIds;
+      const { shapeMask, filteredShapeIds } = ref;
       let dataBounds = glShapes?.dataBounds;
       let scanlineDataTexture = glShapes?.scanlineDataTexture;
       if (
@@ -503,10 +511,14 @@ export class WebGLShapesController extends WebGLControllerBase {
         if (shapeMask !== undefined) {
           multiPolygons = multiPolygons.filter((_, j) => shapeMask[j]);
         }
-        dataBounds = WebGLShapesController._getDataBounds(multiPolygons);
-        scanlineDataTexture = this._createScanlineDataTexture(
+        dataBounds = await WebGLShapesController._getDataBounds(multiPolygons, {
+          signal,
+        });
+        signal?.throwIfAborted();
+        scanlineDataTexture = await this._createScanlineDataTexture(
           multiPolygons,
           dataBounds,
+          { signal },
         );
         signal?.throwIfAborted();
       }
@@ -615,24 +627,30 @@ export class WebGLShapesController extends WebGLControllerBase {
    * @param multiPolygons - Polygon geometry for each shape in the object
    * @param objectBounds - Axis-aligned bounding box of all shapes
    */
-  private _createScanlineDataTexture(
+  private async _createScanlineDataTexture(
     multiPolygons: MultiPolygon[],
     objectBounds: Rect,
-  ): WebGLTexture {
+    options?: { signal?: AbortSignal },
+  ): Promise<WebGLTexture> {
+    const { signal } = options ?? {};
+    signal?.throwIfAborted();
     const numValuesPerTextureLine =
       4 * WebGLShapesController._scanlineDataTextureWidth; // 4 values per RGBA32F texel
     const { scanlines, totalNumScanlineShapes, totalNumScanlineShapeEdges } =
-      WebGLShapesController._createScanlines(
+      await WebGLShapesController._createScanlines(
         this._numScanlines,
         multiPolygons,
         objectBounds,
+        { signal },
       );
-    const scanlineBuffer = WebGLShapesController._packScanlines(
+    signal?.throwIfAborted();
+    const scanlineBuffer = await WebGLShapesController._packScanlines(
       scanlines,
       totalNumScanlineShapes,
       totalNumScanlineShapeEdges,
-      { align: numValuesPerTextureLine },
+      { align: numValuesPerTextureLine, signal },
     );
+    signal?.throwIfAborted();
     const scanlineData = new Float32Array(scanlineBuffer);
     const scanlineDataTexture = WebGLUtils.createDataTexture(
       this.gl,
@@ -833,7 +851,12 @@ export class WebGLShapesController extends WebGLControllerBase {
    * @param multiPolygons - Polygon geometry
    * @returns The bounding rectangle in data-space coordinates
    */
-  private static _getDataBounds(multiPolygons: MultiPolygon[]): Rect {
+  private static async _getDataBounds(
+    multiPolygons: MultiPolygon[],
+    options?: { signal?: AbortSignal },
+  ): Promise<Rect> {
+    const { signal } = options ?? {};
+    signal?.throwIfAborted();
     if (multiPolygons.length === 0) {
       throw new Error("Multi-polygons array must not be empty");
     }
@@ -841,6 +864,7 @@ export class WebGLShapesController extends WebGLControllerBase {
       yMin = Infinity,
       xMax = -Infinity,
       yMax = -Infinity;
+    const maybeYield = AsyncUtils.createYielder({ signal });
     for (const multiPolygon of multiPolygons) {
       for (const polygon of multiPolygon.polygons) {
         for (const path of [polygon.shell, ...polygon.holes]) {
@@ -860,6 +884,7 @@ export class WebGLShapesController extends WebGLControllerBase {
           }
         }
       }
+      await maybeYield();
     }
     return { x: xMin, y: yMin, width: xMax - xMin, height: yMax - yMin };
   }
@@ -876,15 +901,18 @@ export class WebGLShapesController extends WebGLControllerBase {
    * @param objectBounds - Bounding box of all shapes
    * @returns Scanlines with per-shape edges, and total counts for buffer sizing
    */
-  private static _createScanlines(
+  private static async _createScanlines(
     numScanlines: number,
     multiPolygons: MultiPolygon[],
     objectBounds: Rect,
-  ): {
+    options?: { signal?: AbortSignal },
+  ): Promise<{
     scanlines: Scanline[];
     totalNumScanlineShapes: number;
     totalNumScanlineShapeEdges: number;
-  } {
+  }> {
+    const { signal } = options ?? {};
+    signal?.throwIfAborted();
     const scanlines: Scanline[] = Array.from({ length: numScanlines }, () => ({
       xMin: Infinity,
       xMax: -Infinity,
@@ -893,6 +921,7 @@ export class WebGLShapesController extends WebGLControllerBase {
     }));
     let totalNumScanlineShapes = 0;
     let totalNumScanlineShapeEdges = 0;
+    const maybeYield = AsyncUtils.createYielder({ signal });
     for (let shapeIndex = 0; shapeIndex < multiPolygons.length; shapeIndex++) {
       for (const polygon of multiPolygons[shapeIndex]!.polygons) {
         // compute shape xMin/xMax/occupancy mask
@@ -1002,6 +1031,7 @@ export class WebGLShapesController extends WebGLControllerBase {
           }
         }
       }
+      await maybeYield();
     }
     return { scanlines, totalNumScanlineShapes, totalNumScanlineShapeEdges };
   }
@@ -1017,15 +1047,16 @@ export class WebGLShapesController extends WebGLControllerBase {
    * @param scanlines - Rasterized scanlines from {@link _createScanlines}
    * @param totalNumScanlineShapes - Total shape entries across all scanlines
    * @param totalNumScanlineShapeEdges - Total edge entries across all scanlines
-   * @param options - Optional alignment for the buffer to texture line boundaries
+   * @param options - Optional buffer alignment (to texture line boundaries) and abort signal
    */
-  private static _packScanlines(
+  private static async _packScanlines(
     scanlines: Scanline[],
     totalNumScanlineShapes: number,
     totalNumScanlineShapeEdges: number,
-    options?: { align?: number },
-  ): ArrayBuffer {
-    const { align = 1 } = options ?? {};
+    options?: { align?: number; signal?: AbortSignal },
+  ): Promise<ArrayBuffer> {
+    const { align = 1, signal } = options ?? {};
+    signal?.throwIfAborted();
     const buffer = new ArrayBuffer(
       MathUtils.align(
         4 * scanlines.length + // header -> scanline info S
@@ -1038,6 +1069,7 @@ export class WebGLShapesController extends WebGLControllerBase {
     const float32Data = new Float32Array(buffer);
     const uint32Data = new Uint32Array(buffer);
     let currentScanlineTexelOffset = scanlines.length;
+    const maybeYield = AsyncUtils.createYielder({ signal });
     for (let s = 0; s < scanlines.length; s++) {
       const scanline = scanlines[s]!;
       // header
@@ -1074,6 +1106,7 @@ export class WebGLShapesController extends WebGLControllerBase {
         currentScanlineShapeTexelOffset = currentScanlineShapeEdgeTexelOffset;
       }
       currentScanlineTexelOffset = currentScanlineShapeTexelOffset;
+      await maybeYield();
     }
     return buffer;
   }
@@ -1084,7 +1117,8 @@ type ShapesRef = {
   layer: Layer;
   shapes: Shapes;
   numShapes: number;
-  shapeLayers: Map<number, string> | undefined;
+  shapeMask: boolean[] | undefined;
+  filteredShapeIds: number[];
   data: ShapesData;
 };
 

--- a/packages/@tissuumaps-core/src/index.ts
+++ b/packages/@tissuumaps-core/src/index.ts
@@ -21,6 +21,7 @@ export * from "./storage/points";
 export * from "./storage/shapes";
 export * from "./storage/table";
 
+export { AsyncUtils } from "./utils/AsyncUtils";
 export { ColorUtils } from "./utils/ColorUtils";
 export { HashUtils } from "./utils/HashUtils";
 export { MathUtils } from "./utils/MathUtils";

--- a/packages/@tissuumaps-core/src/utils/AsyncUtils.test.ts
+++ b/packages/@tissuumaps-core/src/utils/AsyncUtils.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { AsyncUtils } from "./AsyncUtils";
+
+describe("AsyncUtils.yield", () => {
+  it("resolves", async () => {
+    await expect(AsyncUtils.yield()).resolves.toBeUndefined();
+  });
+
+  it("resolves concurrent waiters in order", async () => {
+    const order: number[] = [];
+    await Promise.all([
+      AsyncUtils.yield().then(() => order.push(0)),
+      AsyncUtils.yield().then(() => order.push(1)),
+      AsyncUtils.yield().then(() => order.push(2)),
+    ]);
+    expect(order).toEqual([0, 1, 2]);
+  });
+});
+
+describe("AsyncUtils.forEach", () => {
+  it("invokes body with each item and index in order", async () => {
+    const seen: [string, number][] = [];
+    await AsyncUtils.forEach(["a", "b", "c"], (item, i) => {
+      seen.push([item, i]);
+    });
+    expect(seen).toEqual([
+      ["a", 0],
+      ["b", 1],
+      ["c", 2],
+    ]);
+  });
+
+  it("does nothing for an empty collection", async () => {
+    const body = vi.fn();
+    await AsyncUtils.forEach([], body);
+    expect(body).not.toHaveBeenCalled();
+  });
+
+  it("supports typed arrays", async () => {
+    const seen: number[] = [];
+    await AsyncUtils.forEach(new Uint32Array([10, 20, 30]), (item) => {
+      seen.push(item);
+    });
+    expect(seen).toEqual([10, 20, 30]);
+  });
+
+  it("covers items spanning multiple chunks", async () => {
+    const items = Array.from({ length: 11 }, (_, i) => i);
+    let count = 0;
+    let last = -1;
+    await AsyncUtils.forEach(
+      items,
+      (item, i) => {
+        expect(i).toBe(last + 1);
+        expect(item).toBe(i);
+        last = i;
+        count++;
+      },
+      { yieldMs: -1, checkEvery: 4 },
+    );
+    expect(count).toBe(items.length);
+    expect(last).toBe(items.length - 1);
+  });
+
+  it("throws immediately when the signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const body = vi.fn();
+    await expect(
+      AsyncUtils.forEach([1, 2, 3], body, { signal: controller.signal }),
+    ).rejects.toThrow();
+    expect(body).not.toHaveBeenCalled();
+  });
+
+  it("stops and rejects when aborted mid-iteration", async () => {
+    const controller = new AbortController();
+    const seen: number[] = [];
+    const items = Array.from({ length: 16 }, (_, i) => i);
+    const promise = AsyncUtils.forEach(
+      items,
+      (item) => {
+        seen.push(item);
+        if (item === 3) {
+          controller.abort();
+        }
+      },
+      { signal: controller.signal, yieldMs: -1, checkEvery: 4 },
+    );
+    await expect(promise).rejects.toThrow();
+    // The first chunk (4 items) runs fully, then the post-yield abort check stops it.
+    expect(seen.length).toBe(4);
+  });
+});
+
+describe("AsyncUtils.createYielder", () => {
+  it("yields when the time budget is exceeded", async () => {
+    const yielder = AsyncUtils.createYielder({ yieldMs: -1 });
+    // yieldMs < 0 means every call exceeds the budget and yields.
+    await expect(yielder()).resolves.toBeUndefined();
+  });
+
+  it("is a no-op while within the time budget", async () => {
+    const yielder = AsyncUtils.createYielder({ yieldMs: 60_000 });
+    await expect(yielder()).resolves.toBeUndefined();
+  });
+
+  it("throws on the abort check after yielding", async () => {
+    const controller = new AbortController();
+    const yielder = AsyncUtils.createYielder({
+      signal: controller.signal,
+      yieldMs: -1,
+    });
+    controller.abort();
+    await expect(yielder()).rejects.toThrow();
+  });
+
+  it("does not throw while within budget even if aborted", async () => {
+    const controller = new AbortController();
+    const yielder = AsyncUtils.createYielder({
+      signal: controller.signal,
+      yieldMs: 60_000,
+    });
+    controller.abort();
+    await expect(yielder()).resolves.toBeUndefined();
+  });
+});

--- a/packages/@tissuumaps-core/src/utils/AsyncUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/AsyncUtils.ts
@@ -1,0 +1,99 @@
+/**
+ * Utility methods for running large CPU workloads on the main thread without
+ * blocking the UI, by cooperatively yielding to the event loop
+ */
+export class AsyncUtils {
+  // Shared MessageChannel used as a macrotask scheduler when `scheduler.yield()`
+  // is unavailable. A single channel with a FIFO queue of resolvers avoids
+  // allocating a channel per yield. MessageChannel delivers one message per
+  // `postMessage`, in order, so the n-th message resolves the n-th waiter.
+  private static _messageChannel: MessageChannel | undefined;
+  private static _pendingResolvers: (() => void)[] = [];
+
+  /**
+   * Yields control back to the event loop, allowing the browser to paint and
+   * process input before resuming.
+   *
+   * Uses the native `scheduler.yield()` when available, otherwise falls back to
+   * a shared `MessageChannel` (a macrotask without `setTimeout`'s clamping).
+   */
+  static yield(): Promise<void> {
+    const scheduler = (
+      globalThis as { scheduler?: { yield?: () => Promise<void> } }
+    ).scheduler;
+    if (typeof scheduler?.yield === "function") {
+      return scheduler.yield();
+    }
+    if (AsyncUtils._messageChannel === undefined) {
+      AsyncUtils._messageChannel = new MessageChannel();
+      AsyncUtils._messageChannel.port1.onmessage = () => {
+        AsyncUtils._pendingResolvers.shift()?.();
+      };
+    }
+    return new Promise<void>((resolve) => {
+      AsyncUtils._pendingResolvers.push(resolve);
+      AsyncUtils._messageChannel!.port2.postMessage(undefined);
+    });
+  }
+
+  /**
+   * Creates a time-sliced yielder for loops whose iterations are too coarse or
+   * heterogeneous for {@link AsyncUtils.forEach} (e.g. nested loops).
+   *
+   * Call the returned function at safe points inside a loop: it yields to the
+   * event loop and re-checks the abort signal once the time budget since the
+   * last yield is exceeded, and is otherwise a cheap no-op.
+   *
+   * @param options - Optional abort signal and time (ms) to run before yielding
+   *   (`yieldMs`)
+   */
+  static createYielder(options?: {
+    signal?: AbortSignal;
+    yieldMs?: number;
+  }): () => Promise<void> {
+    const { signal, yieldMs = 5 } = options ?? {};
+    let start = performance.now();
+    return async () => {
+      if (performance.now() - start > yieldMs) {
+        await AsyncUtils.yield();
+        signal?.throwIfAborted();
+        start = performance.now();
+      }
+    };
+  }
+
+  /**
+   * Invokes `callback(item, index)` for every element of `items`, yielding to
+   * the event loop whenever the time budget is exceeded so the UI stays
+   * responsive.
+   *
+   * The abort signal is checked up front and after every yield, preserving
+   * fail-fast cancellation: an abort rejects with the signal's reason and no
+   * further iterations run.
+   *
+   * @param items - The array-like collection to iterate over
+   * @param callback - Synchronous work to perform for each `item` and its `index`
+   * @param options - Optional abort signal, time (ms) to run before yielding
+   *   (`yieldMs`), and the number of iterations between budget checks
+   *   (`checkEvery`)
+   */
+  static async forEach<T>(
+    items: ArrayLike<T>,
+    callback: (item: T, index: number) => void,
+    options?: {
+      signal?: AbortSignal;
+      yieldMs?: number;
+      checkEvery?: number;
+    },
+  ): Promise<void> {
+    const { signal, yieldMs, checkEvery = 1024 } = options ?? {};
+    signal?.throwIfAborted();
+    const maybeYield = AsyncUtils.createYielder({ signal, yieldMs });
+    for (let i = 0; i < items.length; i++) {
+      callback(items[i]!, i);
+      if ((i + 1) % checkEvery === 0 && i + 1 < items.length) {
+        await maybeYield();
+      }
+    }
+  }
+}

--- a/packages/@tissuumaps-core/src/utils/data/ColorDataUtils.test.ts
+++ b/packages/@tissuumaps-core/src/utils/data/ColorDataUtils.test.ts
@@ -363,7 +363,7 @@ describe("ColorDataUtils", () => {
   });
 
   describe("loadRandomColorData", () => {
-    it("returns buffer with colors from the palette", () => {
+    it("returns buffer with colors from the palette", async () => {
       const palette = colorPalettes[0]!;
       const ids = [1, 2, 3];
       const config = {
@@ -371,7 +371,7 @@ describe("ColorDataUtils", () => {
         random: { palette: palette.id },
       };
 
-      const data = ColorDataUtils.loadRandomColorData(ids, config, black);
+      const data = await ColorDataUtils.loadRandomColorData(ids, config, black);
 
       expect(data.length).toBe(3);
       const validEncodings = palette.colors.map((c) =>
@@ -382,14 +382,14 @@ describe("ColorDataUtils", () => {
       }
     });
 
-    it("returns uniform default color when palette is not found", () => {
+    it("returns uniform default color when palette is not found", async () => {
       const ids = [1, 2];
       const config = {
         source: "random" as const,
         random: { palette: "nonexistent" },
       };
 
-      const data = ColorDataUtils.loadRandomColorData(ids, config, red);
+      const data = await ColorDataUtils.loadRandomColorData(ids, config, red);
 
       expect(data[0]).toBe(ColorDataUtils.encodeColor(red));
       expect(data[1]).toBe(ColorDataUtils.encodeColor(red));

--- a/packages/@tissuumaps-core/src/utils/data/ColorDataUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/data/ColorDataUtils.ts
@@ -13,6 +13,7 @@ import {
 import { type Color, type DefaultMap } from "../../model/types";
 import { type ColorPalette, colorPalettes } from "../../palettes";
 import { type TableData } from "../../storage/table";
+import { AsyncUtils } from "../AsyncUtils";
 import { ColorUtils } from "../ColorUtils";
 import { HashUtils } from "../HashUtils";
 import { MathUtils } from "../MathUtils";
@@ -91,22 +92,30 @@ export class ColorDataUtils extends DataUtilsBase {
       );
       signal?.throwIfAborted();
     } else if (activeConfigSource === "random" && isRandomConfig(config)) {
-      data = ColorDataUtils.loadRandomColorData(ids, config, defaultColor, {
-        align,
-      });
+      data = await ColorDataUtils.loadRandomColorData(
+        ids,
+        config,
+        defaultColor,
+        { signal, align },
+      );
+      signal?.throwIfAborted();
     } else {
       console.warn("No valid color config found, using default color");
       data = ColorDataUtils.createUniformColorData(ids.length, defaultColor, {
         align,
       });
     }
-    for (let i = 0; i < ids.length; i++) {
-      let c = MathUtils.safeLeftShift(data[i]!, 8);
-      if (visibilityData === undefined || visibilityData[i]! > 0) {
-        c += opacityData !== undefined ? opacityData[i]! : 255;
-      }
-      data[i] = c;
-    }
+    await AsyncUtils.forEach(
+      ids,
+      (_, i) => {
+        let c = MathUtils.safeLeftShift(data[i]!, 8);
+        if (visibilityData === undefined || visibilityData[i]! > 0) {
+          c += opacityData !== undefined ? opacityData[i]! : 255;
+        }
+        data[i] = c;
+      },
+      { signal },
+    );
     return data;
   }
 
@@ -279,16 +288,17 @@ export class ColorDataUtils extends DataUtilsBase {
    * @param ids - Ordered list of item IDs
    * @param config - Random configuration specifying the palette to sample from
    * @param defaultColor - Fallback color when the palette is not found
-   * @param options - Optional buffer alignment
+   * @param options - Optional abort signal and buffer alignment
    * @returns A `Uint32Array` of encoded random color values
    */
-  static loadRandomColorData(
+  static async loadRandomColorData(
     ids: number[],
     config: Extract<ColorConfig, RandomConfig<unknown>>,
     defaultColor: Color,
-    options?: { align?: number },
-  ): Uint32Array {
-    const { align = 1 } = options ?? {};
+    options?: { signal?: AbortSignal; align?: number },
+  ): Promise<Uint32Array> {
+    const { signal, align = 1 } = options ?? {};
+    signal?.throwIfAborted();
     const colorPalette = colorPalettes.find(
       (colorPalette) => colorPalette.id === config.random.palette,
     );
@@ -301,11 +311,15 @@ export class ColorDataUtils extends DataUtilsBase {
       });
     }
     const data = ColorDataUtils._createColorDataBuffer(ids.length, { align });
-    for (let i = 0; i < ids.length; i++) {
-      const index = Math.floor(Math.random() * colorPalette.colors.length);
-      const color = colorPalette.colors[index]!;
-      data[i] = ColorDataUtils.encodeColor(color);
-    }
+    await AsyncUtils.forEach(
+      ids,
+      (_, i) => {
+        const index = Math.floor(Math.random() * colorPalette.colors.length);
+        const color = colorPalette.colors[index]!;
+        data[i] = ColorDataUtils.encodeColor(color);
+      },
+      { signal },
+    );
     return data;
   }
 

--- a/packages/@tissuumaps-core/src/utils/data/DataUtilsBase.ts
+++ b/packages/@tissuumaps-core/src/utils/data/DataUtilsBase.ts
@@ -1,5 +1,6 @@
 import { type TableData } from "../../storage/table";
 import { type TypedArray } from "../../types";
+import { AsyncUtils } from "../AsyncUtils";
 
 export class DataUtilsBase {
   /**
@@ -39,21 +40,29 @@ export class DataUtilsBase {
     const tableValueRange = await tableData.loadValueRange(column, { signal });
     signal?.throwIfAborted();
     const tableValuesById = new Map<number, unknown>();
-    tableData.getIds().forEach((id, i) => {
-      tableValuesById.set(id, tableValues[i]);
-    });
-    ids.forEach((id, i) => {
-      if (tableValuesById.has(id)) {
-        const tableValue = tableValuesById.get(id);
-        const parsedValue = parseTableValue(tableValue, tableValueRange);
-        data[i] = encodeValue(parsedValue ?? defaultValue);
-      } else {
-        console.warn(
-          `ID ${id} is missing from loaded table data (column ${column})`,
-        );
-        data[i] = encodeValue(defaultValue);
-      }
-    });
+    await AsyncUtils.forEach(
+      tableData.getIds(),
+      (id, i) => {
+        tableValuesById.set(id, tableValues[i]);
+      },
+      { signal },
+    );
+    await AsyncUtils.forEach(
+      ids,
+      (id, i) => {
+        if (tableValuesById.has(id)) {
+          const tableValue = tableValuesById.get(id);
+          const parsedValue = parseTableValue(tableValue, tableValueRange);
+          data[i] = encodeValue(parsedValue ?? defaultValue);
+        } else {
+          console.warn(
+            `ID ${id} is missing from loaded table data (column ${column})`,
+          );
+          data[i] = encodeValue(defaultValue);
+        }
+      },
+      { signal },
+    );
   }
 
   /**
@@ -89,21 +98,35 @@ export class DataUtilsBase {
     const tableGroups = await tableData.loadValues(column, { signal });
     signal?.throwIfAborted();
     const tableGroupsById = new Map<number, unknown>();
-    tableData.getIds().forEach((id, i) => {
-      tableGroupsById.set(id, tableGroups[i]);
-    });
-    ids.forEach((id, i) => {
-      if (tableGroupsById.has(id)) {
-        const tableGroup = tableGroupsById.get(id);
-        const group = JSON.stringify(tableGroup);
-        const value = mapGroupToValue(group);
-        data[i] = encodeValue(value ?? defaultValue);
-      } else {
-        console.warn(
-          `ID ${id} is missing from loaded table data (column ${column})`,
-        );
-        data[i] = encodeValue(defaultValue);
-      }
-    });
+    await AsyncUtils.forEach(
+      tableData.getIds(),
+      (id, i) => {
+        tableGroupsById.set(id, tableGroups[i]);
+      },
+      { signal },
+    );
+    const encodedValueByTableGroup = new Map<unknown, number>();
+    await AsyncUtils.forEach(
+      ids,
+      (id, i) => {
+        if (tableGroupsById.has(id)) {
+          const tableGroup = tableGroupsById.get(id);
+          let encodedValue = encodedValueByTableGroup.get(tableGroup);
+          if (encodedValue === undefined) {
+            const group = JSON.stringify(tableGroup);
+            const value = mapGroupToValue(group);
+            encodedValue = encodeValue(value ?? defaultValue);
+            encodedValueByTableGroup.set(tableGroup, encodedValue);
+          }
+          data[i] = encodedValue;
+        } else {
+          console.warn(
+            `ID ${id} is missing from loaded table data (column ${column})`,
+          );
+          data[i] = encodeValue(defaultValue);
+        }
+      },
+      { signal },
+    );
   }
 }


### PR DESCRIPTION
# References and relevant issues

Jira: **TMAP-150**

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

CPU-side marshalling of point/shape attributes into GPU buffers previously ran as synchronous O(N) loops on the main thread, freezing the UI while large datasets loaded. This PR makes that work non-blocking via cooperative yielding.

- Add `AsyncUtils` (`yield`, `forEach`, `createYielder`): time-budgeted (~5 ms) cooperative yielding to the event loop, with fail-fast `AbortSignal` cancellation.
- Marshal point attributes (coordinates, marker, size, visibility, opacity, color) in yielding chunks instead of synchronous loops, so the UI stays responsive while large point clouds load (`WebGLPointsController`, `DataUtilsBase`, `ColorDataUtils`).
- Apply the same chunked yielding to shape rasterization — scanline creation/packing and fill/stroke color textures (`WebGLShapesController`).
- Compute each object's per-layer item mask and filtered id list once in `_loadPoints`/`_loadShapes` and reuse it, removing the duplicate `getIds()` + filter previously run per object.
- Rendering output is unchanged — this is purely a responsiveness change plus a small dedup.

# Screenshot of the fix

N/A — no visual change.

# Use of AI

Yes. Planned and implemented with Claude Code (Claude Opus 4.8) in an agent session; the diff and tests were reviewed before committing.

# Testing

Instructions on how to test:

- Unit tests: `pnpm --filter @tissuumaps/core test` (adds `AsyncUtils.test.ts`; updates `ColorDataUtils`/`DataUtilsBase` tests).
- Manual: `pnpm dev`, load a large points dataset (table-backed group-by color is the heaviest path) and confirm the UI stays interactive (panels, hover, viewport pan) during loading, and that the rendered result matches `development`.

# Further comments

Targets `development`. No new dependencies and no config changes required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
