### PR TITLE
fix: Always add dummy background image covering point data bounds

### DIFF
--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -526,7 +526,6 @@ export class OpenSeadragonController {
 
   private _updateDummy(dummyBounds: Rect | null): void {
     if (dummyBounds !== null && this._dummyTiledImage === undefined) {
-      const fitBounds = this._tiledImageStates.length === 0;
       const index = this.viewer.world.getItemCount();
       this.viewer.addTiledImage({
         tileSource: {
@@ -539,7 +538,11 @@ export class OpenSeadragonController {
         width: dummyBounds.width,
         height: dummyBounds.height,
         success: (event) => {
-          if (!fitBounds) return;
+          // Re-check the live state instead of a value captured before this
+          // async callback: only fit to the dummy bounds while no real images
+          // are present, otherwise a real image added in the meantime would
+          // cause an unexpected viewport jump.
+          if (this._tiledImageStates.length > 0) return;
           const { item: tiledImage } = event as unknown as {
             item: OpenSeadragon.TiledImage;
           };

--- a/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
+++ b/packages/@tissuumaps-core/src/controllers/OpenSeadragonController.ts
@@ -525,11 +525,8 @@ export class OpenSeadragonController {
   }
 
   private _updateDummy(dummyBounds: Rect | null): void {
-    if (
-      this._tiledImageStates.length === 0 &&
-      this._dummyTiledImage === undefined &&
-      dummyBounds !== null
-    ) {
+    if (dummyBounds !== null && this._dummyTiledImage === undefined) {
+      const fitBounds = this._tiledImageStates.length === 0;
       const index = this.viewer.world.getItemCount();
       this.viewer.addTiledImage({
         tileSource: {
@@ -542,6 +539,7 @@ export class OpenSeadragonController {
         width: dummyBounds.width,
         height: dummyBounds.height,
         success: (event) => {
+          if (!fitBounds) return;
           const { item: tiledImage } = event as unknown as {
             item: OpenSeadragon.TiledImage;
           };
@@ -549,10 +547,13 @@ export class OpenSeadragonController {
         },
       });
       this._dummyTiledImage = this.viewer.world.getItemAt(index);
-    } else if (
-      this._tiledImageStates.length > 0 &&
-      this._dummyTiledImage !== undefined
-    ) {
+    } else if (dummyBounds !== null && this._dummyTiledImage !== undefined) {
+      this._dummyTiledImage.setPosition(
+        new OpenSeadragon.Point(dummyBounds.x, dummyBounds.y),
+        true,
+      );
+      this._dummyTiledImage.setWidth(dummyBounds.width, true);
+    } else if (dummyBounds === null && this._dummyTiledImage !== undefined) {
       this.viewer.world.removeItem(this._dummyTiledImage);
       this._dummyTiledImage = undefined;
     }


### PR DESCRIPTION
Previously the transparent dummy image was only created when no real images were loaded. This caused the viewport to be locked to a tiny real image when point data extended far beyond it. The dummy is now always added so OpenSeadragon's world bounds cover all points.

# References and relevant issues

Jira issue: TMAP-341

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# List of changes made

- Always create the transparent dummy image when point data bounds exist, regardless of whether real images are loaded. Previously it was only created when no real images were present.
- Update dummy position and size on subsequent synchronize calls when bounds change, instead of only creating it once.
- Only fit viewport to dummy bounds when there are no real images, preserving existing viewport behavior when a real image is loaded.
- Remove the dummy only when there is no point data at all (`dummyBounds` is null).

# Screenshot of the fix

N/A

# Use of AI

This PR was created with the assistance of Claude Code (Claude Opus 4.6).

# Testing

- Load a project with a small real image and point data that extends far beyond the image bounds
- Verify the viewport can pan and zoom to reach all point data
- Load a project with no real image and only point data — verify it still fits to the points as before
- Load a project with a normal-sized image and point data within the image — verify no regression

# Further comments

N/A