### PR TITLE
feat: parallelize loading of images/labels/points/shapes/tables (TMAP-347)

### DIFF
--- a/apps/tissuumaps/src/store/slices/project.ts
+++ b/apps/tissuumaps/src/store/slices/project.ts
@@ -71,12 +71,6 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
       get().clearProject();
       set({
         projectName: project.name,
-        layers: structuredClone(project.layers),
-        images: structuredClone(project.images),
-        labels: structuredClone(project.labels),
-        points: structuredClone(project.points),
-        shapes: structuredClone(project.shapes),
-        tables: structuredClone(project.tables),
         markerMaps: structuredClone(project.markerMaps),
         sizeMaps: structuredClone(project.sizeMaps),
         colorMaps: structuredClone(project.colorMaps),
@@ -91,21 +85,29 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
           project.viewerAnimationFinishOptions,
         ),
       });
+      for (const layer of project.layers) {
+        get().addLayer(layer);
+      }
       const loadPromises = [];
+      for (const table of project.tables) {
+        get().addTable(table);
+        loadPromises.push(get().loadTable(table.id, { signal, onProgress }));
+      }
       for (const image of project.images) {
+        get().addImage(image);
         loadPromises.push(get().loadImage(image.id, { signal, onProgress }));
       }
       for (const labels of project.labels) {
+        get().addLabels(labels);
         loadPromises.push(get().loadLabels(labels.id, { signal, onProgress }));
       }
       for (const points of project.points) {
+        get().addPoints(points);
         loadPromises.push(get().loadPoints(points.id, { signal, onProgress }));
       }
       for (const shapes of project.shapes) {
+        get().addShapes(shapes);
         loadPromises.push(get().loadShapes(shapes.id, { signal, onProgress }));
-      }
-      for (const table of project.tables) {
-        loadPromises.push(get().loadTable(table.id, { signal, onProgress }));
       }
       await Promise.all(loadPromises);
     },

--- a/apps/tissuumaps/src/store/slices/project.ts
+++ b/apps/tissuumaps/src/store/slices/project.ts
@@ -93,23 +93,29 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
       project.labels.forEach((labels) => state.addLabels(labels));
       project.points.forEach((points) => state.addPoints(points));
       project.shapes.forEach((shapes) => state.addShapes(shapes));
-      const dataPromises: Promise<Data>[] = [];
+      const promises: Promise<Data>[] = [];
       for (const image of project.images) {
-        dataPromises.push(get().loadImage(image.id, { signal, onProgress }));
+        promises.push(get().loadImage(image.id, { signal, onProgress }));
       }
       for (const labels of project.labels) {
-        dataPromises.push(get().loadLabels(labels.id, { signal, onProgress }));
+        promises.push(get().loadLabels(labels.id, { signal, onProgress }));
       }
       for (const points of project.points) {
-        dataPromises.push(get().loadPoints(points.id, { signal, onProgress }));
+        promises.push(get().loadPoints(points.id, { signal, onProgress }));
       }
       for (const shapes of project.shapes) {
-        dataPromises.push(get().loadShapes(shapes.id, { signal, onProgress }));
+        promises.push(get().loadShapes(shapes.id, { signal, onProgress }));
       }
       for (const table of project.tables) {
-        dataPromises.push(get().loadTable(table.id, { signal, onProgress }));
+        promises.push(get().loadTable(table.id, { signal, onProgress }));
       }
-      await Promise.all(dataPromises);
+      const results = await Promise.allSettled(promises);
+      const errors = results
+        .filter((result) => result.status === "rejected")
+        .map((result) => result.reason as unknown);
+      if (errors.length > 0) {
+        throw new AggregateError(errors, "Failed to load project");
+      }
     },
     (_project, options) => options?.signal,
   ),

--- a/apps/tissuumaps/src/store/slices/project.ts
+++ b/apps/tissuumaps/src/store/slices/project.ts
@@ -71,6 +71,12 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
       get().clearProject();
       set({
         projectName: project.name,
+        layers: structuredClone(project.layers),
+        images: structuredClone(project.images),
+        labels: structuredClone(project.labels),
+        points: structuredClone(project.points),
+        shapes: structuredClone(project.shapes),
+        tables: structuredClone(project.tables),
         markerMaps: structuredClone(project.markerMaps),
         sizeMaps: structuredClone(project.sizeMaps),
         colorMaps: structuredClone(project.colorMaps),
@@ -85,44 +91,23 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
           project.viewerAnimationFinishOptions,
         ),
       });
