### PR TITLE
perf: optimize CSV loading, enable PapaParse worker (TMAP-150)

### DIFF
--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
@@ -127,14 +127,12 @@ export class CSVTableDataProvider implements TableDataProvider<
             const column = columns[c]!;
             const columnChunk = columnChunks[c]!;
             if (column.index < 0) {
-              console.warn(`Column "${column.name}" not found`);
               parser.abort();
-              return;
+              throw new Error(`Column "${column.name}" not found`);
             }
             if (column.index >= rowData.length) {
-              console.warn(`Missing value for column "${column.name}"`);
               parser.abort();
-              return;
+              throw new Error(`Missing value for column "${column.name}"`);
             }
             const value = rowData[column.index]!;
             if (Array.isArray(columnChunk)) {

--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
@@ -105,18 +105,12 @@ export class CSVTableDataProvider implements TableDataProvider<
               numChunkRows -= 1;
             }
             columns = (defaultDataSource.loadColumns ?? columnNames).map(
-              (columnName) => {
-                const columnIndex = columnNames.indexOf(columnName);
-                if (columnIndex === -1) {
-                  throw new Error(`Column "${columnName}" not found`);
-                }
-                return {
-                  name: columnName,
-                  index: columnIndex,
-                  isNaN: false,
-                  chunks: [],
-                };
-              },
+              (columnName) => ({
+                name: columnName,
+                index: columnNames.indexOf(columnName),
+                isNaN: false,
+                chunks: [],
+              }),
             );
             if (columnNames === rowData) {
               continue;
@@ -132,7 +126,17 @@ export class CSVTableDataProvider implements TableDataProvider<
           for (let c = 0; c < columns.length; c++) {
             const column = columns[c]!;
             const columnChunk = columnChunks[c]!;
-            const value = rowData[column.index] ?? "";
+            if (column.index < 0) {
+              console.warn(`Column "${column.name}" not found`);
+              parser.abort();
+              return;
+            }
+            if (column.index >= rowData.length) {
+              console.warn(`Missing value for column "${column.name}"`);
+              parser.abort();
+              return;
+            }
+            const value = rowData[column.index]!;
             if (Array.isArray(columnChunk)) {
               columnChunk[currentChunkRow] = value;
             } else {

--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
@@ -100,9 +100,7 @@ export class CSVTableDataProvider implements TableDataProvider<
             columns = columnNames.map((name) => {
               const index = allColumnNames.indexOf(name);
               if (index === -1) {
-                throw new Error(
-                  `Column "${name}" specified in "columns" does not exist in the table.`,
-                );
+                throw new Error(`Column "${name}" not found in CSV file`);
               }
               return { name, index, isNaN: false, data: [] };
             });

--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
@@ -78,7 +78,7 @@ export class CSVTableDataProvider implements TableDataProvider<
           name: string;
           index: number;
           isNaN: boolean;
-          data: (string | number)[];
+          chunks: (Float32Array | string[])[];
         }[]
       | undefined;
     const defaultDataSource = createDefaultCSVTableDataSource(dataSource);
@@ -93,40 +93,77 @@ export class CSVTableDataProvider implements TableDataProvider<
         results: papaparse.ParseResult<string[]>,
         parser: papaparse.Parser,
       ) => {
+        let columnChunks: (Float32Array | string[])[] | undefined;
+        let numChunkRows = results.data.length;
+        let currentChunkRow = 0;
         for (const rowData of results.data) {
           if (columns === undefined) {
-            const allColumnNames = defaultDataSource.columns ?? rowData;
-            const columnNames = defaultDataSource.loadColumns ?? allColumnNames;
-            columns = columnNames.map((name) => {
-              const index = allColumnNames.indexOf(name);
-              if (index === -1) {
-                throw new Error(`Column "${name}" not found in CSV file`);
-              }
-              return { name, index, isNaN: false, data: [] };
-            });
-            if (allColumnNames === rowData) {
+            let columnNames = defaultDataSource.columns;
+            if (columnNames === undefined) {
+              columnNames = rowData;
+              numChunkRows -= 1;
+            }
+            columns = (defaultDataSource.loadColumns ?? columnNames).map(
+              (columnName) => {
+                const columnIndex = columnNames.indexOf(columnName);
+                if (columnIndex === -1) {
+                  throw new Error(`Column "${columnName}" not found`);
+                }
+                return {
+                  name: columnName,
+                  index: columnIndex,
+                  isNaN: false,
+                  chunks: [],
+                };
+              },
+            );
+            if (columnNames === rowData) {
               continue;
             }
           }
-          for (const column of columns) {
+          if (columnChunks === undefined) {
+            columnChunks = columns.map((column) =>
+              column.isNaN
+                ? new Array<string>(numChunkRows)
+                : new Float32Array(numChunkRows),
+            );
+          }
+          for (let c = 0; c < columns.length; c++) {
+            const column = columns[c]!;
+            const columnChunk = columnChunks[c]!;
             const value = rowData[column.index] ?? "";
-            if (column.isNaN) {
-              column.data.push(value);
+            if (Array.isArray(columnChunk)) {
+              columnChunk[currentChunkRow] = value;
             } else {
               let valueIsNaN = value === "";
               if (!valueIsNaN) {
                 const numericValue = +value;
                 valueIsNaN = isNaN(numericValue);
                 if (!valueIsNaN) {
-                  column.data.push(numericValue);
+                  columnChunk[currentChunkRow] = numericValue;
                 }
               }
               if (valueIsNaN) {
-                column.data = Array.from(column.data, String);
-                column.data.push(value);
                 column.isNaN = true;
+                for (let i = 0; i < column.chunks.length; i++) {
+                  column.chunks[i] = Array.from(column.chunks[i]!, String);
+                }
+                const newColumnChunk = new Array<string>(numChunkRows);
+                for (let i = 0; i < currentChunkRow; i++) {
+                  newColumnChunk[i] = String(columnChunk[i]!);
+                }
+                newColumnChunk[currentChunkRow] = value;
+                columnChunks[c] = newColumnChunk;
               }
             }
+          }
+          currentChunkRow++;
+        }
+        if (columns !== undefined && columnChunks !== undefined) {
+          for (let c = 0; c < columns.length; c++) {
+            const column = columns[c]!;
+            const columnChunk = columnChunks[c]!;
+            column.chunks.push(columnChunk);
           }
         }
         if (signal?.aborted) {
@@ -139,12 +176,22 @@ export class CSVTableDataProvider implements TableDataProvider<
       const columnValues = new Map<string, string[] | Float32Array>();
       if (columns !== undefined) {
         for (const column of columns) {
-          columnValues.set(
-            column.name,
-            column.isNaN
-              ? (column.data as string[])
-              : new Float32Array(column.data as number[]),
-          );
+          let values;
+          if (column.isNaN) {
+            const chunks = column.chunks as string[][];
+            values = chunks.flat();
+          } else {
+            const chunks = column.chunks as Float32Array[];
+            const n = chunks.reduce((n, chunk) => n + chunk.length, 0);
+            let offset = 0;
+            values = new Float32Array(n);
+            for (const chunk of chunks) {
+              values.set(chunk, offset);
+              offset += chunk.length;
+            }
+          }
+          columnValues.set(column.name, values);
+          column.chunks = [];
         }
       }
       return columnValues;
@@ -184,7 +231,7 @@ export class CSVTableDataProvider implements TableDataProvider<
       throw new Error("No columns found in the CSV file.");
     }
 
-    const n = columns[0]!.data.length;
+    const n = columnValues.get(columns[0]!.name)?.length ?? 0;
 
     let ids: number[] | undefined;
     if (defaultDataSource.idColumn !== undefined) {

--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
@@ -3,6 +3,7 @@ import * as papaparse from "papaparse";
 import {
   type ProgressCallback,
   type TableDataProvider,
+  type TypedArray,
 } from "@tissuumaps/core";
 
 import { CSVTableData } from "./CSVTableData";
@@ -78,7 +79,7 @@ export class CSVTableDataProvider implements TableDataProvider<
           name: string;
           index: number;
           isNaN: boolean;
-          chunks: (Float32Array | string[])[];
+          chunks: (string[] | TypedArray)[];
         }[]
       | undefined;
     const defaultDataSource = createDefaultCSVTableDataSource(dataSource);
@@ -93,7 +94,7 @@ export class CSVTableDataProvider implements TableDataProvider<
         results: papaparse.ParseResult<string[]>,
         parser: papaparse.Parser,
       ) => {
-        let columnChunks: (Float32Array | string[])[] | undefined;
+        let columnChunks: (string[] | TypedArray)[] | undefined;
         let numChunkRows = results.data.length;
         let currentChunkRow = 0;
         for (const rowData of results.data) {
@@ -173,7 +174,7 @@ export class CSVTableDataProvider implements TableDataProvider<
     };
 
     const makeColumnValues = () => {
-      const columnValues = new Map<string, string[] | Float32Array>();
+      const columnValues = new Map<string, string[] | TypedArray>();
       if (columns !== undefined) {
         for (const column of columns) {
           let values;
@@ -181,10 +182,10 @@ export class CSVTableDataProvider implements TableDataProvider<
             const chunks = column.chunks as string[][];
             values = chunks.flat();
           } else {
-            const chunks = column.chunks as Float32Array[];
+            const chunks = column.chunks as TypedArray[];
             const n = chunks.reduce((n, chunk) => n + chunk.length, 0);
-            let offset = 0;
             values = new Float32Array(n);
+            let offset = 0;
             for (const chunk of chunks) {
               values.set(chunk, offset);
               offset += chunk.length;
@@ -197,7 +198,7 @@ export class CSVTableDataProvider implements TableDataProvider<
       return columnValues;
     };
 
-    let columnValues: Map<string, string[] | Float32Array>;
+    let columnValues: Map<string, string[] | TypedArray>;
     if (defaultDataSource.path !== undefined && workspace !== null) {
       const fh = await workspace.getFileHandle(defaultDataSource.path);
       signal?.throwIfAborted();

--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
@@ -3,7 +3,6 @@ import * as papaparse from "papaparse";
 import {
   type ProgressCallback,
   type TableDataProvider,
-  type TypedArray,
 } from "@tissuumaps/core";
 
 import { CSVTableData } from "./CSVTableData";
@@ -33,7 +32,6 @@ export class CSVTableDataProvider implements TableDataProvider<
         type: "string",
       },
       // TODO loadColumns
-      // TODO chunkSize
       // TODO parseConfig
     },
     required: ["url"], // TODO ... or path
@@ -60,7 +58,6 @@ export class CSVTableDataProvider implements TableDataProvider<
         label: "Name Column",
       },
       // TODO loadColumns
-      // TODO chunkSize
       // TODO parseConfig
     ],
   };
@@ -78,137 +75,112 @@ export class CSVTableDataProvider implements TableDataProvider<
 
     const defaultDataSource = createDefaultCSVTableDataSource(dataSource);
 
-    let n = 0;
-    let allColumns = defaultDataSource.columns;
-    let columns = defaultDataSource.loadColumns ?? allColumns;
-    let columnInfos:
+    let columns:
       | {
           name: string;
           index: number;
-          chunks: (string[] | TypedArray)[];
-          currentChunk: (string | number)[];
           isNaN: boolean;
+          data: (string | number)[];
         }[]
       | undefined;
-    if (allColumns !== undefined && columns !== undefined) {
-      columnInfos = columns.map((column) => ({
-        name: column,
-        index: allColumns!.indexOf(column),
-        chunks: [],
-        currentChunk: [],
+    if (defaultDataSource.columns !== undefined) {
+      const allColumnNames = defaultDataSource.columns;
+      const columnNames = defaultDataSource.loadColumns ?? allColumnNames;
+      columns = columnNames.map((columnName) => ({
+        name: columnName,
+        index: allColumnNames.indexOf(columnName),
         isNaN: false,
+        data: [],
       }));
     }
 
-    const step = (
-      results: papaparse.ParseStepResult<string[]>,
-      parser: papaparse.Parser,
-    ) => {
-      if (
-        allColumns === undefined ||
-        columns === undefined ||
-        columnInfos === undefined
-      ) {
-        allColumns = results.data;
-        columns ??= allColumns;
-        columnInfos = columns.map((column) => ({
-          name: column,
-          index: allColumns!.indexOf(column),
-          chunks: [],
-          currentChunk: [],
-          isNaN: false,
-        }));
-      } else {
-        if (results.data.length !== allColumns.length) {
-          throw new Error(
-            `Data row ${n} has ${results.data.length} values, expected ${allColumns.length}.`,
-          );
-        }
-        for (const columnInfo of columnInfos) {
-          const value = results.data[columnInfo.index]!;
-          columnInfo.isNaN = columnInfo.isNaN || value === "" || isNaN(+value);
-          columnInfo.currentChunk.push(columnInfo.isNaN ? value : +value);
-        }
-        n += 1;
-        if (n % defaultDataSource.chunkSize === 0) {
-          for (const columnInfo of columnInfos) {
-            columnInfo.chunks.push(
-              columnInfo.isNaN
-                ? (columnInfo.currentChunk as string[])
-                : new Float32Array(columnInfo.currentChunk as number[]),
-            );
-            columnInfo.currentChunk = [];
+    const parseConfig: Partial<
+      papaparse.ParseLocalConfig & papaparse.ParseRemoteConfig
+    > = {
+      ...defaultDataSource.parseConfig,
+      worker: true,
+      header: false,
+      skipEmptyLines: true,
+      chunk: (
+        results: papaparse.ParseResult<string[]>,
+        parser: papaparse.Parser,
+      ) => {
+        for (const rowData of results.data) {
+          if (columns === undefined) {
+            const allColumnNames = rowData;
+            const columnNames = defaultDataSource.loadColumns ?? allColumnNames;
+            columns = columnNames.map((columnName) => ({
+              name: columnName,
+              index: allColumnNames.indexOf(columnName),
+              isNaN: false,
+              data: [],
+            }));
+            continue;
+          }
+          for (const column of columns) {
+            const value = rowData[column.index] ?? "";
+            if (column.isNaN) {
+              column.data.push(value);
+            } else {
+              let valueIsNaN = value === "";
+              if (!valueIsNaN) {
+                const numericValue = +value;
+                valueIsNaN = isNaN(numericValue);
+                if (!valueIsNaN) {
+                  column.data.push(numericValue);
+                }
+              }
+              if (valueIsNaN) {
+                column.data = Array.from(column.data, String);
+                column.data.push(value);
+                column.isNaN = true;
+              }
+            }
           }
         }
-      }
-      if (signal?.aborted) {
-        parser.abort();
-      }
+        if (signal?.aborted) {
+          parser.abort();
+        }
+      },
     };
 
-    const complete = () => {
+    const makeColumnValues = () => {
       const columnValues = new Map<string, string[] | Float32Array>();
-      for (const columnInfo of columnInfos!) {
-        if (columnInfo.currentChunk.length > 0) {
-          columnInfo.chunks.push(
-            columnInfo.isNaN
-              ? (columnInfo.currentChunk as string[])
-              : new Float32Array(columnInfo.currentChunk as number[]),
+      if (columns !== undefined) {
+        for (const column of columns) {
+          columnValues.set(
+            column.name,
+            column.isNaN
+              ? (column.data as string[])
+              : new Float32Array(column.data as number[]),
           );
-          columnInfo.currentChunk = [];
         }
-        if (columnInfo.isNaN) {
-          const values = columnInfo.chunks.flatMap((chunkValues) =>
-            Array.isArray(chunkValues)
-              ? chunkValues
-              : Array.from(chunkValues, String),
-          );
-          columnValues.set(columnInfo.name, values);
-        } else {
-          const values = new Float32Array(n);
-          let offset = 0;
-          for (const chunkValues of columnInfo.chunks) {
-            values.set(chunkValues as TypedArray, offset);
-            offset += chunkValues.length;
-          }
-          columnValues.set(columnInfo.name, values);
-        }
-        columnInfo.chunks = [];
       }
       return columnValues;
     };
 
-    let columnValues;
+    let columnValues: Map<string, string[] | Float32Array>;
     if (defaultDataSource.path !== undefined && workspace !== null) {
       const fh = await workspace.getFileHandle(defaultDataSource.path);
       signal?.throwIfAborted();
       const file = await fh.getFile();
-      signal?.throwIfAborted();
-      columnValues = await new Promise<Map<string, string[] | Float32Array>>(
-        (resolve, reject) =>
-          papaparse.parse(file, {
-            ...defaultDataSource.parseConfig,
-            header: false,
-            skipEmptyLines: true,
-            step: step,
-            complete: () => resolve(complete()),
-            error: reject,
-          }),
+      columnValues = await new Promise((resolve, reject) =>
+        papaparse.parse(file, {
+          ...parseConfig,
+          error: reject,
+          complete: () => resolve(makeColumnValues()),
+        }),
       );
       signal?.throwIfAborted();
     } else if (defaultDataSource.url !== undefined) {
       const url = defaultDataSource.url;
-      columnValues = await new Promise<Map<string, string[] | Float32Array>>(
-        (resolve, reject) =>
-          papaparse.parse(url, {
-            ...defaultDataSource.parseConfig,
-            download: true,
-            header: false,
-            skipEmptyLines: true,
-            step: step,
-            complete: () => resolve(complete()),
-            error: reject,
-          }),
+      columnValues = await new Promise((resolve, reject) =>
+        papaparse.parse(url, {
+          ...parseConfig,
+          download: true,
+          error: reject,
+          complete: () => resolve(makeColumnValues()),
+        }),
       );
       signal?.throwIfAborted();
     } else if (defaultDataSource.path !== undefined) {
@@ -216,6 +188,12 @@ export class CSVTableDataProvider implements TableDataProvider<
     } else {
       throw new Error("A URL or workspace path is required to load data.");
     }
+
+    if (columns === undefined || columns.length === 0) {
+      throw new Error("No columns found in the CSV file.");
+    }
+
+    const n = columns[0]!.data.length;
 
     let ids: number[] | undefined;
     if (defaultDataSource.idColumn !== undefined) {
@@ -225,16 +203,13 @@ export class CSVTableDataProvider implements TableDataProvider<
           `ID column "${defaultDataSource.idColumn}" does not exist in the table.`,
         );
       }
-      ids = Array.from(
-        idColumnValues.map((v) => {
-          if (!Number.isInteger(v)) {
-            throw new Error(
-              `ID column "${defaultDataSource.idColumn}" contains non-integer values.`,
-            );
-          }
-          return +v;
-        }),
-      );
+      ids = Array.from<string | number, number>(idColumnValues, (id) => {
+        const numericId = +id;
+        if (id === "" || !Number.isInteger(numericId)) {
+          throw new Error(`ID value "${id}" is not a valid integer.`);
+        }
+        return numericId;
+      });
     }
 
     let names: string[] | undefined;
@@ -245,11 +220,15 @@ export class CSVTableDataProvider implements TableDataProvider<
           `Name column "${defaultDataSource.nameColumn}" does not exist in the table.`,
         );
       }
-      names = Array.isArray(nameColumnValues)
-        ? nameColumnValues.map(String)
-        : Array.from(nameColumnValues, String);
+      names = Array.from<string | number, string>(nameColumnValues, String);
     }
 
-    return new CSVTableData(n, ids, names, columns!, columnValues);
+    return new CSVTableData(
+      n,
+      ids,
+      names,
+      columns.map((c) => c.name),
+      columnValues,
+    );
   }
 }

--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
@@ -73,8 +73,6 @@ export class CSVTableDataProvider implements TableDataProvider<
     const { signal, workspace = null } = options ?? {};
     signal?.throwIfAborted();
 
-    const defaultDataSource = createDefaultCSVTableDataSource(dataSource);
-
     let columns:
       | {
           name: string;
@@ -83,17 +81,7 @@ export class CSVTableDataProvider implements TableDataProvider<
           data: (string | number)[];
         }[]
       | undefined;
-    if (defaultDataSource.columns !== undefined) {
-      const allColumnNames = defaultDataSource.columns;
-      const columnNames = defaultDataSource.loadColumns ?? allColumnNames;
-      columns = columnNames.map((columnName) => ({
-        name: columnName,
-        index: allColumnNames.indexOf(columnName),
-        isNaN: false,
-        data: [],
-      }));
-    }
-
+    const defaultDataSource = createDefaultCSVTableDataSource(dataSource);
     const parseConfig: Partial<
       papaparse.ParseLocalConfig & papaparse.ParseRemoteConfig
     > = {
@@ -107,15 +95,20 @@ export class CSVTableDataProvider implements TableDataProvider<
       ) => {
         for (const rowData of results.data) {
           if (columns === undefined) {
-            const allColumnNames = rowData;
+            const allColumnNames = defaultDataSource.columns ?? rowData;
             const columnNames = defaultDataSource.loadColumns ?? allColumnNames;
-            columns = columnNames.map((columnName) => ({
-              name: columnName,
-              index: allColumnNames.indexOf(columnName),
-              isNaN: false,
-              data: [],
-            }));
-            continue;
+            columns = columnNames.map((name) => {
+              const index = allColumnNames.indexOf(name);
+              if (index === -1) {
+                throw new Error(
+                  `Column "${name}" specified in "columns" does not exist in the table.`,
+                );
+              }
+              return { name, index, isNaN: false, data: [] };
+            });
+            if (allColumnNames === rowData) {
+              continue;
+            }
           }
           for (const column of columns) {
             const value = rowData[column.index] ?? "";

--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataSource.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataSource.ts
@@ -5,7 +5,6 @@ import { type TableDataSource } from "@tissuumaps/core";
 export const csvTableDataSourceType = "csv";
 
 export const csvTableDataSourceDefaults = {
-  chunkSize: 10000,
   parseConfig: {
     delimiter: ",",
   },
@@ -18,7 +17,6 @@ export interface CSVTableDataSource extends TableDataSource<
   idColumn?: string;
   nameColumn?: string;
   loadColumns?: string[];
-  chunkSize?: number;
   parseConfig?: Pick<
     papaparse.ParseConfig,
     | "delimiter"

--- a/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
@@ -213,10 +213,10 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
       ids: idProperty !== undefined ? ids : undefined,
       names: nameProperty !== undefined ? names : undefined,
       geometry: {
-        shapePolygonOffsets: Uint32Array.from(accumulator.shapePolygonOffsets),
-        polygonRingOffsets: Uint32Array.from(accumulator.polygonRingOffsets),
-        ringVertexOffsets: Uint32Array.from(accumulator.ringVertexOffsets),
-        coords: Float32Array.from(accumulator.coords),
+        shapePolygonOffsets: new Uint32Array(accumulator.shapePolygonOffsets),
+        polygonRingOffsets: new Uint32Array(accumulator.polygonRingOffsets),
+        ringVertexOffsets: new Uint32Array(accumulator.ringVertexOffsets),
+        coords: new Float32Array(accumulator.coords),
       },
     };
   }

--- a/packages/@tissuumaps-storage/src/table/TablePointsData.ts
+++ b/packages/@tissuumaps-storage/src/table/TablePointsData.ts
@@ -45,10 +45,10 @@ export class TablePointsData implements PointsData {
     let [xs, ys] = await Promise.all([xPromise, yPromise]);
     signal?.throwIfAborted();
     if (!(xs instanceof Float32Array)) {
-      xs = Float32Array.from(xs);
+      xs = new Float32Array(xs);
     }
     if (!(ys instanceof Float32Array)) {
-      ys = Float32Array.from(ys);
+      ys = new Float32Array(ys);
     }
     return { xs, ys };
   }


### PR DESCRIPTION
# References and relevant issues

Jira: [TMAP-150](https://scilifelab.atlassian.net/browse/TMAP-150)

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- Enable PapaParse's `worker: true` and switch CSV parsing from the per-row `step` callback to the batched `chunk` callback, so parsing runs off the main thread and the UI stays responsive while loading large CSV files.
- Simplify column accumulation in `CSVTableDataProvider`: values are collected directly into a single per-column array instead of the previous manual fixed-size chunking, and a final `makeColumnValues()` step materializes each column as a `Float32Array` (numeric) or `string[]` (non-numeric). This removes the now-unnecessary `chunkSize` data-source option.
- Improve numeric/NaN handling: a column stays numeric until the first non-parseable value, at which point its already-collected values are lazily converted to strings — avoiding an extra full pass over the data.
- Tighten ID/name column handling with clearer per-value error messages and a single `Array.from` mapping pass.
- Replace `TypedArray.from(...)` with `new TypedArray(...)` constructors in `GeoJSONShapesDataProvider` and `TablePointsData`, which is faster when the input is already an array-like of numbers.

# Screenshot of the fix

N/A — performance/refactor change with no visual difference.

# Use of AI

AI (Claude Code) was used to draft this pull request description.

# Testing

- Instructions on how to test: load a points/table object backed by a large CSV file and confirm that data loads correctly (numeric and string columns, ID/name columns) and that the UI remains responsive during loading.

# Further comments

The `// TODO chunkSize` placeholders in the JSON schema / UI schema were removed alongside the dropped `chunkSize` option.