### PR TITLE
perf(storage): parse data off the main thread (CSV/Parquet/GeoJSON workers)

### DIFF
--- a/apps/tissuumaps/src/store/adapters/LoadedShapesDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedShapesDataAdapter.ts
@@ -1,9 +1,9 @@
 import { useCallback } from "react";
 
 import {
-  type MultiPolygon,
   type ProgressCallback,
   type ShapesData,
+  type ShapesGeometry,
 } from "@tissuumaps/core";
 import { type ViewerAdapter } from "@tissuumaps/viewer";
 
@@ -28,14 +28,14 @@ export class LoadedShapesDataAdapter implements ShapesData {
     return this._getData().getNames();
   }
 
-  async loadMultiPolygons(options?: {
+  async loadGeometry(options?: {
     signal?: AbortSignal;
     onProgress?: ProgressCallback;
-  }): Promise<MultiPolygon[]> {
+  }): Promise<ShapesGeometry> {
     const { signal, onProgress } = options ?? {};
     signal?.throwIfAborted();
     const state = useTissUUmaps.getState();
-    return await state.loadShapesMultiPolygons(this._shapesId, {
+    return await state.loadShapesGeometry(this._shapesId, {
       signal,
       onProgress,
     });

--- a/apps/tissuumaps/src/store/slices/shapes.ts
+++ b/apps/tissuumaps/src/store/slices/shapes.ts
@@ -1,11 +1,11 @@
 import { deepEqual } from "fast-equals";
 
 import {
-  type MultiPolygon,
   type ProgressCallback,
   type Shapes,
   type ShapesData,
   type ShapesDataSource,
+  type ShapesGeometry,
 } from "@tissuumaps/core";
 
 import { deduplicate } from "../deduplicate";
@@ -14,7 +14,7 @@ import { type TissUUmapsStateCreator } from "../index";
 type LoadedShapesData = {
   dataSource: ShapesDataSource;
   data: ShapesData;
-  loadedMultiPolygons?: MultiPolygon[];
+  loadedGeometry?: ShapesGeometry;
 };
 
 export type ShapesSlice = ShapesSliceState & ShapesSliceActions;
@@ -40,14 +40,14 @@ export type ShapesSliceActions = {
       newDataSource?: ShapesDataSource;
     },
   ) => Promise<ShapesData>;
-  loadShapesMultiPolygons: (
+  loadShapesGeometry: (
     shapesId: string,
     options?: {
       signal?: AbortSignal;
       reload?: boolean;
       onProgress?: ProgressCallback;
     },
-  ) => Promise<MultiPolygon[]>;
+  ) => Promise<ShapesGeometry>;
   unloadShapes: (shapesId: string) => boolean;
 };
 
@@ -233,11 +233,11 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
     },
     (_shapesId, options) => options?.signal,
   ),