-      // first, add layers
-      for (const layer of project.layers) {
-        get().addLayer(layer);
+      const loadPromises = [];
+      for (const image of project.images) {
+        loadPromises.push(get().loadImage(image.id, { signal, onProgress }));
       }
-      // then, add and asynchronously load data objects
-      {
-        const tablePromises = project.tables.map((table) => {
-          get().addTable(table);
-          return get().loadTable(table.id, { signal, onProgress });
-        });
-        await Promise.all(tablePromises);
-        signal?.throwIfAborted();
+      for (const labels of project.labels) {
+        loadPromises.push(get().loadLabels(labels.id, { signal, onProgress }));
       }
-      // finally, add and asynchronously load rendered data objects
-      {
-        const imagePromises = project.images.map((image) => {
-          get().addImage(image);
-          return get().loadImage(image.id, { signal, onProgress });
-        });
-        const labelsPromises = project.labels.map((labels) => {
-          get().addLabels(labels);
-          return get().loadLabels(labels.id, { signal, onProgress });
-        });
-        const pointsPromises = project.points.map((points) => {
-          get().addPoints(points);
-          return get().loadPoints(points.id, { signal, onProgress });
-        });
-        const shapesPromises = project.shapes.map((shapes) => {
-          get().addShapes(shapes);
-          return get().loadShapes(shapes.id, { signal, onProgress });
-        });
-        await Promise.all([
-          ...imagePromises,
-          ...labelsPromises,
-          ...pointsPromises,
-          ...shapesPromises,
-        ]);
+      for (const points of project.points) {
+        loadPromises.push(get().loadPoints(points.id, { signal, onProgress }));
       }
+      for (const shapes of project.shapes) {
+        loadPromises.push(get().loadShapes(shapes.id, { signal, onProgress }));
+      }
+      for (const table of project.tables) {
+        loadPromises.push(get().loadTable(table.id, { signal, onProgress }));
+      }
+      await Promise.all(loadPromises);
     },
     (_project, options) => options?.signal,
   ),

--- a/apps/tissuumaps/src/store/slices/project.ts
+++ b/apps/tissuumaps/src/store/slices/project.ts
@@ -1,5 +1,6 @@
 import {
   type Color,
+  type Data,
   type DefaultMap,
   type Marker,
   type ProgressCallback,
@@ -88,28 +89,28 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
       for (const layer of project.layers) {
         get().addLayer(layer);
       }
-      const loadPromises = [];
+      const dataPromises: Promise<Data>[] = [];
       for (const table of project.tables) {
         get().addTable(table);
-        loadPromises.push(get().loadTable(table.id, { signal, onProgress }));
+        dataPromises.push(get().loadTable(table.id, { signal, onProgress }));
       }
       for (const image of project.images) {
         get().addImage(image);
-        loadPromises.push(get().loadImage(image.id, { signal, onProgress }));
+        dataPromises.push(get().loadImage(image.id, { signal, onProgress }));
       }
       for (const labels of project.labels) {
         get().addLabels(labels);
-        loadPromises.push(get().loadLabels(labels.id, { signal, onProgress }));
+        dataPromises.push(get().loadLabels(labels.id, { signal, onProgress }));
       }
       for (const points of project.points) {
         get().addPoints(points);
-        loadPromises.push(get().loadPoints(points.id, { signal, onProgress }));
+        dataPromises.push(get().loadPoints(points.id, { signal, onProgress }));
       }
       for (const shapes of project.shapes) {
         get().addShapes(shapes);
-        loadPromises.push(get().loadShapes(shapes.id, { signal, onProgress }));
+        dataPromises.push(get().loadShapes(shapes.id, { signal, onProgress }));
       }
-      await Promise.all(loadPromises);
+      await Promise.all(dataPromises);
     },
     (_project, options) => options?.signal,
   ),

--- a/apps/tissuumaps/src/store/slices/project.ts
+++ b/apps/tissuumaps/src/store/slices/project.ts
@@ -110,8 +110,12 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
         promises.push(get().loadTable(table.id, { signal, onProgress }));
       }
       const results = await Promise.allSettled(promises);
+      signal?.throwIfAborted();
       const errors = results
-        .filter((result) => result.status === "rejected")
+        .filter(
+          (result): result is PromiseRejectedResult =>
+            result.status === "rejected",
+        )
         .map((result) => result.reason as unknown);
       if (errors.length > 0) {
         throw new AggregateError(errors, "Failed to load project");

--- a/apps/tissuumaps/src/store/slices/project.ts
+++ b/apps/tissuumaps/src/store/slices/project.ts
@@ -86,29 +86,28 @@ export const createProjectSlice: TissUUmapsStateCreator<ProjectSlice> = (
           project.viewerAnimationFinishOptions,
         ),
       });
-      for (const layer of project.layers) {
-        get().addLayer(layer);
-      }
+      const state = get();
+      project.layers.forEach((layer) => state.addLayer(layer));
+      project.tables.forEach((table) => state.addTable(table));
+      project.images.forEach((image) => state.addImage(image));
+      project.labels.forEach((labels) => state.addLabels(labels));
+      project.points.forEach((points) => state.addPoints(points));
+      project.shapes.forEach((shapes) => state.addShapes(shapes));
       const dataPromises: Promise<Data>[] = [];
-      for (const table of project.tables) {
-        get().addTable(table);
-        dataPromises.push(get().loadTable(table.id, { signal, onProgress }));
-      }
       for (const image of project.images) {
-        get().addImage(image);
         dataPromises.push(get().loadImage(image.id, { signal, onProgress }));
       }
       for (const labels of project.labels) {
-        get().addLabels(labels);
         dataPromises.push(get().loadLabels(labels.id, { signal, onProgress }));
       }
       for (const points of project.points) {
-        get().addPoints(points);
         dataPromises.push(get().loadPoints(points.id, { signal, onProgress }));
       }
       for (const shapes of project.shapes) {
-        get().addShapes(shapes);
         dataPromises.push(get().loadShapes(shapes.id, { signal, onProgress }));
+      }
+      for (const table of project.tables) {
+        dataPromises.push(get().loadTable(table.id, { signal, onProgress }));
       }
       await Promise.all(dataPromises);
     },


### PR DESCRIPTION
# References and relevant issues

TMAP-347

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- Parallelize loading of images, labels, points, shapes and tables in the project slice, so the data objects of a project are loaded concurrently rather than sequentially.
- Simplify the loading logic in `apps/tissuumaps/src/store/slices/project.ts`.

# Screenshot of the fix

<!-- Attach screenshot if relevant. -->

# Use of AI

AI (Claude Code) was used to assist with creating this pull request.

# Testing

- Instructions on how to test

# Further comments

<!-- Specify questions or related information. -->
