### PR TITLE
refactor: introduce worker-transferable geometry types for points and shapes

### DIFF
--- a/apps/tissuumaps/src/store/adapters/LoadedPointsDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedPointsDataAdapter.ts
@@ -1,6 +1,10 @@
 import { useCallback } from "react";
 
-import { type PointsData, type ProgressCallback } from "@tissuumaps/core";
+import {
+  type PointsData,
+  type PointsGeometry,
+  type ProgressCallback,
+} from "@tissuumaps/core";
 import { type ViewerAdapter } from "@tissuumaps/viewer";
 
 import { useTissUUmaps } from "..";
@@ -24,14 +28,14 @@ export class LoadedPointsDataAdapter implements PointsData {
     return this._getData().getNames();
   }
 
-  async loadCoordinates(options?: {
+  async loadGeometry(options?: {
     signal?: AbortSignal;
     onProgress?: ProgressCallback;
-  }): Promise<[Float32Array, Float32Array]> {
+  }): Promise<PointsGeometry> {
     const { signal, onProgress } = options ?? {};
     signal?.throwIfAborted();
     const state = useTissUUmaps.getState();
-    return await state.loadPointsCoordinates(this._pointsId, {
+    return await state.loadPointsGeometry(this._pointsId, {
       signal,
       onProgress,
     });

--- a/apps/tissuumaps/src/store/adapters/LoadedShapesDataAdapter.ts
+++ b/apps/tissuumaps/src/store/adapters/LoadedShapesDataAdapter.ts
@@ -1,9 +1,9 @@
 import { useCallback } from "react";
 
 import {
-  type MultiPolygon,
   type ProgressCallback,
   type ShapesData,
+  type ShapesGeometry,
 } from "@tissuumaps/core";
 import { type ViewerAdapter } from "@tissuumaps/viewer";
 
@@ -28,14 +28,14 @@ export class LoadedShapesDataAdapter implements ShapesData {
     return this._getData().getNames();
   }
 
-  async loadMultiPolygons(options?: {
+  async loadGeometry(options?: {
     signal?: AbortSignal;
     onProgress?: ProgressCallback;
-  }): Promise<MultiPolygon[]> {
+  }): Promise<ShapesGeometry> {
     const { signal, onProgress } = options ?? {};
     signal?.throwIfAborted();
     const state = useTissUUmaps.getState();
-    return await state.loadShapesMultiPolygons(this._shapesId, {
+    return await state.loadShapesGeometry(this._shapesId, {
       signal,
       onProgress,
     });

--- a/apps/tissuumaps/src/store/slices/points.ts
+++ b/apps/tissuumaps/src/store/slices/points.ts
@@ -4,6 +4,7 @@ import {
   type Points,
   type PointsData,
   type PointsDataSource,
+  type PointsGeometry,
   type ProgressCallback,
 } from "@tissuumaps/core";
 
@@ -13,7 +14,7 @@ import { type TissUUmapsStateCreator } from "../index";
 type LoadedPointsData = {
   dataSource: PointsDataSource;
   data: PointsData;
-  loadedCoordinates?: [Float32Array, Float32Array];
+  loadedGeometry?: PointsGeometry;
 };
 
 export type PointsSlice = PointsSliceState & PointsSliceActions;
@@ -39,14 +40,14 @@ export type PointsSliceActions = {
       newDataSource?: PointsDataSource;
     },
   ) => Promise<PointsData>;
-  loadPointsCoordinates: (
+  loadPointsGeometry: (
     pointsId: string,
     options?: {
       signal?: AbortSignal;
       reload?: boolean;
       onProgress?: ProgressCallback;
     },
-  ) => Promise<[Float32Array, Float32Array]>;
+  ) => Promise<PointsGeometry>;
   unloadPoints: (pointsId: string) => boolean;
 };
 
@@ -236,11 +237,11 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
     },
     (_pointsId, options) => options?.signal,
   ),
-  loadPointsCoordinates: deduplicate(
+  loadPointsGeometry: deduplicate(
     async (pointsId, options) => {
       const { signal, reload = false, onProgress } = options ?? {};
       signal?.throwIfAborted();
-      // Check if the points, the corresponding data source, and the requested coordinates are already loaded
+      // Check if the points, the corresponding data source, and the requested geometry are already loaded
       const state = get();
       const loadedDataKey = state.loadedPoints.get(pointsId);
       if (loadedDataKey === undefined) {
@@ -252,11 +253,11 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
           `Data source for points with ID ${pointsId} not loaded.`,
         );
       }
-      if (loadedData.loadedCoordinates !== undefined && !reload) {
-        return loadedData.loadedCoordinates;
+      if (loadedData.loadedGeometry !== undefined && !reload) {
+        return loadedData.loadedGeometry;
       }
-      // Load the requested coordinates
-      const coordinates = await loadedData.data.loadCoordinates({
+      // Load the requested geometry
+      const geometry = await loadedData.data.loadGeometry({
         signal,
         onProgress,
       });
@@ -284,13 +285,13 @@ export const createPointsSlice: TissUUmapsStateCreator<PointsSlice> = (
           "AbortError",
         );
       }
-      // Store the loaded coordinates in the state
+      // Store the loaded geometry in the state
       set((draft) => {
         const loadedDataDraft =
           draft.loadedPointsData.get(currentLoadedDataKey)!;
-        loadedDataDraft.loadedCoordinates = coordinates;
+        loadedDataDraft.loadedGeometry = geometry;
       });
-      return coordinates;
+      return geometry;
     },
     (_pointsId, options) => options?.signal,
   ),

--- a/apps/tissuumaps/src/store/slices/shapes.ts
+++ b/apps/tissuumaps/src/store/slices/shapes.ts
@@ -1,11 +1,11 @@
 import { deepEqual } from "fast-equals";
 
 import {
-  type MultiPolygon,
   type ProgressCallback,
   type Shapes,
   type ShapesData,
   type ShapesDataSource,
+  type ShapesGeometry,
 } from "@tissuumaps/core";
 
 import { deduplicate } from "../deduplicate";
@@ -14,7 +14,7 @@ import { type TissUUmapsStateCreator } from "../index";
 type LoadedShapesData = {
   dataSource: ShapesDataSource;
   data: ShapesData;
-  loadedMultiPolygons?: MultiPolygon[];
+  loadedGeometry?: ShapesGeometry;
 };
 
 export type ShapesSlice = ShapesSliceState & ShapesSliceActions;
@@ -40,14 +40,14 @@ export type ShapesSliceActions = {
       newDataSource?: ShapesDataSource;
     },
   ) => Promise<ShapesData>;
-  loadShapesMultiPolygons: (
+  loadShapesGeometry: (
     shapesId: string,
     options?: {
       signal?: AbortSignal;
       reload?: boolean;
       onProgress?: ProgressCallback;
     },
-  ) => Promise<MultiPolygon[]>;
+  ) => Promise<ShapesGeometry>;
   unloadShapes: (shapesId: string) => boolean;
 };
 
@@ -233,11 +233,11 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
     },
     (_shapesId, options) => options?.signal,
   ),
-  loadShapesMultiPolygons: deduplicate(
+  loadShapesGeometry: deduplicate(
     async (shapesId, options) => {
       const { signal, reload = false, onProgress } = options ?? {};
       signal?.throwIfAborted();
-      // Check if the shapes, the corresponding data source, and the requested multi-polygons are already loaded
+      // Check if the shapes, the corresponding data source, and the requested geometry are already loaded
       const state = get();
       const loadedDataKey = state.loadedShapes.get(shapesId);
       if (loadedDataKey === undefined) {
@@ -249,11 +249,11 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
           `Data source for shapes with ID ${shapesId} not loaded.`,
         );
       }
-      if (loadedData.loadedMultiPolygons !== undefined && !reload) {
-        return loadedData.loadedMultiPolygons;
+      if (loadedData.loadedGeometry !== undefined && !reload) {
+        return loadedData.loadedGeometry;
       }
-      // Load the requested multi-polygons
-      const multiPolygons = await loadedData.data.loadMultiPolygons({
+      // Load the requested geometry
+      const geometry = await loadedData.data.loadGeometry({
         signal,
         onProgress,
       });
@@ -281,13 +281,13 @@ export const createShapesSlice: TissUUmapsStateCreator<ShapesSlice> = (
           "AbortError",
         );
       }
-      // Store the loaded multi-polygons in the state
+      // Store the loaded geometry in the state
       set((draft) => {
         const loadedDataDraft =
           draft.loadedShapesData.get(currentLoadedDataKey)!;
-        loadedDataDraft.loadedMultiPolygons = multiPolygons;
+        loadedDataDraft.loadedGeometry = geometry;
       });
-      return multiPolygons;
+      return geometry;
     },
     (_shapesId, options) => options?.signal,
   ),

--- a/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLPointsController.ts
@@ -657,25 +657,25 @@ export class WebGLPointsController extends WebGLControllerBase {
           : undefined;
       // x/y
       if (bufferSliceChanged || dataBounds === undefined) {
-        let [xData, yData] = await ref.data.loadCoordinates({ signal });
+        let { xs, ys } = await ref.data.loadGeometry({ signal });
         signal?.throwIfAborted();
         if (pointMask !== undefined) {
-          xData = xData.filter((_, j) => pointMask[j]);
-          yData = yData.filter((_, j) => pointMask[j]);
+          xs = xs.filter((_, j) => pointMask[j]);
+          ys = ys.filter((_, j) => pointMask[j]);
         }
-        dataBounds = WebGLPointsController._getDataBounds(xData, yData);
+        dataBounds = WebGLPointsController._getDataBounds(xs, ys);
         WebGLUtils.loadBuffer(
           this.gl,
           this.gl.ARRAY_BUFFER,
           this._buffers.x,
-          xData,
+          xs,
           { offset },
         );
         WebGLUtils.loadBuffer(
           this.gl,
           this.gl.ARRAY_BUFFER,
           this._buffers.y,
-          yData,
+          ys,
           { offset },
         );
       }

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -20,7 +20,7 @@ import {
 } from "../model/types";
 import { type ShapesData } from "../storage/shapes";
 import { type TableData } from "../storage/table";
-import { type MultiPolygon, type Rect, type Vertex } from "../types";
+import { type Rect, type ShapesGeometry } from "../types";
 import { AsyncUtils } from "../utils/AsyncUtils";
 import { MathUtils } from "../utils/MathUtils";
 import { TransformUtils } from "../utils/TransformUtils";
@@ -506,17 +506,17 @@ export class WebGLShapesController extends WebGLControllerBase {
         dataBounds === undefined ||
         scanlineDataTexture === undefined
       ) {
-        let multiPolygons = await ref.data.loadMultiPolygons({ signal });
+        const geometry = await ref.data.loadGeometry({ signal });
         signal?.throwIfAborted();
-        if (shapeMask !== undefined) {
-          multiPolygons = multiPolygons.filter((_, j) => shapeMask[j]);
-        }
-        dataBounds = await WebGLShapesController._getDataBounds(multiPolygons, {
-          signal,
-        });
+        dataBounds = await WebGLShapesController._getDataBounds(
+          geometry,
+          shapeMask,
+          { signal },
+        );
         signal?.throwIfAborted();
         scanlineDataTexture = await this._createScanlineDataTexture(
-          multiPolygons,
+          geometry,
+          shapeMask,
           dataBounds,
           { signal },
         );
@@ -621,14 +621,16 @@ export class WebGLShapesController extends WebGLControllerBase {
   /**
    * Builds the scanline data texture for a shapes object
    *
-   * Rasterizes all multi-polygons into horizontal scanlines, packs the
+   * Rasterizes all shapes into horizontal scanlines, packs the
    * result into a float buffer, and uploads it as an RGBA32F texture.
    *
-   * @param multiPolygons - Polygon geometry for each shape in the object
+   * @param geometry - Geometry for all shapes in the object
+   * @param shapeMask - Per-shape inclusion mask, or `undefined` if all shapes are included
    * @param objectBounds - Axis-aligned bounding box of all shapes
    */
   private async _createScanlineDataTexture(
-    multiPolygons: MultiPolygon[],
+    geometry: ShapesGeometry,
+    shapeMask: boolean[] | undefined,
     objectBounds: Rect,
     options?: { signal?: AbortSignal },
   ): Promise<WebGLTexture> {
@@ -639,7 +641,8 @@ export class WebGLShapesController extends WebGLControllerBase {
     const { scanlines, totalNumScanlineShapes, totalNumScanlineShapeEdges } =
       await WebGLShapesController._createScanlines(
         this._numScanlines,
-        multiPolygons,
+        geometry,
+        shapeMask,
         objectBounds,
         { signal },
       );
@@ -846,64 +849,82 @@ export class WebGLShapesController extends WebGLControllerBase {
   }
 
   /**
-   * Computes the axis-aligned bounding box of all multi-polygons
+   * Computes the axis-aligned bounding box of all (included) shapes
    *
-   * @param multiPolygons - Polygon geometry
+   * @param geometry - Geometry for all shapes in the object
+   * @param shapeMask - Per-shape inclusion mask, or `undefined` if all shapes are included
    * @returns The bounding rectangle in data-space coordinates
    */
   private static async _getDataBounds(
-    multiPolygons: MultiPolygon[],
+    geometry: ShapesGeometry,
+    shapeMask: boolean[] | undefined,
     options?: { signal?: AbortSignal },
   ): Promise<Rect> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    if (multiPolygons.length === 0) {
-      throw new Error("Multi-polygons array must not be empty");
-    }
+    const {
+      shapePolygonOffsets,
+      polygonRingOffsets,
+      ringVertexOffsets,
+      coords,
+    } = geometry;
     let xMin = Infinity,
       yMin = Infinity,
       xMax = -Infinity,
       yMax = -Infinity;
     const maybeYield = AsyncUtils.createYielder({ signal });
-    for (const multiPolygon of multiPolygons) {
-      for (const polygon of multiPolygon.polygons) {
-        for (const path of [polygon.shell, ...polygon.holes]) {
-          for (const vertex of path) {
-            if (vertex.x < xMin) {
-              xMin = vertex.x;
-            }
-            if (vertex.y < yMin) {
-              yMin = vertex.y;
-            }
-            if (vertex.x > xMax) {
-              xMax = vertex.x;
-            }
-            if (vertex.y > yMax) {
-              yMax = vertex.y;
-            }
+    for (let s = 0; s < shapePolygonOffsets.length - 1; s++) {
+      if (shapeMask !== undefined && !shapeMask[s]) {
+        continue;
+      }
+      const polygonStart = shapePolygonOffsets[s]!;
+      const polygonEnd = shapePolygonOffsets[s + 1]!;
+      for (let p = polygonStart; p < polygonEnd; p++) {
+        const shellRing = polygonRingOffsets[p]!;
+        const shellVertexStart = ringVertexOffsets[shellRing]!;
+        const shellVertexEnd = ringVertexOffsets[shellRing + 1]!;
+        for (let v = shellVertexStart; v < shellVertexEnd; v++) {
+          const x = coords[2 * v]!;
+          const y = coords[2 * v + 1]!;
+          if (x < xMin) {
+            xMin = x;
+          }
+          if (y < yMin) {
+            yMin = y;
+          }
+          if (x > xMax) {
+            xMax = x;
+          }
+          if (y > yMax) {
+            yMax = y;
           }
         }
       }
       await maybeYield();
     }
+    if (xMin >= xMax || yMin >= yMax) {
+      throw new Error("Shapes geometry must not be empty");
+    }
     return { x: xMin, y: yMin, width: xMax - xMin, height: yMax - yMin };
   }
 
   /**
-   * Rasterizes multi-polygons into horizontal scanlines
+   * Rasterizes shapes into horizontal scanlines
    *
    * For each scanline, determines which shapes and edges intersect it,
    * computes per-scanline/per-shape bounding boxes, and builds a 128-bit
    * occupancy mask for fast skip-testing in the fragment shader.
    *
    * @param numScanlines - Number of horizontal scanlines
-   * @param multiPolygons - Polygon geometry for all shapes
+   * @param geometry - Geometry for all shapes in the object
+   * @param shapeMask - Per-shape inclusion mask, or `undefined` if all shapes are included
    * @param objectBounds - Bounding box of all shapes
    * @returns Scanlines with per-shape edges, and total counts for buffer sizing
    */
   private static async _createScanlines(
     numScanlines: number,
-    multiPolygons: MultiPolygon[],
+    geometry: ShapesGeometry,
+    shapeMask: boolean[] | undefined,
     objectBounds: Rect,
     options?: { signal?: AbortSignal },
   ): Promise<{
@@ -913,6 +934,12 @@ export class WebGLShapesController extends WebGLControllerBase {
   }> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
+    const {
+      shapePolygonOffsets,
+      polygonRingOffsets,
+      ringVertexOffsets,
+      coords,
+    } = geometry;
     const scanlines: Scanline[] = Array.from({ length: numScanlines }, () => ({
       xMin: Infinity,
       xMax: -Infinity,
@@ -922,18 +949,30 @@ export class WebGLShapesController extends WebGLControllerBase {
     let totalNumScanlineShapes = 0;
     let totalNumScanlineShapeEdges = 0;
     const maybeYield = AsyncUtils.createYielder({ signal });
-    for (let shapeIndex = 0; shapeIndex < multiPolygons.length; shapeIndex++) {
-      for (const polygon of multiPolygons[shapeIndex]!.polygons) {
+    let shapeIndex = 0; // compacted index over included shapes
+    for (let s = 0; s < shapePolygonOffsets.length - 1; s++) {
+      if (shapeMask !== undefined && !shapeMask[s]) {
+        continue;
+      }
+      const shapePolygonStart = shapePolygonOffsets[s]!;
+      const shapePolygonEnd = shapePolygonOffsets[s + 1]!;
+      for (let p = shapePolygonStart; p < shapePolygonEnd; p++) {
+        const polygonRingStart = polygonRingOffsets[p]!;
+        const polygonRingEnd = polygonRingOffsets[p + 1]!;
         // compute shape xMin/xMax/occupancy mask
         let xMin = Infinity,
           yMin = Infinity,
           xMax = -Infinity,
           yMax = -Infinity;
-        for (const v of polygon.shell) {
-          xMin = Math.min(xMin, v.x);
-          yMin = Math.min(yMin, v.y);
-          xMax = Math.max(xMax, v.x);
-          yMax = Math.max(yMax, v.y);
+        const shellVertexStart = ringVertexOffsets[polygonRingStart]!;
+        const shellVertexEnd = ringVertexOffsets[polygonRingStart + 1]!;
+        for (let v = shellVertexStart; v < shellVertexEnd; v++) {
+          const x = coords[2 * v]!;
+          const y = coords[2 * v + 1]!;
+          xMin = Math.min(xMin, x);
+          yMin = Math.min(yMin, y);
+          xMax = Math.max(xMax, x);
+          yMax = Math.max(yMax, y);
         }
         const firstScanlineIndex = MathUtils.clamp(
           Math.floor(
@@ -995,16 +1034,23 @@ export class WebGLShapesController extends WebGLControllerBase {
           }
         }
         // add shape edges to scanlines
-        for (const path of [polygon.shell, ...polygon.holes]) {
-          for (let i = 0; i < path.length; ++i) {
-            const v0 = path[(i + 0) % path.length]!;
-            const v1 = path[(i + 1) % path.length]!;
-            if (v0.x === v1.x && v0.y === v1.y) {
+        for (let r = polygonRingStart; r < polygonRingEnd; r++) {
+          const ringVertexStart = ringVertexOffsets[r]!;
+          const ringVertexEnd = ringVertexOffsets[r + 1]!;
+          const nRingVertices = ringVertexEnd - ringVertexStart;
+          for (let i = 0; i < nRingVertices; ++i) {
+            const v0 = ringVertexStart + ((i + 0) % nRingVertices);
+            const v1 = ringVertexStart + ((i + 1) % nRingVertices);
+            const v0x = coords[2 * v0]!;
+            const v0y = coords[2 * v0 + 1]!;
+            const v1x = coords[2 * v1]!;
+            const v1y = coords[2 * v1 + 1]!;
+            if (v0x === v1x && v0y === v1y) {
               continue; // ignore zero-length edges
             }
             const firstEdgeScanlineIndex = MathUtils.clamp(
               Math.floor(
-                (numScanlines * (Math.min(v0.y, v1.y) - objectBounds.y)) /
+                (numScanlines * (Math.min(v0y, v1y) - objectBounds.y)) /
                   objectBounds.height,
               ),
               0,
@@ -1012,7 +1058,7 @@ export class WebGLShapesController extends WebGLControllerBase {
             );
             const lastEdgeScanlineIndex = MathUtils.clamp(
               Math.ceil(
-                (numScanlines * (Math.max(v0.y, v1.y) - objectBounds.y)) /
+                (numScanlines * (Math.max(v0y, v1y) - objectBounds.y)) /
                   objectBounds.height,
               ),
               0,
@@ -1025,13 +1071,14 @@ export class WebGLShapesController extends WebGLControllerBase {
             ) {
               const scanline = scanlines[scanlineIndex]!;
               const scanlineShape = scanline.shapes.get(shapeIndex)!;
-              scanlineShape.edges.push({ v0, v1 });
+              scanlineShape.edges.push({ v0x, v0y, v1x, v1y });
               totalNumScanlineShapeEdges++;
             }
           }
         }
       }
       await maybeYield();
+      shapeIndex++;
     }
     return { scanlines, totalNumScanlineShapes, totalNumScanlineShapeEdges };
   }
@@ -1094,10 +1141,10 @@ export class WebGLShapesController extends WebGLControllerBase {
           // scanline shape edge
           float32Data.set(
             [
-              scanlineShapeEdge.v0.x,
-              scanlineShapeEdge.v0.y,
-              scanlineShapeEdge.v1.x,
-              scanlineShapeEdge.v1.y,
+              scanlineShapeEdge.v0x,
+              scanlineShapeEdge.v0y,
+              scanlineShapeEdge.v1x,
+              scanlineShapeEdge.v1y,
             ],
             4 * currentScanlineShapeEdgeTexelOffset,
           );
@@ -1182,10 +1229,14 @@ type ScanlineShape = {
 
 /** A polygon edge intersecting a scanline, defined by its two endpoints */
 type ScanlineShapeEdge = {
-  /** First endpoint */
-  v0: Vertex;
-  /** Second endpoint */
-  v1: Vertex;
+  /** X coordinate of the first endpoint */
+  v0x: number;
+  /** Y coordinate of the first endpoint */
+  v0y: number;
+  /** X coordinate of the second endpoint */
+  v1x: number;
+  /** Y coordinate of the second endpoint */
+  v1y: number;
 };
 
 /** A 128-bit occupancy mask stored as four 32-bit integers */

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -902,8 +902,13 @@ export class WebGLShapesController extends WebGLControllerBase {
       }
       await maybeYield();
     }
-    if (xMin >= xMax || yMin >= yMax) {
+    if (!Number.isFinite(xMin) || !Number.isFinite(yMin)) {
       throw new Error("Shapes geometry must not be empty");
+    }
+    if (xMin >= xMax || yMin >= yMax) {
+      throw new Error(
+        "Shapes geometry bounds must have non-zero width and height",
+      );
     }
     return { x: xMin, y: yMin, width: xMax - xMin, height: yMax - yMin };
   }

--- a/packages/@tissuumaps-core/src/storage/points.ts
+++ b/packages/@tissuumaps-core/src/storage/points.ts
@@ -1,5 +1,5 @@
 import { type PointsDataSource } from "../model/points";
-import { type ProgressCallback } from "../types";
+import { type PointsGeometry, type ProgressCallback } from "../types";
 import { type ItemsData, type ItemsDataProvider } from "./base";
 
 /**
@@ -18,13 +18,13 @@ export interface PointsDataProvider<
  */
 export interface PointsData extends ItemsData {
   /**
-   * Loads the coordinates for all points
+   * Loads the geometry for all points
    *
    * @param options - Optional abort signal and progress callback
-   * @returns The x and y coordinates as separate arrays, in index order
+   * @returns A promise that resolves to the loaded points geometry
    */
-  loadCoordinates(options?: {
+  loadGeometry(options?: {
     signal?: AbortSignal;
     onProgress?: ProgressCallback;
-  }): Promise<[Float32Array, Float32Array]>;
+  }): Promise<PointsGeometry>;
 }

--- a/packages/@tissuumaps-core/src/storage/shapes.ts
+++ b/packages/@tissuumaps-core/src/storage/shapes.ts
@@ -1,5 +1,5 @@
 import { type ShapesDataSource } from "../model/shapes";
-import { type MultiPolygon, type ProgressCallback } from "../types";
+import { type ProgressCallback, type ShapesGeometry } from "../types";
 import { type ItemsData, type ItemsDataProvider } from "./base";
 
 /**
@@ -14,17 +14,17 @@ export interface ShapesDataProvider<
 > extends ItemsDataProvider<TShapesDataSource, TShapesData> {}
 
 /**
- * Loaded shape collection data providing multi-polygon geometry access
+ * Loaded shape collection data providing geometry access
  */
 export interface ShapesData extends ItemsData {
   /**
-   * Loads the multi-polygon geometry for all shapes
+   * Loads the geometry for all shapes
    *
    * @param options - Optional abort signal and progress callback
-   * @returns One {@link MultiPolygon} per shape, in index order
+   * @returns A promise that resolves to the loaded shapes geometry
    */
-  loadMultiPolygons(options?: {
+  loadGeometry(options?: {
     signal?: AbortSignal;
     onProgress?: ProgressCallback;
-  }): Promise<MultiPolygon[]>;
+  }): Promise<ShapesGeometry>;
 }

--- a/packages/@tissuumaps-core/src/types.ts
+++ b/packages/@tissuumaps-core/src/types.ts
@@ -74,3 +74,12 @@ export type Vertex = {
   /** Y coordinate of the vertex */
   y: number;
 };
+
+/** Point cloud geometry consisting of separate arrays for x and y coordinates */
+export type PointsGeometry = {
+  /** X coordinates of the points */
+  xs: Float32Array;
+
+  /** Y coordinates of the points */
+  ys: Float32Array;
+};

--- a/packages/@tissuumaps-core/src/types.ts
+++ b/packages/@tissuumaps-core/src/types.ts
@@ -83,3 +83,53 @@ export type PointsGeometry = {
   /** Y coordinates of the points */
   ys: Float32Array;
 };
+
+/**
+ * Geometry for shapes (multi-polygons) stored in CSR-style format
+ *
+ * Shapes are organized in a shapes -> polygons -> rings -> vertices structure,
+ * using CSR-style offset arrays to define the relationships between these elements.
+ * Typed arrays are used for efficient storage and transfer across worker boundaries.
+ *
+ * - Shape `s` owns polygons `[shapePolygonOffsets[s], shapePolygonOffsets[s+1])`
+ * - Polygon `p` owns rings `[polygonRingOffsets[p], polygonRingOffsets[p+1])`
+ * - Ring `r` owns vertices `[ringVertexOffsets[r], ringVertexOffsets[r+1])`
+ * - Vertex `v` has coordinates at `coords[2*v]` (x) and `coords[2*v + 1]` (y)
+ */
+export type ShapesGeometry = {
+  /**
+   * Shape --> polygon offsets
+   *
+   * Length: number of shapes + 1 (last entry is total polygon count)
+   *
+   * One entry per shape (multi-polygon), giving the starting polygon index for each shape.
+   */
+  shapePolygonOffsets: Uint32Array;
+
+  /**
+   * Polygon --> ring offsets
+   *
+   * Length: number of polygons + 1 (last entry is total ring count)
+   *
+   * One entry per polygon, giving the starting ring index for each polygon; the first ring is the shell, and any subsequent rings are holes.
+   */
+  polygonRingOffsets: Uint32Array;
+
+  /**
+   * Ring --> vertex offsets
+   *
+   * Length: number of rings + 1 (last entry is total vertex count)
+   *
+   * One entry per ring, giving the starting vertex index for each ring; the last vertex of a ring is implicitly connected to the first vertex.
+   */
+  ringVertexOffsets: Uint32Array;
+
+  /**
+   * Vertex coordinates
+   *
+   * Length: 2 * number of vertices
+   *
+   * Two entries per vertex, giving the x and y coordinates of each vertex; the coordinates of vertex i are at indices 2*i and 2*i + 1 (interleaved).
+   */
+  coords: Float32Array;
+};

--- a/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesData.ts
+++ b/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesData.ts
@@ -1,22 +1,22 @@
 import {
-  type MultiPolygon,
   type ProgressCallback,
   type ShapesData,
+  type ShapesGeometry,
 } from "@tissuumaps/core";
 
 export class GeoJSONShapesData implements ShapesData {
   private _ids: number[] | undefined;
   private _names: string[] | undefined;
-  private readonly _multiPolygons: MultiPolygon[];
+  private readonly _geometry: ShapesGeometry;
 
   constructor(
     ids: number[] | undefined,
     names: string[] | undefined,
-    multiPolygons: MultiPolygon[],
+    geometry: ShapesGeometry,
   ) {
     this._ids = ids;
     this._names = names;
-    this._multiPolygons = multiPolygons;
+    this._geometry = geometry;
   }
 
   getIds(): number[] {
@@ -28,20 +28,20 @@ export class GeoJSONShapesData implements ShapesData {
   }
 
   getSize(): number {
-    return this._multiPolygons.length;
+    return this._geometry.shapePolygonOffsets.length - 1;
   }
 
   getNames(): string[] | undefined {
     return this._names;
   }
 
-  loadMultiPolygons(options?: {
+  loadGeometry(options?: {
     signal?: AbortSignal;
     onProgress?: ProgressCallback;
-  }): Promise<MultiPolygon[]> {
+  }): Promise<ShapesGeometry> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
-    return Promise.resolve(this._multiPolygons);
+    return Promise.resolve(this._geometry);
   }
 
   close(): void {}

--- a/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
@@ -216,15 +216,25 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
     }
     let polygonsAdded = false;
     for (const rings of polygons) {
-      if (rings.length === 0) {
-        console.warn("Skipping polygon without an outer ring.");
+      if (rings.length === 0 || rings[0]!.length < 3) {
+        console.warn("Skipping polygon without a valid shell.");
         continue;
       }
+      let ringsAdded = false;
       for (const ring of rings) {
+        if (ring.length < 3) {
+          console.warn("Skipping invalid ring with fewer than three vertices.");
+          continue;
+        }
         for (const pos of ring) {
           accumulator.coords.push(pos[0]!, pos[1]!);
         }
         accumulator.ringVertexOffsets.push(accumulator.coords.length / 2);
+        ringsAdded = true;
+      }
+      if (!ringsAdded) {
+        console.warn("Skipping polygon without valid rings.");
+        continue;
       }
       accumulator.polygonRingOffsets.push(
         accumulator.ringVertexOffsets.length - 1,

--- a/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
@@ -121,7 +121,7 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
   }
 
   private static _parseGeoJSON(
-    geo: geojson.GeoJSON,
+    geo: geojson.GeoJSON<geojson.Geometry | null>,
     idProperty: string | undefined,
     nameProperty: string | undefined,
   ): {
@@ -129,6 +129,9 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
     names: string[] | undefined;
     geometry: ShapesGeometry;
   } {
+    if (geo === null) {
+      throw new Error("GeoJSON data must not be null.");
+    }
     if (idProperty !== undefined && geo.type !== "FeatureCollection") {
       throw new Error(
         "ID properties can only be used with GeoJSON FeatureCollections.",
@@ -149,9 +152,14 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
       coords: [],
     };
 
+    let valid = false;
     switch (geo.type) {
       case "FeatureCollection":
         for (const feature of geo.features) {
+          if (feature.geometry === null) {
+            console.warn("Skipping feature with null geometry.");
+            continue;
+          }
           const shapeAppended = GeoJSONShapesDataProvider._parseGeometry(
             feature.geometry,
             accumulator,
@@ -175,18 +183,30 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
             // eslint-disable-next-line @typescript-eslint/no-base-to-string
             names.push(String(name));
           }
+          valid ||= shapeAppended;
         }
         break;
       case "Feature":
-        GeoJSONShapesDataProvider._parseGeometry(geo.geometry, accumulator);
+        if (geo.geometry !== null) {
+          valid = GeoJSONShapesDataProvider._parseGeometry(
+            geo.geometry,
+            accumulator,
+          );
+        }
         break;
       case "GeometryCollection":
-        for (const g of geo.geometries) {
-          GeoJSONShapesDataProvider._parseGeometry(g, accumulator);
+        for (const geometry of geo.geometries) {
+          valid ||= GeoJSONShapesDataProvider._parseGeometry(
+            geometry,
+            accumulator,
+          );
         }
         break;
       default:
-        GeoJSONShapesDataProvider._parseGeometry(geo, accumulator);
+        valid = GeoJSONShapesDataProvider._parseGeometry(geo, accumulator);
+    }
+    if (!valid) {
+      throw new Error("No valid geometries found in GeoJSON data.");
     }
 
     return {

--- a/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
@@ -1,10 +1,9 @@
 import type * as geojson from "geojson";
 
 import {
-  type MultiPolygon,
-  type Polygon,
   type ProgressCallback,
   type ShapesDataProvider,
+  type ShapesGeometry,
 } from "@tissuumaps/core";
 
 import { GeoJSONShapesData } from "./GeoJSONShapesData";
@@ -12,6 +11,13 @@ import {
   type GeoJSONShapesDataSource,
   createDefaultGeoJSONShapesDataSource,
 } from "./GeoJSONShapesDataSource";
+
+type ShapesGeometryAccumulator = {
+  shapePolygonOffsets: number[];
+  polygonRingOffsets: number[];
+  ringVertexOffsets: number[];
+  coords: number[];
+};
 
 export class GeoJSONShapesDataProvider implements ShapesDataProvider<
   GeoJSONShapesDataSource,
@@ -87,7 +93,7 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
       signal?.throwIfAborted();
       const text = await file.text();
       signal?.throwIfAborted();
-      geo = JSON.parse(text) as geojson.GeoJSON<geojson.Geometry | null>; // TODO Validate GeoJSON
+      geo = JSON.parse(text) as geojson.GeoJSON; // TODO Validate GeoJSON
     } else if (defaultDataSource.url !== undefined) {
       const response = await fetch(defaultDataSource.url, { signal });
       signal?.throwIfAborted();
@@ -98,122 +104,139 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
       }
       const text = await response.text();
       signal?.throwIfAborted();
-      geo = JSON.parse(text) as geojson.GeoJSON<geojson.Geometry | null>; // TODO Validate GeoJSON
+      geo = JSON.parse(text) as geojson.GeoJSON; // TODO Validate GeoJSON
     } else if (defaultDataSource.path !== undefined) {
       throw new Error("An open workspace is required to open local-only data.");
     } else {
       throw new Error("A URL or workspace path is required to load data.");
     }
 
-    let ids: number[] | undefined;
-    const idProperty = defaultDataSource.idProperty;
-    if (idProperty !== undefined) {
-      if (geo === null || geo.type !== "FeatureCollection") {
-        throw new Error(
-          "ID properties can only be used with GeoJSON FeatureCollections.",
-        );
-      }
-      ids = geo.features.map((feature) => {
-        const id = feature.properties?.[idProperty] as unknown;
-        if (
-          id === undefined ||
-          typeof id !== "number" ||
-          !Number.isInteger(id)
-        ) {
-          throw new Error(`Feature is missing integer ID '${idProperty}'.`);
-        }
-        return id;
-      });
-    }
+    const { ids, names, geometry } = GeoJSONShapesDataProvider._parseGeoJSON(
+      geo,
+      defaultDataSource.idProperty,
+      defaultDataSource.nameProperty,
+    );
 
-    let names: string[] | undefined;
-    const nameProperty = defaultDataSource.nameProperty;
-    if (nameProperty !== undefined) {
-      if (geo === null || geo.type !== "FeatureCollection") {
-        throw new Error(
-          "Name properties can only be used with GeoJSON FeatureCollections.",
-        );
-      }
-      names = geo.features.map((feature) => {
-        const name = feature.properties?.[nameProperty] as unknown;
-        if (name === undefined) {
-          throw new Error(`Feature is missing name '${nameProperty}'.`);
-        }
-        // eslint-disable-next-line @typescript-eslint/no-base-to-string
-        return String(name);
-      });
-    }
-
-    const multiPolygons = GeoJSONShapesDataProvider._parseGeoJSON(geo);
-
-    return new GeoJSONShapesData(ids, names, multiPolygons);
+    return new GeoJSONShapesData(ids, names, geometry);
   }
 
   private static _parseGeoJSON(
-    geo: geojson.GeoJSON<geojson.Geometry | null>,
-  ): MultiPolygon[] {
-    if (geo === null) {
-      return [];
+    geo: geojson.GeoJSON,
+    idProperty: string | undefined,
+    nameProperty: string | undefined,
+  ): {
+    ids: number[] | undefined;
+    names: string[] | undefined;
+    geometry: ShapesGeometry;
+  } {
+    if (idProperty !== undefined && geo.type !== "FeatureCollection") {
+      throw new Error(
+        "ID properties can only be used with GeoJSON FeatureCollections.",
+      );
     }
+    if (nameProperty !== undefined && geo.type !== "FeatureCollection") {
+      throw new Error(
+        "Name properties can only be used with GeoJSON FeatureCollections.",
+      );
+    }
+
+    const ids: number[] = [];
+    const names: string[] = [];
+    const accumulator: ShapesGeometryAccumulator = {
+      shapePolygonOffsets: [0],
+      polygonRingOffsets: [0],
+      ringVertexOffsets: [0],
+      coords: [],
+    };
+
     switch (geo.type) {
       case "FeatureCollection":
-        return geo.features.flatMap((feature) =>
-          feature.geometry !== null
-            ? GeoJSONShapesDataProvider._parseGeoJSONGeometry(feature.geometry)
-            : [],
-        );
+        for (const feature of geo.features) {
+          const shapeAppended = GeoJSONShapesDataProvider._parseGeometry(
+            feature.geometry,
+            accumulator,
+          );
+          if (shapeAppended && idProperty !== undefined) {
+            const id = feature.properties?.[idProperty] as unknown;
+            if (
+              id === undefined ||
+              typeof id !== "number" ||
+              !Number.isInteger(id)
+            ) {
+              throw new Error(`Feature is missing integer ID '${idProperty}'.`);
+            }
+            ids.push(id);
+          }
+          if (shapeAppended && nameProperty !== undefined) {
+            const name = feature.properties?.[nameProperty] as unknown;
+            if (name === undefined) {
+              throw new Error(`Feature is missing name '${nameProperty}'.`);
+            }
+            // eslint-disable-next-line @typescript-eslint/no-base-to-string
+            names.push(String(name));
+          }
+        }
+        break;
       case "Feature":
-        return geo.geometry !== null
-          ? GeoJSONShapesDataProvider._parseGeoJSONGeometry(geo.geometry)
-          : [];
+        GeoJSONShapesDataProvider._parseGeometry(geo.geometry, accumulator);
+        break;
       case "GeometryCollection":
-        return geo.geometries.flatMap((geometry) =>
-          GeoJSONShapesDataProvider._parseGeoJSONGeometry(geometry),
-        );
+        for (const g of geo.geometries) {
+          GeoJSONShapesDataProvider._parseGeometry(g, accumulator);
+        }
+        break;
       default:
-        return GeoJSONShapesDataProvider._parseGeoJSONGeometry(geo);
+        GeoJSONShapesDataProvider._parseGeometry(geo, accumulator);
     }
+
+    return {
+      ids: idProperty !== undefined ? ids : undefined,
+      names: nameProperty !== undefined ? names : undefined,
+      geometry: {
+        shapePolygonOffsets: Uint32Array.from(accumulator.shapePolygonOffsets),
+        polygonRingOffsets: Uint32Array.from(accumulator.polygonRingOffsets),
+        ringVertexOffsets: Uint32Array.from(accumulator.ringVertexOffsets),
+        coords: Float32Array.from(accumulator.coords),
+      },
+    };
   }
 
-  private static _parseGeoJSONGeometry(
+  private static _parseGeometry(
     geometry: geojson.Geometry,
-  ): MultiPolygon[] {
-    switch (geometry.type) {
-      case "Polygon":
-        return [
-          {
-            polygons: [
-              GeoJSONShapesDataProvider._parseGeoJSONGeometryRings(
-                geometry.coordinates,
-              ),
-            ],
-          },
-        ];
-      case "MultiPolygon":
-        return [
-          {
-            polygons: geometry.coordinates.map((rings) =>
-              GeoJSONShapesDataProvider._parseGeoJSONGeometryRings(rings),
-            ),
-          },
-        ];
-      default:
-        console.warn(`Unsupported GeoJSON geometry type: ${geometry.type}`);
-        return [];
+    accumulator: ShapesGeometryAccumulator,
+  ): boolean {
+    let polygons: geojson.Position[][][];
+    if (geometry.type === "Polygon") {
+      polygons = [geometry.coordinates];
+    } else if (geometry.type === "MultiPolygon") {
+      polygons = geometry.coordinates;
+    } else {
+      console.warn(`Unsupported GeoJSON geometry type: ${geometry.type}`);
+      return false;
     }
-  }
-
-  private static _parseGeoJSONGeometryRings(
-    rings: geojson.Position[][],
-  ): Polygon {
-    const [shellRing, ...holeRings] = rings;
-    if (shellRing === undefined) {
-      throw new Error("Polygon has no outer ring.");
+    let polygonsAdded = false;
+    for (const rings of polygons) {
+      if (rings.length === 0) {
+        console.warn("Skipping polygon without an outer ring.");
+        continue;
+      }
+      for (const ring of rings) {
+        for (const pos of ring) {
+          accumulator.coords.push(pos[0]!, pos[1]!);
+        }
+        accumulator.ringVertexOffsets.push(accumulator.coords.length / 2);
+      }
+      accumulator.polygonRingOffsets.push(
+        accumulator.ringVertexOffsets.length - 1,
+      );
+      polygonsAdded = true;
     }
-    const shell = shellRing.map((pos) => ({ x: pos[0]!, y: pos[1]! }));
-    const holes = holeRings.map((holeRing) =>
-      holeRing.map((pos) => ({ x: pos[0]!, y: pos[1]! })),
+    if (!polygonsAdded) {
+      return false;
+    }
+    accumulator.shapePolygonOffsets.push(
+      accumulator.polygonRingOffsets.length - 1,
     );
-    return { shell, holes };
+    return true;
   }
 }

--- a/packages/@tissuumaps-storage/src/table/TablePointsData.ts
+++ b/packages/@tissuumaps-storage/src/table/TablePointsData.ts
@@ -1,5 +1,6 @@
 import {
   type PointsData,
+  type PointsGeometry,
   type ProgressCallback,
   type TableData,
 } from "@tissuumaps/core";
@@ -27,10 +28,10 @@ export class TablePointsData implements PointsData {
     return this._tableData.getNames();
   }
 
-  async loadCoordinates(options?: {
+  async loadGeometry(options?: {
     signal?: AbortSignal;
     onProgress?: ProgressCallback;
-  }): Promise<[Float32Array, Float32Array]> {
+  }): Promise<PointsGeometry> {
     const { signal, onProgress } = options ?? {};
     signal?.throwIfAborted();
     const xPromise = this._tableData.loadValues<number>(this._xColumn, {
@@ -41,15 +42,15 @@ export class TablePointsData implements PointsData {
       signal,
       onProgress,
     });
-    let [xData, yData] = await Promise.all([xPromise, yPromise]);
+    let [xs, ys] = await Promise.all([xPromise, yPromise]);
     signal?.throwIfAborted();
-    if (!(xData instanceof Float32Array)) {
-      xData = Float32Array.from(xData);
+    if (!(xs instanceof Float32Array)) {
+      xs = Float32Array.from(xs);
     }
-    if (!(yData instanceof Float32Array)) {
-      yData = Float32Array.from(yData);
+    if (!(ys instanceof Float32Array)) {
+      ys = Float32Array.from(ys);
     }
-    return [xData, yData];
+    return { xs, ys };
   }
 
   close(): void {}


### PR DESCRIPTION
# References and relevant issues

Relates to **TMAP-347** ("Download data in parallel").

This PR is preparatory work for that ticket: it converts the points and shapes
geometry representations into struct-of-typed-arrays that are **transferable across
worker boundaries** (a prerequisite for parsing/downloading data off the main thread).

# Type of change

<!-- If "Other", please specify. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other: internal refactor (changes `@tissuumaps/core` storage interfaces consumed within this monorepo)

# List of changes made

- **`@tissuumaps/core`** — introduce two transferable geometry types in `types.ts`:
  - `PointsGeometry` (`xs`/`ys` `Float32Array`), replacing the `[Float32Array, Float32Array]` tuple.
  - `ShapesGeometry`, a CSR-style struct-of-typed-arrays (`shapePolygonOffsets`, `polygonRingOffsets`, `ringVertexOffsets`, interleaved `coords`), replacing the nested `MultiPolygon`/`Polygon`/`Path`/`Vertex` object graph.
- **Storage interfaces** — `PointsData.loadCoordinates()` → `loadGeometry(): Promise<PointsGeometry>`; `ShapesData.loadMultiPolygons()` → `loadGeometry(): Promise<ShapesGeometry>`.
- **Rendering** — `WebGLPointsController` and `WebGLShapesController` consume the new types directly. Shapes bounds + scanline rasterization now walk the CSR arrays, evaluate the per-layer `shapeMask` on the fly (no per-layer geometry copy), and use a flat edge scratch type.
- **`@tissuumaps/storage`** — `TablePointsData` returns `PointsGeometry`; the GeoJSON shapes provider parses GeoJSON **directly into the CSR arrays** (skips unsupported/ring-less input with warnings, prunes polygon-less shapes, and keeps `ids`/`names` aligned with the extracted shapes).
- **App store** — points/shapes slices and `Loaded*DataAdapter`s updated to the new `loadGeometry` API.
- The interactive drawing path (`SVGController`) intentionally still produces `MultiPolygon`; converting it is deliberately deferred (no consumer needs it yet).

# Screenshot of the fix

N/A — no user-facing/visual change.

# Use of AI

Yes. Planned and implemented with Claude Code (Claude Opus): codebase exploration, the
migration design, the code changes, and verification (builds/tests) were AI-assisted and
human-reviewed.

# Testing

- A rebuild is needed (package builds changed).
- `pnpm build` succeeds end-to-end (packages + apps).
- `pnpm test` passes (e.g. `@tissuumaps/core` 237/237); no new tests added — this is a
  behavior-preserving refactor and no points/shapes-specific suites existed.

# Further comments

Purely preparatory for worker-based parallel data loading (TMAP-347); no functional or
visual behavior change is intended. The geometry types are now plain typed-array structs
that can be transferred (zero-copy) to/from workers.

<!--
Final Checklist:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
-->