-  loadShapesMultiPolygons: deduplicate(
+  loadShapesGeometry: deduplicate(
     async (shapesId, options) => {
       const { signal, reload = false, onProgress } = options ?? {};
       signal?.throwIfAborted();
-      // Check if the shapes, the corresponding data source, and the requested multi-polygons are already loaded
+      // Check if the shapes, the corresponding data source, and the requested geometry are already loaded
       const state = get();
       const loadedDataKey = state.loadedShapes.get(shapesId);
       if (loadedDataKey === undefined) {
@@ -249,11 +249,11 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
           `Data source for shapes with ID ${shapesId} not loaded.`,
         );
       }
-      if (loadedData.loadedMultiPolygons !== undefined && !reload) {
-        return loadedData.loadedMultiPolygons;
+      if (loadedData.loadedGeometry !== undefined && !reload) {
+        return loadedData.loadedGeometry;
       }
-      // Load the requested multi-polygons
-      const multiPolygons = await loadedData.data.loadMultiPolygons({
+      // Load the requested geometry
+      const geometry = await loadedData.data.loadGeometry({
         signal,
         onProgress,
       });
@@ -281,13 +281,13 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
           "AbortError",
         );
       }
-      // Store the loaded multi-polygons in the state
+      // Store the loaded geometry in the state
       set((draft) => {
         const loadedDataDraft =
           draft.loadedShapesData.get(currentLoadedDataKey)!;
-        loadedDataDraft.loadedMultiPolygons = multiPolygons;
+        loadedDataDraft.loadedGeometry = geometry;
       });
-      return multiPolygons;
+      return geometry;
     },
     (_shapesId, options) => options?.signal,
   ),

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -20,7 +20,7 @@ import {
 } from "../model/types";
 import { type ShapesData } from "../storage/shapes";
 import { type TableData } from "../storage/table";
-import { type MultiPolygon, type Rect, type Vertex } from "../types";
+import { type Rect, type ShapesGeometry, type Vertex } from "../types";
 import { AsyncUtils } from "../utils/AsyncUtils";
 import { MathUtils } from "../utils/MathUtils";
 import { TransformUtils } from "../utils/TransformUtils";
@@ -506,17 +506,17 @@ export class WebGLShapesController extends WebGLControllerBase {
         dataBounds === undefined ||
         scanlineDataTexture === undefined
       ) {
-        let multiPolygons = await ref.data.loadMultiPolygons({ signal });
+        const geometry = await ref.data.loadGeometry({ signal });
         signal?.throwIfAborted();
-        if (shapeMask !== undefined) {
-          multiPolygons = multiPolygons.filter((_, j) => shapeMask[j]);
-        }
-        dataBounds = await WebGLShapesController._getDataBounds(multiPolygons, {
-          signal,
-        });
+        dataBounds = await WebGLShapesController._getDataBounds(
+          geometry,
+          shapeMask,
+          { signal },
+        );
         signal?.throwIfAborted();
         scanlineDataTexture = await this._createScanlineDataTexture(
-          multiPolygons,
+          geometry,
+          shapeMask,
           dataBounds,
           { signal },
         );
@@ -621,14 +621,16 @@ export class WebGLShapesController extends WebGLControllerBase {
   /**
    * Builds the scanline data texture for a shapes object
    *
-   * Rasterizes all multi-polygons into horizontal scanlines, packs the
-   * result into a float buffer, and uploads it as an RGBA32F texture.
+   * Rasterizes all shapes into horizontal scanlines, packs the result into a
+   * float buffer, and uploads it as an RGBA32F texture.
    *
-   * @param multiPolygons - Polygon geometry for each shape in the object
-   * @param objectBounds - Axis-aligned bounding box of all shapes
+   * @param geometry - Flat geometry for all shapes in the object
+   * @param shapeMask - Per-shape inclusion mask for this layer, or `undefined` if all shapes are included
+   * @param objectBounds - Axis-aligned bounding box of the included shapes
    */
   private async _createScanlineDataTexture(
-    multiPolygons: MultiPolygon[],
+    geometry: ShapesGeometry,
+    shapeMask: boolean[] | undefined,
     objectBounds: Rect,
     options?: { signal?: AbortSignal },
   ): Promise<WebGLTexture> {
@@ -639,7 +641,8 @@ export class WebGLShapesController extends WebGLControllerBase {
     const { scanlines, totalNumScanlineShapes, totalNumScanlineShapeEdges } =
       await WebGLShapesController._createScanlines(
         this._numScanlines,
-        multiPolygons,
+        geometry,
+        shapeMask,
         objectBounds,
         { signal },
       );
@@ -846,64 +849,88 @@ export class WebGLShapesController extends WebGLControllerBase {
   }
 
   /**
-   * Computes the axis-aligned bounding box of all multi-polygons
+   * Computes the axis-aligned bounding box of the included shapes' geometry
    *
-   * @param multiPolygons - Polygon geometry
+   * @param geometry - Flat geometry for all shapes
+   * @param shapeMask - Per-shape inclusion mask, or `undefined` if all shapes are included
    * @returns The bounding rectangle in data-space coordinates
    */
   private static async _getDataBounds(
-    multiPolygons: MultiPolygon[],
+    geometry: ShapesGeometry,
+    shapeMask: boolean[] | undefined,
     options?: { signal?: AbortSignal },
   ): Promise<Rect> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    if (multiPolygons.length === 0) {
-      throw new Error("Multi-polygons array must not be empty");
-    }
+    const {
+      coords,
+      shapePolygonOffsets,
+      polygonRingOffsets,
+      ringVertexOffsets,
+    } = geometry;
+    const numShapes = shapePolygonOffsets.length - 1;
     let xMin = Infinity,
       yMin = Infinity,
       xMax = -Infinity,
       yMax = -Infinity;
     const maybeYield = AsyncUtils.createYielder({ signal });
-    for (const multiPolygon of multiPolygons) {
-      for (const polygon of multiPolygon.polygons) {
-        for (const path of [polygon.shell, ...polygon.holes]) {
-          for (const vertex of path) {
-            if (vertex.x < xMin) {
-              xMin = vertex.x;
-            }
-            if (vertex.y < yMin) {
-              yMin = vertex.y;
-            }
-            if (vertex.x > xMax) {
-              xMax = vertex.x;
-            }
-            if (vertex.y > yMax) {
-              yMax = vertex.y;
-            }
-          }
+    for (let s = 0; s < numShapes; s++) {
+      if (shapeMask !== undefined && !shapeMask[s]) {
+        continue;
+      }
+      // A shape's vertices are contiguous in `coords`. Via the CSR offsets, the
+      // shape's polygon range [s, s + 1) maps to a ring range [ringStart,
+      // ringEnd) and in turn to the half-open vertex range [vertexStart,
+      // vertexEnd) — where ringEnd is the first ring of the next shape (the
+      // exclusive end).
+      const ringStart = polygonRingOffsets[shapePolygonOffsets[s]!]!;
+      const ringEnd = polygonRingOffsets[shapePolygonOffsets[s + 1]!]!;
+      const vertexStart = ringVertexOffsets[ringStart]!;
+      const vertexEnd = ringVertexOffsets[ringEnd]!;
+      for (let v = vertexStart; v < vertexEnd; v++) {
+        const x = coords[2 * v]!;
+        const y = coords[2 * v + 1]!;
+        if (x < xMin) {
+          xMin = x;
+        }
+        if (y < yMin) {
+          yMin = y;
+        }
+        if (x > xMax) {
+          xMax = x;
+        }
+        if (y > yMax) {
+          yMax = y;
         }
       }
       await maybeYield();
+    }
+    if (xMin > xMax) {
+      throw new Error("Shapes geometry must not be empty");
     }
     return { x: xMin, y: yMin, width: xMax - xMin, height: yMax - yMin };
   }
 
   /**
-   * Rasterizes multi-polygons into horizontal scanlines
+   * Rasterizes the included shapes into horizontal scanlines
    *
    * For each scanline, determines which shapes and edges intersect it,
    * computes per-scanline/per-shape bounding boxes, and builds a 128-bit
    * occupancy mask for fast skip-testing in the fragment shader.
    *
+   * Excluded shapes (per `shapeMask`) are skipped; included shapes are keyed by
+   * their compacted index (matching the order of the color textures).
+   *
    * @param numScanlines - Number of horizontal scanlines
-   * @param multiPolygons - Polygon geometry for all shapes
-   * @param objectBounds - Bounding box of all shapes
+   * @param geometry - Flat geometry for all shapes
+   * @param shapeMask - Per-shape inclusion mask, or `undefined` if all shapes are included
+   * @param objectBounds - Bounding box of the included shapes
    * @returns Scanlines with per-shape edges, and total counts for buffer sizing
    */
   private static async _createScanlines(
     numScanlines: number,
-    multiPolygons: MultiPolygon[],
+    geometry: ShapesGeometry,
+    shapeMask: boolean[] | undefined,
     objectBounds: Rect,
     options?: { signal?: AbortSignal },
   ): Promise<{
@@ -913,6 +940,13 @@ export class WebGLShapesController extends WebGLControllerBase {
   }> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
+    const {
+      coords,
+      shapePolygonOffsets,
+      polygonRingOffsets,
+      ringVertexOffsets,
+    } = geometry;
+    const numShapes = shapePolygonOffsets.length - 1;
     const scanlines: Scanline[] = Array.from({ length: numScanlines }, () => ({
       xMin: Infinity,
       xMax: -Infinity,
@@ -922,18 +956,31 @@ export class WebGLShapesController extends WebGLControllerBase {
     let totalNumScanlineShapes = 0;
     let totalNumScanlineShapeEdges = 0;
     const maybeYield = AsyncUtils.createYielder({ signal });
-    for (let shapeIndex = 0; shapeIndex < multiPolygons.length; shapeIndex++) {
-      for (const polygon of multiPolygons[shapeIndex]!.polygons) {
-        // compute shape xMin/xMax/occupancy mask
+    let shapeIndex = -1; // compacted index over included shapes
+    for (let s = 0; s < numShapes; s++) {
+      if (shapeMask !== undefined && !shapeMask[s]) {
+        continue;
+      }
+      shapeIndex++;
+      const polygonStart = shapePolygonOffsets[s]!;
+      const polygonEnd = shapePolygonOffsets[s + 1]!;
+      for (let p = polygonStart; p < polygonEnd; p++) {
+        const ringStart = polygonRingOffsets[p]!;
+        const ringEnd = polygonRingOffsets[p + 1]!;
+        // compute shape xMin/xMax/occupancy mask from the shell (first ring)
+        const shellStart = ringVertexOffsets[ringStart]!;
+        const shellEnd = ringVertexOffsets[ringStart + 1]!;
         let xMin = Infinity,
           yMin = Infinity,
           xMax = -Infinity,
           yMax = -Infinity;
-        for (const v of polygon.shell) {
-          xMin = Math.min(xMin, v.x);
-          yMin = Math.min(yMin, v.y);
-          xMax = Math.max(xMax, v.x);
-          yMax = Math.max(yMax, v.y);
+        for (let v = shellStart; v < shellEnd; v++) {
+          const x = coords[2 * v]!;
+          const y = coords[2 * v + 1]!;
+          xMin = Math.min(xMin, x);
+          yMin = Math.min(yMin, y);
+          xMax = Math.max(xMax, x);
+          yMax = Math.max(yMax, y);
         }
         const firstScanlineIndex = MathUtils.clamp(
           Math.floor(
@@ -994,11 +1041,16 @@ export class WebGLShapesController extends WebGLControllerBase {
             scanlineShape.xMax = Math.max(scanlineShape.xMax, xMax);
           }
         }
-        // add shape edges to scanlines
-        for (const path of [polygon.shell, ...polygon.holes]) {
-          for (let i = 0; i < path.length; ++i) {
-            const v0 = path[(i + 0) % path.length]!;
-            const v1 = path[(i + 1) % path.length]!;
+        // add shape edges to scanlines (shell and holes)
+        for (let r = ringStart; r < ringEnd; r++) {
+          const vertexStart = ringVertexOffsets[r]!;
+          const vertexEnd = ringVertexOffsets[r + 1]!;
+          const ringLength = vertexEnd - vertexStart;
+          for (let i = 0; i < ringLength; ++i) {
+            const a = vertexStart + ((i + 0) % ringLength);
+            const b = vertexStart + ((i + 1) % ringLength);
+            const v0: Vertex = { x: coords[2 * a]!, y: coords[2 * a + 1]! };
+            const v1: Vertex = { x: coords[2 * b]!, y: coords[2 * b + 1]! };
             if (v0.x === v1.x && v0.y === v1.y) {
               continue; // ignore zero-length edges
             }

--- a/packages/@tissuumaps-core/src/storage/shapes.ts
+++ b/packages/@tissuumaps-core/src/storage/shapes.ts
@@ -1,5 +1,5 @@
 import { type ShapesDataSource } from "../model/shapes";
-import { type MultiPolygon, type ProgressCallback } from "../types";
+import { type ProgressCallback, type ShapesGeometry } from "../types";
 import { type ItemsData, type ItemsDataProvider } from "./base";
 
 /**
@@ -14,17 +14,17 @@ export interface ShapesDataProvider<
 > extends ItemsDataProvider<TShapesDataSource, TShapesData> {}
 
 /**
- * Loaded shape collection data providing multi-polygon geometry access
+ * Loaded shape collection data providing polygon geometry access
  */
 export interface ShapesData extends ItemsData {
   /**
-   * Loads the multi-polygon geometry for all shapes
+   * Loads the flat geometry for all shapes
    *
    * @param options - Optional abort signal and progress callback
-   * @returns One {@link MultiPolygon} per shape, in index order
+   * @returns The {@link ShapesGeometry} for all shapes, in index order
    */
-  loadMultiPolygons(options?: {
+  loadGeometry(options?: {
     signal?: AbortSignal;
     onProgress?: ProgressCallback;
-  }): Promise<MultiPolygon[]>;
+  }): Promise<ShapesGeometry>;
 }

--- a/packages/@tissuumaps-core/src/types.ts
+++ b/packages/@tissuumaps-core/src/types.ts
@@ -74,3 +74,28 @@ export type Vertex = {
   /** Y coordinate of the vertex */
   y: number;
 };
+
+/**
+ * Flat, transfer-friendly representation of many shapes' geometry.
+ *
+ * A struct-of-arrays with CSR-style (offset) nesting shape → polygons → rings →
+ * vertices. All arrays are `ArrayBuffer`-backed so the whole geometry transfers
+ * zero-copy across a worker boundary. Coordinates are `Float32Array` to match
+ * the GPU representation (the scanline texture is `RGBA32F`).
+ *
+ * - Shape `s` owns polygons `[shapePolygonOffsets[s], shapePolygonOffsets[s + 1])`.
+ * - Polygon `p` owns rings `[polygonRingOffsets[p], polygonRingOffsets[p + 1])`;
+ *   the first ring of each polygon is its shell, the rest are holes.
+ * - Ring `r` owns vertices `[ringVertexOffsets[r], ringVertexOffsets[r + 1])`,
+ *   each vertex being `(coords[2 * v], coords[2 * v + 1])`.
+ */
+export type ShapesGeometry = {
+  /** Interleaved x, y per vertex; length `2 * vertexCount`. */
+  coords: Float32Array;
+  /** CSR ring → vertex offsets; length `ringCount + 1`. */
+  ringVertexOffsets: Uint32Array;
+  /** CSR polygon → ring offsets (first ring = shell); length `polygonCount + 1`. */
+  polygonRingOffsets: Uint32Array;
+  /** CSR shape → polygon offsets; length `shapeCount + 1`. */
+  shapePolygonOffsets: Uint32Array;
+};

--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
@@ -100,16 +100,14 @@ export class CSVTableDataProvider implements TableDataProvider<
       }));
     }
 
-    const step = (
-      results: papaparse.ParseStepResult<string[]>,
-      parser: papaparse.Parser,
-    ) => {
+    const processRow = (row: string[]) => {
       if (
         allColumns === undefined ||
         columns === undefined ||
         columnInfos === undefined
       ) {
-        allColumns = results.data;
+        // First row: column header (unless columns were provided up front).
+        allColumns = row;
         columns ??= allColumns;
         columnInfos = columns.map((column) => ({
           name: column,
@@ -118,28 +116,40 @@ export class CSVTableDataProvider implements TableDataProvider<
           currentChunk: [],
           isNaN: false,
         }));
-      } else {
-        if (results.data.length !== allColumns.length) {
-          throw new Error(
-            `Data row ${n} has ${results.data.length} values, expected ${allColumns.length}.`,
-          );
-        }
+        return;
+      }
+      if (row.length !== allColumns.length) {
+        throw new Error(
+          `Data row ${n} has ${row.length} values, expected ${allColumns.length}.`,
+        );
+      }
+      for (const columnInfo of columnInfos) {
+        const value = row[columnInfo.index]!;
+        columnInfo.isNaN = columnInfo.isNaN || value === "" || isNaN(+value);
+        columnInfo.currentChunk.push(columnInfo.isNaN ? value : +value);
+      }
+      n += 1;
+      if (n % defaultDataSource.chunkSize === 0) {
         for (const columnInfo of columnInfos) {
-          const value = results.data[columnInfo.index]!;
-          columnInfo.isNaN = columnInfo.isNaN || value === "" || isNaN(+value);
-          columnInfo.currentChunk.push(columnInfo.isNaN ? value : +value);
+          columnInfo.chunks.push(
+            columnInfo.isNaN
+              ? (columnInfo.currentChunk as string[])
+              : new Float32Array(columnInfo.currentChunk as number[]),
+          );
+          columnInfo.currentChunk = [];
         }
-        n += 1;
-        if (n % defaultDataSource.chunkSize === 0) {
-          for (const columnInfo of columnInfos) {
-            columnInfo.chunks.push(
-              columnInfo.isNaN
-                ? (columnInfo.currentChunk as string[])
-                : new Float32Array(columnInfo.currentChunk as number[]),
-            );
-            columnInfo.currentChunk = [];
-          }
-        }
+      }
+    };
+
+    // Use the batched `chunk` callback (not per-row `step`): with `worker: true`
+    // the parse runs off the main thread and posts back one message per chunk
+    // (per-row `step` would post one message per row).
+    const chunk = (
+      results: papaparse.ParseResult<string[]>,
+      parser: papaparse.Parser,
+    ) => {
+      for (const row of results.data) {
+        processRow(row);
       }
       if (signal?.aborted) {
         parser.abort();
@@ -188,9 +198,10 @@ export class CSVTableDataProvider implements TableDataProvider<
         (resolve, reject) =>
           papaparse.parse(file, {
             ...defaultDataSource.parseConfig,
+            worker: true,
             header: false,
             skipEmptyLines: true,
-            step: step,
+            chunk: chunk,
             complete: () => resolve(complete()),
             error: reject,
           }),
@@ -202,10 +213,11 @@ export class CSVTableDataProvider implements TableDataProvider<
         (resolve, reject) =>
           papaparse.parse(url, {
             ...defaultDataSource.parseConfig,
+            worker: true,
             download: true,
             header: false,
             skipEmptyLines: true,
-            step: step,
+            chunk: chunk,
             complete: () => resolve(complete()),
             error: reject,
           }),

--- a/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesData.ts
+++ b/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesData.ts
@@ -1,22 +1,22 @@
 import {
-  type MultiPolygon,
   type ProgressCallback,
   type ShapesData,
+  type ShapesGeometry,
 } from "@tissuumaps/core";
 
 export class GeoJSONShapesData implements ShapesData {
   private _ids: number[] | undefined;
   private _names: string[] | undefined;
-  private readonly _multiPolygons: MultiPolygon[];
+  private readonly _geometry: ShapesGeometry;
 
   constructor(
     ids: number[] | undefined,
     names: string[] | undefined,
-    multiPolygons: MultiPolygon[],
+    geometry: ShapesGeometry,
   ) {
     this._ids = ids;
     this._names = names;
-    this._multiPolygons = multiPolygons;
+    this._geometry = geometry;
   }
 
   getIds(): number[] {
@@ -28,20 +28,20 @@ export class GeoJSONShapesData implements ShapesData {
   }
 
   getSize(): number {
-    return this._multiPolygons.length;
+    return this._geometry.shapePolygonOffsets.length - 1;
   }
 
   getNames(): string[] | undefined {
     return this._names;
   }
 
-  loadMultiPolygons(options?: {
+  loadGeometry(options?: {
     signal?: AbortSignal;
     onProgress?: ProgressCallback;
-  }): Promise<MultiPolygon[]> {
+  }): Promise<ShapesGeometry> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    return Promise.resolve(this._multiPolygons);
+    return Promise.resolve(this._geometry);
   }
 
   close(): void {}

--- a/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
@@ -1,8 +1,4 @@
-import type * as geojson from "geojson";
-
 import {
-  type MultiPolygon,
-  type Polygon,
   type ProgressCallback,
   type ShapesDataProvider,
 } from "@tissuumaps/core";
@@ -12,6 +8,13 @@ import {
   type GeoJSONShapesDataSource,
   createDefaultGeoJSONShapesDataSource,
 } from "./GeoJSONShapesDataSource";
+import GeoJSONWorker from "./geojson.worker.ts?worker&inline";
+import {
+  type GeoJSONRequest,
+  type GeoJSONResponse,
+  type GeoJSONResult,
+  type GeoJSONSource,
+} from "./geojsonProtocol";
 
 export class GeoJSONShapesDataProvider implements ShapesDataProvider<
   GeoJSONShapesDataSource,
@@ -79,141 +82,76 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
 
     const defaultDataSource = createDefaultGeoJSONShapesDataSource(dataSource);
 
-    let geo;
+    // Acquire the source on the main thread, but parse + flatten in the worker:
+    // a local file is read and its ArrayBuffer transferred; a remote URL is
+    // fetched inside the worker.
+    let source: GeoJSONSource;
     if (defaultDataSource.path !== undefined && workspace !== null) {
       const fh = await workspace.getFileHandle(defaultDataSource.path);
       signal?.throwIfAborted();
       const file = await fh.getFile();
       signal?.throwIfAborted();
-      const text = await file.text();
+      const buffer = await file.arrayBuffer();
       signal?.throwIfAborted();
-      geo = JSON.parse(text) as geojson.GeoJSON<geojson.Geometry | null>; // TODO Validate GeoJSON
+      source = { kind: "buffer", buffer };
     } else if (defaultDataSource.url !== undefined) {
-      const response = await fetch(defaultDataSource.url, { signal });
-      signal?.throwIfAborted();
-      if (!response.ok) {
-        throw new Error(
-          `Failed to load GeoJSON from ${defaultDataSource.url}: ${response.status} ${response.statusText}`,
-        );
-      }
-      const text = await response.text();
-      signal?.throwIfAborted();
-      geo = JSON.parse(text) as geojson.GeoJSON<geojson.Geometry | null>; // TODO Validate GeoJSON
+      source = { kind: "url", url: defaultDataSource.url };
     } else if (defaultDataSource.path !== undefined) {
       throw new Error("An open workspace is required to open local-only data.");
     } else {
       throw new Error("A URL or workspace path is required to load data.");
     }
 
-    let ids: number[] | undefined;
-    const idProperty = defaultDataSource.idProperty;
-    if (idProperty !== undefined) {
-      if (geo === null || geo.type !== "FeatureCollection") {
-        throw new Error(
-          "ID properties can only be used with GeoJSON FeatureCollections.",
-        );
-      }
-      ids = geo.features.map((feature) => {
-        const id = feature.properties?.[idProperty] as unknown;
-        if (
-          id === undefined ||
-          typeof id !== "number" ||
-          !Number.isInteger(id)
-        ) {
-          throw new Error(`Feature is missing integer ID '${idProperty}'.`);
-        }
-        return id;
-      });
-    }
-
-    let names: string[] | undefined;
-    const nameProperty = defaultDataSource.nameProperty;
-    if (nameProperty !== undefined) {
-      if (geo === null || geo.type !== "FeatureCollection") {
-        throw new Error(
-          "Name properties can only be used with GeoJSON FeatureCollections.",
-        );
-      }
-      names = geo.features.map((feature) => {
-        const name = feature.properties?.[nameProperty] as unknown;
-        if (name === undefined) {
-          throw new Error(`Feature is missing name '${nameProperty}'.`);
-        }
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        return String(name);
-      });
-    }
-
-    const multiPolygons = GeoJSONShapesDataProvider._parseGeoJSON(geo);
-
-    return new GeoJSONShapesData(ids, names, multiPolygons);
-  }
-
-  private static _parseGeoJSON(
-    geo: geojson.GeoJSON<geojson.Geometry | null>,
-  ): MultiPolygon[] {
-    if (geo === null) {
-      return [];
-    }
-    switch (geo.type) {
-      case "FeatureCollection":
-        return geo.features.flatMap((feature) =>
-          feature.geometry !== null
-            ? GeoJSONShapesDataProvider._parseGeoJSONGeometry(feature.geometry)
-            : [],
-        );
-      case "Feature":
-        return geo.geometry !== null
-          ? GeoJSONShapesDataProvider._parseGeoJSONGeometry(geo.geometry)
-          : [];
-      case "GeometryCollection":
-        return geo.geometries.flatMap((geometry) =>
-          GeoJSONShapesDataProvider._parseGeoJSONGeometry(geometry),
-        );
-      default:
-        return GeoJSONShapesDataProvider._parseGeoJSONGeometry(geo);
-    }
-  }
-
-  private static _parseGeoJSONGeometry(
-    geometry: geojson.Geometry,
-  ): MultiPolygon[] {
-    switch (geometry.type) {
-      case "Polygon":
-        return [
-          {
-            polygons: [
-              GeoJSONShapesDataProvider._parseGeoJSONGeometryRings(
-                geometry.coordinates,
-              ),
-            ],
+    const worker = new GeoJSONWorker();
+    try {
+      const result = await new Promise<GeoJSONResult>((resolve, reject) => {
+        const listenerCleanup = new AbortController();
+        worker.addEventListener(
+          "message",
+          (event: MessageEvent<GeoJSONResponse>) => {
+            listenerCleanup.abort();
+            const response = event.data;
+            if (response.type === "error") {
+              reject(new Error(response.message));
+            } else {
+              resolve(response.result);
+            }
           },
-        ];
-      case "MultiPolygon":
-        return [
-          {
-            polygons: geometry.coordinates.map((rings) =>
-              GeoJSONShapesDataProvider._parseGeoJSONGeometryRings(rings),
-            ),
+          { signal: listenerCleanup.signal },
+        );
+        worker.addEventListener(
+          "error",
+          (event: ErrorEvent) => {
+            listenerCleanup.abort();
+            const reason: unknown = event.error;
+            reject(reason instanceof Error ? reason : new Error(event.message));
           },
-        ];
-      default:
-        console.warn(`Unsupported GeoJSON geometry type: ${geometry.type}`);
-        return [];
+          { signal: listenerCleanup.signal },
+        );
+        if (signal !== undefined) {
+          signal.addEventListener(
+            "abort",
+            () => {
+              listenerCleanup.abort();
+              const reason: unknown = signal.reason;
+              reject(reason instanceof Error ? reason : new Error("Aborted"));
+            },
+            { signal: listenerCleanup.signal },
+          );
+        }
+        const request: GeoJSONRequest = {
+          source,
+          idProperty: defaultDataSource.idProperty,
+          nameProperty: defaultDataSource.nameProperty,
+        };
+        const transfer: Transferable[] =
+          source.kind === "buffer" ? [source.buffer] : [];
+        worker.postMessage(request, transfer);
+      });
+      signal?.throwIfAborted();
+      return new GeoJSONShapesData(result.ids, result.names, result.geometry);
+    } finally {
+      worker.terminate();
     }
-  }
-
-  private static _parseGeoJSONGeometryRings(
-    rings: geojson.Position[][],
-  ): Polygon {
-    const [shellRing, ...holeRings] = rings;
-    if (shellRing === undefined) {
-      throw new Error("Polygon has no outer ring.");
-    }
-    const shell = shellRing.map((pos) => ({ x: pos[0]!, y: pos[1]! }));
-    const holes = holeRings.map((holeRing) =>
-      holeRing.map((pos) => ({ x: pos[0]!, y: pos[1]! })),
-    );
-    return { shell, holes };
   }
 }

--- a/packages/@tissuumaps-storage/src/geojson/geojson.worker.ts
+++ b/packages/@tissuumaps-storage/src/geojson/geojson.worker.ts
@@ -1,0 +1,50 @@
+import { parseGeoJSON } from "./geojsonParse";
+import { type GeoJSONRequest } from "./geojsonProtocol";
+
+// Minimal view of the dedicated worker global scope, cast from `self` to avoid a
+// DOM/WebWorker lib clash in this single-lib (DOM) TS project.
+interface DedicatedWorkerScope {
+  postMessage(message: unknown, transfer?: Transferable[]): void;
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent<GeoJSONRequest>) => void,
+  ): void;
+}
+const ctx = self as unknown as DedicatedWorkerScope;
+
+ctx.addEventListener("message", (event) => {
+  void handleRequest(event.data);
+});
+
+async function handleRequest(request: GeoJSONRequest): Promise<void> {
+  try {
+    let text: string;
+    if (request.source.kind === "buffer") {
+      text = new TextDecoder().decode(request.source.buffer);
+    } else {
+      const response = await fetch(request.source.url);
+      if (!response.ok) {
+        throw new Error(
+          `Failed to load GeoJSON from ${request.source.url}: ${response.status} ${response.statusText}`,
+        );
+      }
+      text = await response.text();
+    }
+    const { geometry, ids, names } = parseGeoJSON(
+      text,
+      request.idProperty,
+      request.nameProperty,
+    );
+    ctx.postMessage({ type: "result", result: { geometry, ids, names } }, [
+      geometry.coords.buffer,
+      geometry.ringVertexOffsets.buffer,
+      geometry.polygonRingOffsets.buffer,
+      geometry.shapePolygonOffsets.buffer,
+    ]);
+  } catch (error) {
+    ctx.postMessage({
+      type: "error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/@tissuumaps-storage/src/geojson/geojsonParse.ts
+++ b/packages/@tissuumaps-storage/src/geojson/geojsonParse.ts
@@ -1,0 +1,158 @@
+import type * as geojson from "geojson";
+
+import {
+  type MultiPolygon,
+  type Polygon,
+  type ShapesGeometry,
+} from "@tissuumaps/core";
+
+/**
+ * Pure GeoJSON parsing, isolated from the worker message wiring so it can be
+ * reasoned about and reused. Parses the text, extracts per-feature ids/names,
+ * and flattens the polygon geometry into the transfer-friendly
+ * {@link ShapesGeometry}.
+ *
+ * The flattening is done here (rather than via `@tissuumaps/core`'s
+ * `multiPolygonsToGeometry`) so the worker bundle never imports the core
+ * barrel, which eagerly pulls in OpenSeadragon and would crash a worker that
+ * has no `document`.
+ */
+export function parseGeoJSON(
+  text: string,
+  idProperty?: string,
+  nameProperty?: string,
+): { geometry: ShapesGeometry; ids?: number[]; names?: string[] } {
+  const geo = JSON.parse(text) as geojson.GeoJSON<geojson.Geometry | null>; // TODO Validate GeoJSON
+
+  let ids: number[] | undefined;
+  if (idProperty !== undefined) {
+    if (geo === null || geo.type !== "FeatureCollection") {
+      throw new Error(
+        "ID properties can only be used with GeoJSON FeatureCollections.",
+      );
+    }
+    ids = geo.features.map((feature) => {
+      const id = feature.properties?.[idProperty] as unknown;
+      if (id === undefined || typeof id !== "number" || !Number.isInteger(id)) {
+        throw new Error(`Feature is missing integer ID '${idProperty}'.`);
+      }
+      return id;
+    });
+  }
+
+  let names: string[] | undefined;
+  if (nameProperty !== undefined) {
+    if (geo === null || geo.type !== "FeatureCollection") {
+      throw new Error(
+        "Name properties can only be used with GeoJSON FeatureCollections.",
+      );
+    }
+    names = geo.features.map((feature) => {
+      const name = feature.properties?.[nameProperty] as unknown;
+      if (name === undefined) {
+        throw new Error(`Feature is missing name '${nameProperty}'.`);
+      }
+      // eslint-disable-next-line @typescript-eslint/no-base-to-string
+      return String(name);
+    });
+  }
+
+  return { geometry: toShapesGeometry(parseGeoJSONGeometry(geo)), ids, names };
+}
+
+/**
+ * Flattens an array of {@link MultiPolygon}s (one per shape) into the flat
+ * {@link ShapesGeometry} representation, in two passes (count, then fill) to
+ * size the typed arrays exactly.
+ */
+function toShapesGeometry(multiPolygons: MultiPolygon[]): ShapesGeometry {
+  let polygonCount = 0;
+  let ringCount = 0;
+  let vertexCount = 0;
+  for (const multiPolygon of multiPolygons) {
+    polygonCount += multiPolygon.polygons.length;
+    for (const polygon of multiPolygon.polygons) {
+      ringCount += 1 + polygon.holes.length;
+      vertexCount += polygon.shell.length;
+      for (const hole of polygon.holes) {
+        vertexCount += hole.length;
+      }
+    }
+  }
+
+  const coords = new Float32Array(2 * vertexCount);
+  const ringVertexOffsets = new Uint32Array(ringCount + 1);
+  const polygonRingOffsets = new Uint32Array(polygonCount + 1);
+  const shapePolygonOffsets = new Uint32Array(multiPolygons.length + 1);
+
+  let vertexIndex = 0;
+  let ringIndex = 0;
+  let polygonIndex = 0;
+  for (let s = 0; s < multiPolygons.length; s++) {
+    shapePolygonOffsets[s] = polygonIndex;
+    for (const polygon of multiPolygons[s]!.polygons) {
+      polygonRingOffsets[polygonIndex] = ringIndex;
+      polygonIndex++;
+      for (const ring of [polygon.shell, ...polygon.holes]) {
+        ringVertexOffsets[ringIndex] = vertexIndex;
+        ringIndex++;
+        for (const vertex of ring) {
+          coords[2 * vertexIndex] = vertex.x;
+          coords[2 * vertexIndex + 1] = vertex.y;
+          vertexIndex++;
+        }
+      }
+    }
+  }
+  shapePolygonOffsets[multiPolygons.length] = polygonIndex;
+  polygonRingOffsets[polygonCount] = ringIndex;
+  ringVertexOffsets[ringCount] = vertexIndex;
+
+  return { coords, ringVertexOffsets, polygonRingOffsets, shapePolygonOffsets };
+}
+
+function parseGeoJSONGeometry(
+  geo: geojson.GeoJSON<geojson.Geometry | null>,
+): MultiPolygon[] {
+  if (geo === null) {
+    return [];
+  }
+  switch (geo.type) {
+    case "FeatureCollection":
+      return geo.features.flatMap((feature) =>
+        feature.geometry !== null ? parseGeometry(feature.geometry) : [],
+      );
+    case "Feature":
+      return geo.geometry !== null ? parseGeometry(geo.geometry) : [];
+    case "GeometryCollection":
+      return geo.geometries.flatMap((geometry) => parseGeometry(geometry));
+    default:
+      return parseGeometry(geo);
+  }
+}
+
+function parseGeometry(geometry: geojson.Geometry): MultiPolygon[] {
+  switch (geometry.type) {
+    case "Polygon":
+      return [{ polygons: [parseRings(geometry.coordinates)] }];
+    case "MultiPolygon":
+      return [
+        { polygons: geometry.coordinates.map((rings) => parseRings(rings)) },
+      ];
+    default:
+      console.warn(`Unsupported GeoJSON geometry type: ${geometry.type}`);
+      return [];
+  }
+}
+
+function parseRings(rings: geojson.Position[][]): Polygon {
+  const [shellRing, ...holeRings] = rings;
+  if (shellRing === undefined) {
+    throw new Error("Polygon has no outer ring.");
+  }
+  const shell = shellRing.map((pos) => ({ x: pos[0]!, y: pos[1]! }));
+  const holes = holeRings.map((holeRing) =>
+    holeRing.map((pos) => ({ x: pos[0]!, y: pos[1]! })),
+  );
+  return { shell, holes };
+}

--- a/packages/@tissuumaps-storage/src/geojson/geojsonProtocol.ts
+++ b/packages/@tissuumaps-storage/src/geojson/geojsonProtocol.ts
@@ -1,0 +1,25 @@
+import { type ShapesGeometry } from "@tissuumaps/core";
+
+/** The data source handed to the worker — a transferred buffer or a URL it fetches itself. */
+export type GeoJSONSource =
+  | { kind: "buffer"; buffer: ArrayBuffer }
+  | { kind: "url"; url: string };
+
+/** Request sent from the main thread to the worker. */
+export type GeoJSONRequest = {
+  source: GeoJSONSource;
+  idProperty?: string;
+  nameProperty?: string;
+};
+
+/** Parsed result returned by the worker (the geometry transfers zero-copy). */
+export type GeoJSONResult = {
+  geometry: ShapesGeometry;
+  ids?: number[];
+  names?: string[];
+};
+
+/** Response sent from the worker to the main thread. */
+export type GeoJSONResponse =
+  | { type: "result"; result: GeoJSONResult }
+  | { type: "error"; message: string };

--- a/packages/@tissuumaps-storage/src/parquet/ParquetTableData.ts
+++ b/packages/@tissuumaps-storage/src/parquet/ParquetTableData.ts
@@ -1,33 +1,30 @@
-import * as hyparquet from "hyparquet";
-import { compressors } from "hyparquet-compressors";
-import { parquetReadColumn } from "hyparquet/src/read.js";
-
 import {
   type GenericArray,
   type ProgressCallback,
   type TableData,
 } from "@tissuumaps/core";
 
-export class ParquetTableData implements TableData {
-  private _ids: number[] | undefined;
-  private _names: string[] | undefined;
-  private readonly _buffer: hyparquet.AsyncBuffer;
-  private readonly _metadata: hyparquet.FileMetaData;
-  private readonly _columns: string[];
+import { type ParquetWorkerClient } from "./ParquetWorkerClient";
+import { type ParquetOpenResult } from "./parquetProtocol";
 
-  constructor(
-    ids: number[] | undefined,
-    names: string[] | undefined,
-    buffer: hyparquet.AsyncBuffer,
-    metadata: hyparquet.FileMetaData,
-  ) {
-    this._ids = ids;
-    this._names = names;
-    this._buffer = buffer;
-    this._metadata = metadata;
-    this._columns = hyparquet
-      .parquetSchema(metadata)
-      .children.map((c) => c.element.name);
+/**
+ * Thin RPC client over a {@link ParquetWorkerClient}. Synchronous metadata
+ * (size, ids, names, column names) is captured at open; column values are
+ * decoded lazily in the worker on each `loadValues` call.
+ */
+export class ParquetTableData implements TableData {
+  private readonly _client: ParquetWorkerClient;
+  private readonly _numRows: number;
+  private readonly _columns: string[];
+  private _ids: number[] | undefined;
+  private readonly _names: string[] | undefined;
+
+  constructor(client: ParquetWorkerClient, open: ParquetOpenResult) {
+    this._client = client;
+    this._numRows = open.numRows;
+    this._columns = open.columns;
+    this._ids = open.ids;
+    this._names = open.names;
   }
 
   getIds(): number[] {
@@ -39,7 +36,7 @@ export class ParquetTableData implements TableData {
   }
 
   getSize(): number {
-    return Number(this._metadata.num_rows);
+    return this._numRows;
   }
 
   getNames(): string[] | undefined {
@@ -74,14 +71,9 @@ export class ParquetTableData implements TableData {
   ): Promise<GenericArray<T>> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    const rawColumnData = await parquetReadColumn({
-      file: this._buffer,
-      columns: [column],
-      metadata: this._metadata,
-      compressors: compressors,
-    });
+    const values = await this._client.loadColumn(column, { signal });
     signal?.throwIfAborted();
-    return Array.from(rawColumnData) as GenericArray<T>;
+    return values as unknown as GenericArray<T>;
   }
 
   async loadUniqueValues<T>(
@@ -124,5 +116,7 @@ export class ParquetTableData implements TableData {
     return undefined;
   }
 
-  close(): void {}
+  close(): void {
+    this._client.close();
+  }
 }

--- a/packages/@tissuumaps-storage/src/parquet/ParquetTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/parquet/ParquetTableDataProvider.ts
@@ -1,7 +1,3 @@
-import * as hyparquet from "hyparquet";
-import { compressors } from "hyparquet-compressors";
-import { parquetReadColumn } from "hyparquet/src/read.js";
-
 import {
   type ProgressCallback,
   type TableDataProvider,
@@ -12,6 +8,9 @@ import {
   type ParquetTableDataSource,
   createDefaultParquetTableDataSource,
 } from "./ParquetTableDataSource";
+import { ParquetWorkerClient } from "./ParquetWorkerClient";
+import ParquetWorker from "./parquet.worker.ts?worker&inline";
+import { type ParquetSource } from "./parquetProtocol";
 
 export class ParquetTableDataProvider implements TableDataProvider<
   ParquetTableDataSource,
@@ -71,68 +70,42 @@ export class ParquetTableDataProvider implements TableDataProvider<
 
     const defaultDataSource = createDefaultParquetTableDataSource(dataSource);
 
-    let buffer;
+    // Acquire the source on the main thread, but do all hyparquet decoding in
+    // the worker: a local file is read and its ArrayBuffer transferred; a remote
+    // URL is fetched (with range requests) inside the worker.
+    let source: ParquetSource;
     if (defaultDataSource.path !== undefined && workspace !== null) {
       const fh = await workspace.getFileHandle(defaultDataSource.path);
       signal?.throwIfAborted();
       const file = await fh.getFile();
       signal?.throwIfAborted();
-      buffer = await file.arrayBuffer();
+      const buffer = await file.arrayBuffer();
       signal?.throwIfAborted();
+      source = { kind: "buffer", buffer };
     } else if (defaultDataSource.url !== undefined) {
-      buffer = await hyparquet.asyncBufferFromUrl({
+      source = {
+        kind: "url",
         url: defaultDataSource.url,
-        requestInit: { headers: defaultDataSource.requestHeaders },
-      });
-      signal?.throwIfAborted();
+        requestHeaders: defaultDataSource.requestHeaders,
+      };
     } else if (defaultDataSource.path !== undefined) {
       throw new Error("An open workspace is required to open local-only data.");
     } else {
       throw new Error("A URL or workspace path is required to load data.");
     }
 
-    const metadata = await hyparquet.parquetMetadataAsync(buffer);
-    signal?.throwIfAborted();
-
-    let ids;
-    if (defaultDataSource.idColumn !== undefined) {
-      const rawIdColumnData = await parquetReadColumn({
-        file: buffer,
-        columns: [defaultDataSource.idColumn],
-        metadata: metadata,
-        compressors: compressors,
+    const client = new ParquetWorkerClient(new ParquetWorker());
+    try {
+      const result = await client.open(source, {
+        idColumn: defaultDataSource.idColumn,
+        nameColumn: defaultDataSource.nameColumn,
+        signal,
       });
       signal?.throwIfAborted();
-      for (let i = 0; i < rawIdColumnData.length; i++) {
-        if (!Number.isInteger(rawIdColumnData[i])) {
-          throw new Error(
-            `ID column "${defaultDataSource.idColumn}" contains non-integer values.`,
-          );
-        }
-      }
-      ids = Array.from(rawIdColumnData);
+      return new ParquetTableData(client, result);
+    } catch (error) {
+      client.close();
+      throw error;
     }
-
-    let names;
-    if (defaultDataSource.nameColumn !== undefined) {
-      const rawNameColumnData = await parquetReadColumn({
-        file: buffer,
-        columns: [defaultDataSource.nameColumn],
-        metadata: metadata,
-        compressors: compressors,
-      });
-      signal?.throwIfAborted();
-      for (let i = 0; i < rawNameColumnData.length; i++) {
-        const name = rawNameColumnData[i] as unknown;
-        if (name === undefined) {
-          throw new Error(
-            `Name column "${defaultDataSource.nameColumn}" contains undefined values.`,
-          );
-        }
-      }
-      names = Array.from(rawNameColumnData, String);
-    }
-
-    return new ParquetTableData(ids, names, buffer, metadata);
   }
 }

--- a/packages/@tissuumaps-storage/src/parquet/ParquetWorkerClient.test.ts
+++ b/packages/@tissuumaps-storage/src/parquet/ParquetWorkerClient.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import { ParquetWorkerClient } from "./ParquetWorkerClient";
+import { type ParquetWorkerResponse } from "./parquetProtocol";
+
+type PostedMessage = { message: unknown; transfer?: Transferable[] };
+
+/** Minimal in-memory stand-in for a `Worker` that records posts and lets tests emit responses. */
+class MockWorker {
+  readonly posted: PostedMessage[] = [];
+  terminated = false;
+  private readonly _listeners = new Map<
+    string,
+    Set<(event: unknown) => void>
+  >();
+
+  addEventListener(type: string, listener: (event: unknown) => void): void {
+    (
+      this._listeners.get(type) ??
+      this._listeners.set(type, new Set()).get(type)!
+    ).add(listener);
+  }
+
+  removeEventListener(type: string, listener: (event: unknown) => void): void {
+    this._listeners.get(type)?.delete(listener);
+  }
+
+  postMessage(message: unknown, transfer?: Transferable[]): void {
+    this.posted.push({ message, transfer });
+  }
+
+  terminate(): void {
+    this.terminated = true;
+  }
+
+  emitMessage(response: ParquetWorkerResponse): void {
+    for (const listener of this._listeners.get("message") ?? []) {
+      listener({ data: response });
+    }
+  }
+}
+
+function createClient(): { client: ParquetWorkerClient; worker: MockWorker } {
+  const worker = new MockWorker();
+  const client = new ParquetWorkerClient(worker as unknown as Worker);
+  return { client, worker };
+}
+
+describe("ParquetWorkerClient", () => {
+  it("sends an open request and resolves with the result", async () => {
+    const { client, worker } = createClient();
+    const promise = client.open(
+      { kind: "url", url: "data.parquet" },
+      { idColumn: "id" },
+    );
+    expect(worker.posted[0]!.message).toEqual({
+      type: "open",
+      id: 0,
+      source: { kind: "url", url: "data.parquet" },
+      idColumn: "id",
+      nameColumn: undefined,
+    });
+    const result = { numRows: 3, columns: ["id", "x"], ids: [0, 1, 2] };
+    worker.emitMessage({ type: "result", id: 0, result });
+    await expect(promise).resolves.toEqual(result);
+  });
+
+  it("transfers the buffer for a buffer source", () => {
+    const { client, worker } = createClient();
+    const buffer = new ArrayBuffer(16);
+    void client.open({ kind: "buffer", buffer });
+    expect(worker.posted[0]!.transfer).toEqual([buffer]);
+  });
+
+  it("resolves loadColumn with the column data", async () => {
+    const { client, worker } = createClient();
+    const promise = client.loadColumn("x");
+    expect(worker.posted[0]!.message).toEqual({
+      type: "loadColumn",
+      id: 0,
+      column: "x",
+    });
+    const column = new Float32Array([1, 2, 3]);
+    worker.emitMessage({ type: "result", id: 0, result: column });
+    await expect(promise).resolves.toBe(column);
+  });
+
+  it("rejects on an error response", async () => {
+    const { client, worker } = createClient();
+    const promise = client.loadColumn("missing");
+    worker.emitMessage({ type: "error", id: 0, message: "no such column" });
+    await expect(promise).rejects.toThrow("no such column");
+  });
+
+  it("throws immediately when the signal is already aborted", async () => {
+    const { client, worker } = createClient();
+    const controller = new AbortController();
+    controller.abort();
+    await expect(
+      client.loadColumn("x", { signal: controller.signal }),
+    ).rejects.toThrow();
+    expect(worker.posted).toHaveLength(0);
+  });
+
+  it("rejects on mid-flight abort and ignores the late response", async () => {
+    const { client, worker } = createClient();
+    const controller = new AbortController();
+    const promise = client.loadColumn("x", { signal: controller.signal });
+    controller.abort();
+    await expect(promise).rejects.toBeDefined();
+    // A late worker reply for the aborted request must be ignored, not throw.
+    expect(() =>
+      worker.emitMessage({
+        type: "result",
+        id: 0,
+        result: new Float32Array([1]),
+      }),
+    ).not.toThrow();
+  });
+
+  it("terminates the worker and rejects pending requests on close", async () => {
+    const { client, worker } = createClient();
+    const promise = client.loadColumn("x");
+    client.close();
+    expect(worker.terminated).toBe(true);
+    await expect(promise).rejects.toThrow("terminated");
+  });
+});

--- a/packages/@tissuumaps-storage/src/parquet/ParquetWorkerClient.ts
+++ b/packages/@tissuumaps-storage/src/parquet/ParquetWorkerClient.ts
@@ -1,0 +1,128 @@
+import {
+  type ParquetColumnData,
+  type ParquetOpenResult,
+  type ParquetSource,
+  type ParquetWorkerRequest,
+  type ParquetWorkerResponse,
+} from "./parquetProtocol";
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (reason: Error) => void;
+  signal?: AbortSignal;
+  onAbort?: () => void;
+};
+
+/**
+ * Main-thread RPC client over a Parquet decode worker.
+ *
+ * The `Worker` is injected so this class is free of any bundler-specific worker
+ * import and can be unit-tested with a mock. Requests are matched to responses
+ * by an incrementing id; typed-array column buffers are transferred (zero-copy).
+ */
+export class ParquetWorkerClient {
+  private readonly _worker: Worker;
+  private readonly _pending = new Map<number, PendingRequest>();
+  private _nextId = 0;
+
+  constructor(worker: Worker) {
+    this._worker = worker;
+    this._worker.addEventListener("message", this._onMessage);
+    this._worker.addEventListener("error", this._onError);
+  }
+
+  async open(
+    source: ParquetSource,
+    options?: { idColumn?: string; nameColumn?: string; signal?: AbortSignal },
+  ): Promise<ParquetOpenResult> {
+    const { idColumn, nameColumn, signal } = options ?? {};
+    const transfer = source.kind === "buffer" ? [source.buffer] : [];
+    const result = await this._request(
+      (id) => ({ type: "open", id, source, idColumn, nameColumn }),
+      transfer,
+      signal,
+    );
+    return result as ParquetOpenResult;
+  }
+
+  async loadColumn(
+    column: string,
+    options?: { signal?: AbortSignal },
+  ): Promise<ParquetColumnData> {
+    const { signal } = options ?? {};
+    const result = await this._request(
+      (id) => ({ type: "loadColumn", id, column }),
+      [],
+      signal,
+    );
+    return result as ParquetColumnData;
+  }
+
+  close(): void {
+    this._worker.removeEventListener("message", this._onMessage);
+    this._worker.removeEventListener("error", this._onError);
+    this._worker.terminate();
+    for (const pending of this._pending.values()) {
+      this._cleanup(pending);
+      pending.reject(new Error("Parquet worker terminated"));
+    }
+    this._pending.clear();
+  }
+
+  private _request(
+    build: (id: number) => ParquetWorkerRequest,
+    transfer: Transferable[],
+    signal?: AbortSignal,
+  ): Promise<unknown> {
+    signal?.throwIfAborted();
+    const id = this._nextId++;
+    return new Promise<unknown>((resolve, reject) => {
+      const pending: PendingRequest = { resolve, reject, signal };
+      if (signal !== undefined) {
+        pending.onAbort = () => {
+          this._pending.delete(id);
+          const reason: unknown = signal.reason;
+          reject(
+            reason instanceof Error ? reason : new Error("Request aborted"),
+          );
+        };
+        signal.addEventListener("abort", pending.onAbort, { once: true });
+      }
+      this._pending.set(id, pending);
+      this._worker.postMessage(build(id), transfer);
+    });
+  }
+
+  private _cleanup(pending: PendingRequest): void {
+    if (pending.signal !== undefined && pending.onAbort !== undefined) {
+      pending.signal.removeEventListener("abort", pending.onAbort);
+    }
+  }
+
+  private readonly _onMessage = (
+    event: MessageEvent<ParquetWorkerResponse>,
+  ): void => {
+    const response = event.data;
+    const pending = this._pending.get(response.id);
+    if (pending === undefined) {
+      return; // already settled or aborted
+    }
+    this._pending.delete(response.id);
+    this._cleanup(pending);
+    if (response.type === "error") {
+      pending.reject(new Error(response.message));
+    } else {
+      pending.resolve(response.result);
+    }
+  };
+
+  private readonly _onError = (event: ErrorEvent): void => {
+    const reason: unknown = event.error;
+    const error = reason instanceof Error ? reason : new Error(event.message);
+    for (const pending of this._pending.values()) {
+      this._cleanup(pending);
+      pending.reject(error);
+    }
+    this._pending.clear();
+  };
+}

--- a/packages/@tissuumaps-storage/src/parquet/parquet.worker.ts
+++ b/packages/@tissuumaps-storage/src/parquet/parquet.worker.ts
@@ -1,0 +1,56 @@
+import { openParquetSource, readParquetColumn } from "./parquetDecode";
+import { type ParquetState } from "./parquetDecode";
+import { type ParquetWorkerRequest } from "./parquetProtocol";
+
+// Minimal view of the dedicated worker global scope, cast from `self` to avoid a
+// DOM/WebWorker lib clash in this single-lib (DOM) TS project.
+interface DedicatedWorkerScope {
+  postMessage(message: unknown, transfer?: Transferable[]): void;
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent<ParquetWorkerRequest>) => void,
+  ): void;
+}
+const ctx = self as unknown as DedicatedWorkerScope;
+
+let state: ParquetState | undefined;
+
+ctx.addEventListener("message", (event) => {
+  void handleRequest(event.data);
+});
+
+async function handleRequest(request: ParquetWorkerRequest): Promise<void> {
+  try {
+    if (request.type === "open") {
+      const opened = await openParquetSource(
+        request.source,
+        request.idColumn,
+        request.nameColumn,
+      );
+      state = opened.state;
+      ctx.postMessage({
+        type: "result",
+        id: request.id,
+        result: opened.result,
+      });
+    } else {
+      if (state === undefined) {
+        throw new Error("Parquet worker received loadColumn before open");
+      }
+      const column = await readParquetColumn(state, request.column);
+      const transfer = ArrayBuffer.isView(column)
+        ? [column.buffer as ArrayBuffer]
+        : [];
+      ctx.postMessage(
+        { type: "result", id: request.id, result: column },
+        transfer,
+      );
+    }
+  } catch (error) {
+    ctx.postMessage({
+      type: "error",
+      id: request.id,
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+}

--- a/packages/@tissuumaps-storage/src/parquet/parquetDecode.ts
+++ b/packages/@tissuumaps-storage/src/parquet/parquetDecode.ts
@@ -1,0 +1,78 @@
+import * as hyparquet from "hyparquet";
+import { compressors } from "hyparquet-compressors";
+import { parquetReadColumn } from "hyparquet/src/read.js";
+
+import { type TypedArray } from "@tissuumaps/core";
+
+import { type ParquetOpenResult, type ParquetSource } from "./parquetProtocol";
+
+/**
+ * Pure Parquet decoding, isolated from the worker message wiring so it can be
+ * unit-tested on the main thread. `hyparquet` is imported only here (and thus,
+ * transitively, only into the worker bundle) — it is never pulled into the main
+ * application bundle.
+ */
+export type ParquetState = {
+  file: hyparquet.AsyncBuffer | ArrayBuffer;
+  metadata: hyparquet.FileMetaData;
+};
+
+/** Resolves the source, reads metadata, and eagerly decodes the id/name columns. */
+export async function openParquetSource(
+  source: ParquetSource,
+  idColumn?: string,
+  nameColumn?: string,
+): Promise<{ state: ParquetState; result: ParquetOpenResult }> {
+  const file =
+    source.kind === "buffer"
+      ? source.buffer
+      : await hyparquet.asyncBufferFromUrl({
+          url: source.url,
+          requestInit: { headers: source.requestHeaders },
+        });
+  const metadata = await hyparquet.parquetMetadataAsync(file);
+  const state: ParquetState = { file, metadata };
+  const columns = hyparquet
+    .parquetSchema(metadata)
+    .children.map((c) => c.element.name);
+  const numRows = Number(metadata.num_rows);
+
+  let ids: number[] | undefined;
+  if (idColumn !== undefined) {
+    const raw = await readParquetColumn(state, idColumn);
+    ids = Array.from(raw, (value) => {
+      if (!Number.isInteger(value)) {
+        throw new Error(`ID column "${idColumn}" contains non-integer values.`);
+      }
+      return Number(value);
+    });
+  }
+
+  let names: string[] | undefined;
+  if (nameColumn !== undefined) {
+    const raw = await readParquetColumn(state, nameColumn);
+    names = Array.from(raw, (value) => {
+      if (value === undefined || value === null) {
+        throw new Error(
+          `Name column "${nameColumn}" contains undefined values.`,
+        );
+      }
+      return String(value as string | number);
+    });
+  }
+
+  return { state, result: { numRows, columns, ids, names } };
+}
+
+/** Decodes a single column, returning hyparquet's raw typed array / array. */
+export async function readParquetColumn(
+  state: ParquetState,
+  column: string,
+): Promise<unknown[] | TypedArray> {
+  return (await parquetReadColumn({
+    file: state.file,
+    columns: [column],
+    metadata: state.metadata,
+    compressors: compressors,
+  })) as unknown[] | TypedArray;
+}

--- a/packages/@tissuumaps-storage/src/parquet/parquetProtocol.ts
+++ b/packages/@tissuumaps-storage/src/parquet/parquetProtocol.ts
@@ -1,0 +1,44 @@
+/** The data source handed to the worker — a transferred buffer or a URL it fetches itself. */
+export type ParquetSource =
+  | { kind: "buffer"; buffer: ArrayBuffer }
+  | {
+      kind: "url";
+      url: string;
+      requestHeaders?: { [headerName: string]: string };
+    };
+
+/** Result of opening a Parquet source (metadata + eagerly decoded id/name columns). */
+export type ParquetOpenResult = {
+  numRows: number;
+  columns: string[];
+  ids?: number[];
+  names?: string[];
+};
+
+/** Raw column data from the decoder: a typed array (transferred) or a plain array. */
+export type ParquetColumnData = ArrayBufferView | unknown[];
+
+/** Requests sent from the main thread to the worker. */
+export type ParquetWorkerRequest =
+  | {
+      type: "open";
+      id: number;
+      source: ParquetSource;
+      idColumn?: string;
+      nameColumn?: string;
+    }
+  | { type: "loadColumn"; id: number; column: string };
+
+/**
+ * Responses sent from the worker to the main thread.
+ *
+ * `result` is `ParquetOpenResult` for an `open` request and `ParquetColumnData`
+ * for a `loadColumn` request; the client knows which to expect from the request `id`.
+ */
+export type ParquetWorkerResponse =
+  | {
+      type: "result";
+      id: number;
+      result: ParquetOpenResult | ParquetColumnData;
+    }
+  | { type: "error"; id: number; message: string };


### PR DESCRIPTION
# References and relevant issues

Jira: **TMAP-150**

Follow-up to #145 (which moved CPU-side marshalling off the critical path); this PR tackles the remaining storage-adapter **parsing**.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

Data parsing in the storage adapters ran synchronously on the main thread, freezing the UI while large datasets loaded. This PR moves it off-thread, preferring the parser libraries' own worker support and adding custom workers only where needed.

- **CSV** (`CSVTableDataProvider`): enable papaparse's built-in worker (`worker: true`) so tokenization runs off-thread; drive parsing from the batched `chunk` callback instead of per-row `step`. papaparse falls back to a main-thread parse where `Worker` is unavailable.
- **Parquet** (`parquet.worker.ts`, `ParquetWorkerClient`, `ParquetTableData`): a custom `?worker&inline` worker owns the `ArrayBuffer` and runs all hyparquet decoding (metadata, id/name, lazy per-column reads); typed column buffers transfer zero-copy. hyparquet + hyparquet-compressors leave the main bundle entirely (bundled only into the self-contained worker blob).
- **GeoJSON** (`geojson.worker.ts`, `geojsonParse`): a custom `?worker&inline` worker runs `JSON.parse` + the coordinate transform and returns a flat, transfer-friendly `ShapesGeometry` (struct-of-arrays with CSR offsets; coords as `Float32Array`).
- **Geometry representation:** add `ShapesGeometry` to `@tissuumaps/core`; change `ShapesData.loadMultiPolygons` → `loadGeometry`; rewrite `WebGLShapesController._getDataBounds` / `_createScanlines` to walk the flat offsets (rasterization output unchanged). `MultiPolygon` is retained for the interactive shape-drawing path.
- AbortSignal cancellation is preserved across all worker boundaries.

# Screenshot of the fix

N/A.

# Use of AI

Yes. Planned and implemented with Claude Code (Claude Opus 4.8) in an agent session; the diff and tests were reviewed before committing.

# Testing

A rebuild is needed due to new dependencies: **No** (no new dependencies).

Automated:
- `pnpm --filter @tissuumaps/core test` and `pnpm --filter @tissuumaps/storage test` (incl. the flat-geometry conversion and the Parquet RPC client).
- `pnpm build` confirms the production single-file `index.html` is intact with no separate worker chunks, and that hyparquet/OpenSeadragon are not pulled into the worker bundles.

Manual (recommended before merge): `pnpm dev`, then load a large CSV, Parquet, and GeoJSON and confirm the UI stays interactive during loading and the rendered points/shapes match `development`.

# Further comments

Draft: opening for early review while the manual `pnpm dev` verification above is completed. Targets `development`. The storage package's unit tests run in node and cannot import the `@tissuumaps/core` barrel (it eagerly loads OpenSeadragon, which needs `document`), so worker runtime paths and shape rasterization equivalence are covered by build + typecheck rather than unit tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
