### PR TITLE
refactor: harmonize number parsing

### DIFF
--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -864,10 +864,10 @@ export class WebGLShapesController extends WebGLControllerBase {
       ringVertexOffsets,
       coords,
     } = geometry;
-    let xMin = Infinity,
-      yMin = Infinity,
-      xMax = -Infinity,
-      yMax = -Infinity;
+    let xMin: number | undefined,
+      yMin: number | undefined,
+      xMax: number | undefined,
+      yMax: number | undefined;
     const maybeYield = AsyncUtils.createYielder({ signal });
     for (let s = 0; s < shapePolygonOffsets.length - 1; s++) {
       if (shapeMask !== undefined && !shapeMask[s]) {
@@ -882,23 +882,28 @@ export class WebGLShapesController extends WebGLControllerBase {
         for (let v = shellVertexStart; v < shellVertexEnd; v++) {
           const x = coords[2 * v]!;
           const y = coords[2 * v + 1]!;
-          if (x < xMin) {
+          if (xMin === undefined || x < xMin) {
             xMin = x;
           }
-          if (y < yMin) {
+          if (yMin === undefined || y < yMin) {
             yMin = y;
           }
-          if (x > xMax) {
+          if (xMax === undefined || x > xMax) {
             xMax = x;
           }
-          if (y > yMax) {
+          if (yMax === undefined || y > yMax) {
             yMax = y;
           }
         }
       }
       await maybeYield();
     }
-    if (!Number.isFinite(xMin) || !Number.isFinite(yMin)) {
+    if (
+      xMin === undefined ||
+      yMin === undefined ||
+      xMax === undefined ||
+      yMax === undefined
+    ) {
       throw new Error("Shapes geometry must not be empty");
     }
     if (xMin >= xMax || yMin >= yMax) {

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -1028,11 +1028,7 @@ export class WebGLShapesController extends WebGLControllerBase {
           }
           const scanlineShape = scanline.shapes.get(shapeIndex);
           if (scanlineShape === undefined) {
-            scanline.shapes.set(shapeIndex, {
-              xMin: xMin,
-              xMax: xMax,
-              edges: [],
-            });
+            scanline.shapes.set(shapeIndex, { xMin, xMax, edges: [] });
             totalNumScanlineShapes++;
           } else {
             scanlineShape.xMin = Math.min(scanlineShape.xMin, xMin);

--- a/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
+++ b/packages/@tissuumaps-core/src/controllers/WebGLShapesController.ts
@@ -864,10 +864,10 @@ export class WebGLShapesController extends WebGLControllerBase {
       ringVertexOffsets,
       coords,
     } = geometry;
-    let xMin: number | undefined,
-      yMin: number | undefined,
-      xMax: number | undefined,
-      yMax: number | undefined;
+    let xMin = Infinity,
+      yMin = Infinity,
+      xMax = -Infinity,
+      yMax = -Infinity;
     const maybeYield = AsyncUtils.createYielder({ signal });
     for (let s = 0; s < shapePolygonOffsets.length - 1; s++) {
       if (shapeMask !== undefined && !shapeMask[s]) {
@@ -882,16 +882,16 @@ export class WebGLShapesController extends WebGLControllerBase {
         for (let v = shellVertexStart; v < shellVertexEnd; v++) {
           const x = coords[2 * v]!;
           const y = coords[2 * v + 1]!;
-          if (xMin === undefined || x < xMin) {
+          if (x < xMin) {
             xMin = x;
           }
-          if (yMin === undefined || y < yMin) {
+          if (y < yMin) {
             yMin = y;
           }
-          if (xMax === undefined || x > xMax) {
+          if (x > xMax) {
             xMax = x;
           }
-          if (yMax === undefined || y > yMax) {
+          if (y > yMax) {
             yMax = y;
           }
         }
@@ -899,10 +899,10 @@ export class WebGLShapesController extends WebGLControllerBase {
       await maybeYield();
     }
     if (
-      xMin === undefined ||
-      yMin === undefined ||
-      xMax === undefined ||
-      yMax === undefined
+      !Number.isFinite(xMin) ||
+      !Number.isFinite(yMin) ||
+      !Number.isFinite(xMax) ||
+      !Number.isFinite(yMax)
     ) {
       throw new Error("Shapes geometry must not be empty");
     }

--- a/packages/@tissuumaps-core/src/index.ts
+++ b/packages/@tissuumaps-core/src/index.ts
@@ -25,6 +25,7 @@ export { AsyncUtils } from "./utils/AsyncUtils";
 export { ColorUtils } from "./utils/ColorUtils";
 export { HashUtils } from "./utils/HashUtils";
 export { MathUtils } from "./utils/MathUtils";
+export { ParseUtils } from "./utils/ParseUtils";
 export { TransformUtils } from "./utils/TransformUtils";
 export { WebGLUtils } from "./utils/WebGLUtils";
 export { MarkerDataUtils } from "./utils/data/MarkerDataUtils";

--- a/packages/@tissuumaps-core/src/utils/ParseUtils.test.ts
+++ b/packages/@tissuumaps-core/src/utils/ParseUtils.test.ts
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { ParseUtils } from "./ParseUtils";
 
-describe("ParserUtils", () => {
+describe("ParseUtils", () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });

--- a/packages/@tissuumaps-core/src/utils/ParseUtils.test.ts
+++ b/packages/@tissuumaps-core/src/utils/ParseUtils.test.ts
@@ -1,0 +1,146 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { ParseUtils } from "./ParseUtils";
+
+describe("ParserUtils", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("tryParseFinite", () => {
+    it("returns finite numbers as-is", () => {
+      expect(ParseUtils.tryParseFinite(0)).toBe(0);
+      expect(ParseUtils.tryParseFinite(42)).toBe(42);
+      expect(ParseUtils.tryParseFinite(-3.14)).toBe(-3.14);
+    });
+
+    it("returns undefined for non-finite numbers", () => {
+      expect(ParseUtils.tryParseFinite(NaN)).toBeUndefined();
+      expect(ParseUtils.tryParseFinite(Infinity)).toBeUndefined();
+      expect(ParseUtils.tryParseFinite(-Infinity)).toBeUndefined();
+    });
+
+    it("parses numeric strings", () => {
+      expect(ParseUtils.tryParseFinite("42")).toBe(42);
+      expect(ParseUtils.tryParseFinite("-3.14")).toBe(-3.14);
+      expect(ParseUtils.tryParseFinite("  7  ")).toBe(7);
+      expect(ParseUtils.tryParseFinite("1e3")).toBe(1000);
+    });
+
+    it("returns undefined for empty or whitespace-only strings", () => {
+      expect(ParseUtils.tryParseFinite("")).toBeUndefined();
+      expect(ParseUtils.tryParseFinite("   ")).toBeUndefined();
+    });
+
+    it("returns undefined for non-numeric strings", () => {
+      expect(ParseUtils.tryParseFinite("abc")).toBeUndefined();
+      expect(ParseUtils.tryParseFinite("12px")).toBeUndefined();
+    });
+
+    it("returns undefined for non-number, non-string, non-bigint values", () => {
+      expect(ParseUtils.tryParseFinite(undefined)).toBeUndefined();
+      expect(ParseUtils.tryParseFinite(null)).toBeUndefined();
+      expect(ParseUtils.tryParseFinite(true)).toBeUndefined();
+      expect(ParseUtils.tryParseFinite({})).toBeUndefined();
+      expect(ParseUtils.tryParseFinite([])).toBeUndefined();
+    });
+
+    it("parses bigints within the safe integer range", () => {
+      expect(ParseUtils.tryParseFinite(42n)).toBe(42);
+      expect(ParseUtils.tryParseFinite(-7n)).toBe(-7);
+      expect(ParseUtils.tryParseFinite(BigInt(Number.MAX_SAFE_INTEGER))).toBe(
+        Number.MAX_SAFE_INTEGER,
+      );
+    });
+
+    it("warns but still parses out-of-range bigints by default", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const big = BigInt(Number.MAX_SAFE_INTEGER) + 10n;
+      expect(ParseUtils.tryParseFinite(big)).toBe(Number(big));
+      expect(warn).toHaveBeenCalledOnce();
+    });
+
+    it("returns undefined for out-of-range bigints when requireSafeBigInt is set", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const big = BigInt(Number.MAX_SAFE_INTEGER) + 10n;
+      expect(
+        ParseUtils.tryParseFinite(big, { requireSafeBigInt: true }),
+      ).toBeUndefined();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("does not warn for in-range bigints", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      ParseUtils.tryParseFinite(42n);
+      expect(warn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("parseFinite", () => {
+    it("returns the parsed finite number", () => {
+      expect(ParseUtils.parseFinite("3.5")).toBe(3.5);
+      expect(ParseUtils.parseFinite(10)).toBe(10);
+    });
+
+    it("throws for non-finite values", () => {
+      expect(() => ParseUtils.parseFinite("abc")).toThrow(
+        "Value is not a finite number: abc",
+      );
+      expect(() => ParseUtils.parseFinite(NaN)).toThrow(
+        "Value is not a finite number",
+      );
+      expect(() => ParseUtils.parseFinite(undefined)).toThrow(
+        "Value is not a finite number",
+      );
+    });
+  });
+
+  describe("tryParseSafeInt", () => {
+    it("returns safe integers", () => {
+      expect(ParseUtils.tryParseSafeInt(0)).toBe(0);
+      expect(ParseUtils.tryParseSafeInt(42)).toBe(42);
+      expect(ParseUtils.tryParseSafeInt("-7")).toBe(-7);
+      expect(ParseUtils.tryParseSafeInt(42n)).toBe(42);
+    });
+
+    it("returns undefined for non-integer finite numbers", () => {
+      expect(ParseUtils.tryParseSafeInt(3.14)).toBeUndefined();
+      expect(ParseUtils.tryParseSafeInt("2.5")).toBeUndefined();
+    });
+
+    it("returns undefined for unsafe integers", () => {
+      expect(
+        ParseUtils.tryParseSafeInt(Number.MAX_SAFE_INTEGER + 1),
+      ).toBeUndefined();
+    });
+
+    it("returns undefined for out-of-range bigints without warning", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const big = BigInt(Number.MAX_SAFE_INTEGER) + 10n;
+      expect(ParseUtils.tryParseSafeInt(big)).toBeUndefined();
+      expect(warn).not.toHaveBeenCalled();
+    });
+
+    it("returns undefined for non-parsable values", () => {
+      expect(ParseUtils.tryParseSafeInt("abc")).toBeUndefined();
+      expect(ParseUtils.tryParseSafeInt(null)).toBeUndefined();
+      expect(ParseUtils.tryParseSafeInt(NaN)).toBeUndefined();
+    });
+  });
+
+  describe("parseSafeInt", () => {
+    it("returns the parsed safe integer", () => {
+      expect(ParseUtils.parseSafeInt("42")).toBe(42);
+      expect(ParseUtils.parseSafeInt(-7)).toBe(-7);
+    });
+
+    it("throws for non-safe-integer values", () => {
+      expect(() => ParseUtils.parseSafeInt(3.14)).toThrow(
+        "Value is not a safe integer: 3.14",
+      );
+      expect(() => ParseUtils.parseSafeInt("abc")).toThrow(
+        "Value is not a safe integer",
+      );
+    });
+  });
+});

--- a/packages/@tissuumaps-core/src/utils/ParseUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/ParseUtils.ts
@@ -1,27 +1,27 @@
 export class ParseUtils {
   static parseFinite(value: unknown): number {
-    const finite = ParseUtils.tryParseFinite(value);
-    if (finite === undefined) {
+    const v = ParseUtils.tryParseFinite(value);
+    if (v === undefined) {
       throw new Error(`Value is not a finite number: ${String(value)}`);
     }
-    return finite;
+    return v;
   }
 
   static parseSafeInt(value: unknown): number {
-    const safeInt = ParseUtils.tryParseSafeInt(value);
-    if (safeInt === undefined) {
+    const v = ParseUtils.tryParseSafeInt(value);
+    if (v === undefined) {
       throw new Error(`Value is not a safe integer: ${String(value)}`);
     }
-    return safeInt;
+    return v;
   }
 
   static tryParseFinite(
     value: unknown,
     options?: { requireSafeBigInt?: boolean },
   ): number | undefined {
-    let number;
+    let v: number;
     if (typeof value === "number") {
-      number = value;
+      v = value;
     } else if (typeof value === "bigint") {
       if (value < Number.MIN_SAFE_INTEGER || value > Number.MAX_SAFE_INTEGER) {
         if (options?.requireSafeBigInt) {
@@ -29,13 +29,13 @@ export class ParseUtils {
         }
         console.warn(`Value ${value} is outside the safe integer range`);
       }
-      number = Number(value);
+      v = Number(value);
     } else if (typeof value === "string" && value.trim() !== "") {
-      number = Number(value);
+      v = Number(value);
     } else {
       return undefined;
     }
-    return Number.isFinite(number) ? number : undefined;
+    return Number.isFinite(v) ? v : undefined;
   }
 
   static tryParseSafeInt(value: unknown): number | undefined {

--- a/packages/@tissuumaps-core/src/utils/ParseUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/ParseUtils.ts
@@ -23,7 +23,10 @@ export class ParseUtils {
     if (typeof value === "number") {
       v = value;
     } else if (typeof value === "bigint") {
-      if (value < Number.MIN_SAFE_INTEGER || value > Number.MAX_SAFE_INTEGER) {
+      if (
+        value < BigInt(Number.MIN_SAFE_INTEGER) ||
+        value > BigInt(Number.MAX_SAFE_INTEGER)
+      ) {
         if (options?.requireSafeBigInt) {
           return undefined;
         }

--- a/packages/@tissuumaps-core/src/utils/ParseUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/ParseUtils.ts
@@ -1,0 +1,48 @@
+export class ParseUtils {
+  static parseFinite(value: unknown): number {
+    const finite = ParseUtils.tryParseFinite(value);
+    if (finite === undefined) {
+      throw new Error(`Value is not a finite number: ${String(value)}`);
+    }
+    return finite;
+  }
+
+  static parseSafeInt(value: unknown): number {
+    const safeInt = ParseUtils.tryParseSafeInt(value);
+    if (safeInt === undefined) {
+      throw new Error(`Value is not a safe integer: ${String(value)}`);
+    }
+    return safeInt;
+  }
+
+  static tryParseFinite(
+    value: unknown,
+    options?: { requireSafeBigInt?: boolean },
+  ): number | undefined {
+    let number;
+    if (typeof value === "number") {
+      number = value;
+    } else if (typeof value === "bigint") {
+      if (value < Number.MIN_SAFE_INTEGER || value > Number.MAX_SAFE_INTEGER) {
+        if (options?.requireSafeBigInt) {
+          return undefined;
+        }
+        console.warn(`Value ${value} is outside the safe integer range`);
+      }
+      number = Number(value);
+    } else if (typeof value === "string" && value.trim() !== "") {
+      number = Number(value);
+    } else {
+      return undefined;
+    }
+    return Number.isFinite(number) ? number : undefined;
+  }
+
+  static tryParseSafeInt(value: unknown): number | undefined {
+    const v = ParseUtils.tryParseFinite(value, { requireSafeBigInt: true });
+    if (v === undefined) {
+      return undefined;
+    }
+    return Number.isSafeInteger(v) ? v : undefined;
+  }
+}

--- a/packages/@tissuumaps-core/src/utils/data/ColorDataUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/data/ColorDataUtils.ts
@@ -371,7 +371,7 @@ export class ColorDataUtils extends DataUtilsBase {
       );
       return colorPalette.colors[index]!;
     }
-    console.warn(`Invalid color value: ${String(v)}`);
+    console.warn(`Invalid color value: ${String(value)}`);
     return undefined;
   }
 

--- a/packages/@tissuumaps-core/src/utils/data/ColorDataUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/data/ColorDataUtils.ts
@@ -17,6 +17,7 @@ import { AsyncUtils } from "../AsyncUtils";
 import { ColorUtils } from "../ColorUtils";
 import { HashUtils } from "../HashUtils";
 import { MathUtils } from "../MathUtils";
+import { ParseUtils } from "../ParseUtils";
 import { DataUtilsBase } from "./DataUtilsBase";
 
 export class ColorDataUtils extends DataUtilsBase {
@@ -359,9 +360,10 @@ export class ColorDataUtils extends DataUtilsBase {
     configuredValueRange: [number, number] | undefined,
     colorPalette: ColorPalette,
   ): Color | undefined {
-    if (typeof value === "number" && Number.isFinite(value)) {
+    const v = ParseUtils.tryParseFinite(value, { requireSafeBigInt: true });
+    if (v !== undefined) {
       const [vmin, vmax] = configuredValueRange ?? valueRange ?? [0, 1];
-      const vnorm = (value - vmin) / (vmax - vmin);
+      const vnorm = (v - vmin) / (vmax - vmin);
       const index = MathUtils.clamp(
         Math.floor(vnorm * colorPalette.colors.length),
         0,
@@ -369,7 +371,7 @@ export class ColorDataUtils extends DataUtilsBase {
       );
       return colorPalette.colors[index]!;
     }
-    console.warn(`Invalid color value: ${String(value)}`);
+    console.warn(`Invalid color value: ${String(v)}`);
     return undefined;
   }
 

--- a/packages/@tissuumaps-storage/src/csv/CSVTableData.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableData.ts
@@ -1,8 +1,9 @@
-import type {
-  GenericArray,
-  ProgressCallback,
-  TableData,
-  TypedArray,
+import {
+  type GenericArray,
+  ParseUtils,
+  type ProgressCallback,
+  type TableData,
+  type TypedArray,
 } from "@tissuumaps/core";
 
 export class CSVTableData implements TableData {
@@ -100,8 +101,8 @@ export class CSVTableData implements TableData {
     if (typeof values[0] === "number") {
       let vmin, vmax;
       for (let i = 0; i < values.length; i++) {
-        const v = values[i];
-        if (typeof v === "number" && Number.isFinite(v)) {
+        const v = ParseUtils.tryParseFinite(values[i]);
+        if (v !== undefined) {
           if (vmin === undefined || v < vmin) {
             vmin = v;
           }

--- a/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableDataProvider.ts
@@ -1,9 +1,10 @@
 import * as papaparse from "papaparse";
 
-import type {
-  ProgressCallback,
-  TableDataProvider,
-  TypedArray,
+import {
+  ParseUtils,
+  type ProgressCallback,
+  type TableDataProvider,
+  type TypedArray,
 } from "@tissuumaps/core";
 
 import { CSVTableData } from "./CSVTableData";
@@ -138,15 +139,10 @@ export class CSVTableDataProvider implements TableDataProvider<
             if (Array.isArray(columnChunk)) {
               columnChunk[currentChunkRow] = value;
             } else {
-              let valueIsNaN = value === "";
-              if (!valueIsNaN) {
-                const numericValue = +value;
-                valueIsNaN = isNaN(numericValue);
-                if (!valueIsNaN) {
-                  columnChunk[currentChunkRow] = numericValue;
-                }
-              }
-              if (valueIsNaN) {
+              const numericValue = ParseUtils.tryParseFinite(value);
+              if (numericValue !== undefined) {
+                columnChunk[currentChunkRow] = numericValue;
+              } else {
                 column.isNaN = true;
                 for (let i = 0; i < column.chunks.length; i++) {
                   column.chunks[i] = Array.from(column.chunks[i]!, String);
@@ -244,13 +240,9 @@ export class CSVTableDataProvider implements TableDataProvider<
           `ID column "${defaultDataSource.idColumn}" does not exist in the table.`,
         );
       }
-      ids = Array.from<string | number, number>(idColumnValues, (id) => {
-        const numericId = +id;
-        if (id === "" || !Number.isInteger(numericId)) {
-          throw new Error(`ID value "${id}" is not a valid integer.`);
-        }
-        return numericId;
-      });
+      ids = Array.from<string | number, number>(idColumnValues, (id) =>
+        ParseUtils.parseSafeInt(id),
+      );
     }
 
     let names: string[] | undefined;

--- a/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesDataProvider.ts
@@ -1,9 +1,10 @@
 import type * as geojson from "geojson";
 
-import type {
-  ProgressCallback,
-  ShapesDataProvider,
-  ShapesGeometry,
+import {
+  ParseUtils,
+  type ProgressCallback,
+  type ShapesDataProvider,
+  type ShapesGeometry,
 } from "@tissuumaps/core";
 
 import { GeoJSONShapesData } from "./GeoJSONShapesData";
@@ -166,14 +167,10 @@ export class GeoJSONShapesDataProvider implements ShapesDataProvider<
           );
           if (shapeAppended && idProperty !== undefined) {
             const id = feature.properties?.[idProperty] as unknown;
-            if (
-              id === undefined ||
-              typeof id !== "number" ||
-              !Number.isInteger(id)
-            ) {
-              throw new Error(`Feature is missing integer ID '${idProperty}'.`);
+            if (id === undefined) {
+              throw new Error(`Feature is missing ID '${idProperty}'`);
             }
-            ids.push(id);
+            ids.push(ParseUtils.parseSafeInt(id));
           }
           if (shapeAppended && nameProperty !== undefined) {
             const name = feature.properties?.[nameProperty] as unknown;

--- a/packages/@tissuumaps-storage/src/parquet/ParquetTableData.ts
+++ b/packages/@tissuumaps-storage/src/parquet/ParquetTableData.ts
@@ -2,10 +2,11 @@ import * as hyparquet from "hyparquet";
 import { compressors } from "hyparquet-compressors";
 import { parquetReadColumn } from "hyparquet/src/read.js";
 
-import type {
-  GenericArray,
-  ProgressCallback,
-  TableData,
+import {
+  type GenericArray,
+  ParseUtils,
+  type ProgressCallback,
+  type TableData,
 } from "@tissuumaps/core";
 
 export class ParquetTableData implements TableData {
@@ -39,7 +40,7 @@ export class ParquetTableData implements TableData {
   }
 
   getSize(): number {
-    return Number(this._metadata.num_rows);
+    return ParseUtils.parseSafeInt(this._metadata.num_rows);
   }
 
   getNames(): string[] | undefined {
@@ -107,8 +108,8 @@ export class ParquetTableData implements TableData {
     if (typeof values[0] === "number") {
       let vmin, vmax;
       for (let i = 0; i < values.length; i++) {
-        const v = values[i];
-        if (typeof v === "number" && Number.isFinite(v)) {
+        const v = ParseUtils.tryParseFinite(values[i]);
+        if (v !== undefined) {
           if (vmin === undefined || v < vmin) {
             vmin = v;
           }

--- a/packages/@tissuumaps-storage/src/parquet/ParquetTableDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/parquet/ParquetTableDataProvider.ts
@@ -2,7 +2,11 @@ import * as hyparquet from "hyparquet";
 import { compressors } from "hyparquet-compressors";
 import { parquetReadColumn } from "hyparquet/src/read.js";
 
-import type { ProgressCallback, TableDataProvider } from "@tissuumaps/core";
+import {
+  ParseUtils,
+  type ProgressCallback,
+  type TableDataProvider,
+} from "@tissuumaps/core";
 
 import { ParquetTableData } from "./ParquetTableData";
 import {
@@ -100,14 +104,7 @@ export class ParquetTableDataProvider implements TableDataProvider<
         compressors: compressors,
       });
       signal?.throwIfAborted();
-      for (let i = 0; i < rawIdColumnData.length; i++) {
-        if (!Number.isInteger(rawIdColumnData[i])) {
-          throw new Error(
-            `ID column "${defaultDataSource.idColumn}" contains non-integer values.`,
-          );
-        }
-      }
-      ids = Array.from(rawIdColumnData);
+      ids = Array.from(rawIdColumnData, (id) => ParseUtils.parseSafeInt(id));
     }
 
     let names;
@@ -119,14 +116,6 @@ export class ParquetTableDataProvider implements TableDataProvider<
         compressors: compressors,
       });
       signal?.throwIfAborted();
-      for (let i = 0; i < rawNameColumnData.length; i++) {
-        const name = rawNameColumnData[i] as unknown;
-        if (name === undefined) {
-          throw new Error(
-            `Name column "${defaultDataSource.nameColumn}" contains undefined values.`,
-          );
-        }
-      }
       names = Array.from(rawNameColumnData, String);
     }
 


### PR DESCRIPTION
# References and relevant issues

<!-- No associated Jira issue. -->

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- Added `ParseUtils` to `@tissuumaps/core` with `parseFinite` / `parseSafeInt` (throwing) and `tryParseFinite` / `tryParseSafeInt` (undefined-returning) helpers, exported from the package index.
- Centralized number parsing: handles `number`, `bigint` (warning or rejecting when outside the safe-integer range), and non-empty `string` inputs in one place.
- Replaced ad-hoc number parsing throughout the storage providers (CSV, Parquet, GeoJSON) and `ColorDataUtils` / `WebGLShapesController` with `ParseUtils`.
- Added unit tests for `ParseUtils`.

# Screenshot of the fix

<!-- Not applicable. -->

# Use of AI

AI (Claude Code) was used to assist with the refactor and to draft this PR.

# Testing

- Instructions on how to test: run `pnpm --filter @tissuumaps/core test` (includes the new `ParseUtils.test.ts`).

# Further comments

Pure refactor to harmonize number parsing; no behavior change intended for valid inputs.
