### PR TITLE
feat: add load project from URL button

### DIFF
--- a/apps/tissuumaps/src/bootstrap.ts
+++ b/apps/tissuumaps/src/bootstrap.ts
@@ -1,5 +1,5 @@
 import { startDataCaches } from "./data/cache";
-import { loadProjectFromURL, projectUrlParam } from "./data/io/project";
+import { loadProjectFromURL, projectURLParam } from "./data/io/project";
 import { enableBuiltInDataProviders } from "./data/providers";
 import { notifyTissUUmapsLoaded } from "./events";
 import { startPluginRegistry } from "./plugins";
@@ -32,7 +32,7 @@ export function bootstrap(): () => void {
 }
 
 /**
- * Starts loading the project named by the {@link projectUrlParam} GET
+ * Starts loading the project named by the {@link projectURLParam} GET
  * parameter, falling back to {@link fallbackProjectUrl} if it is absent or empty
  *
  * Failures are logged, unless loading was cancelled.
@@ -42,7 +42,7 @@ export function bootstrap(): () => void {
 function loadInitialProject(): () => void {
   const abortController = new AbortController();
   const params = new URLSearchParams(window.location.search);
-  const projectUrl = params.get(projectUrlParam) || fallbackProjectUrl;
+  const projectUrl = params.get(projectURLParam) || fallbackProjectUrl;
   loadProjectFromURL(projectUrl, { signal: abortController.signal }).catch(
     (error) => {
       if (!abortController.signal.aborted) {

--- a/apps/tissuumaps/src/bootstrap.ts
+++ b/apps/tissuumaps/src/bootstrap.ts
@@ -1,11 +1,8 @@
 import { startDataCaches } from "./data/cache";
-import { loadProjectFromURL } from "./data/io/project";
+import { loadProjectFromURL, projectUrlParam } from "./data/io/project";
 import { enableBuiltInDataProviders } from "./data/providers";
 import { notifyTissUUmapsLoaded } from "./events";
 import { startPluginRegistry } from "./plugins";
-
-/** The GET parameter naming the project to load on startup */
-const projectUrlParam = "project";
 
 /** The project loaded on startup when the URL does not name one */
 const fallbackProjectUrl = "project.json";

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
@@ -12,9 +12,11 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
+  clearProjectUrlParam,
   loadProjectFromFile,
   loadProjectFromURL,
   saveAndDownloadProjectToJSON,
+  setProjectUrlParam,
 } from "@/data/io/project";
 import { useProjectStore } from "@/stores/project";
 
@@ -40,9 +42,7 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
     }
     loadProjectFromURL(projectUrl)
       .then(() => {
-        const url = new URL(window.location.href);
-        url.searchParams.set("project", projectUrl);
-        window.history.replaceState({}, "", url);
+        setProjectUrlParam(projectUrl);
       })
       .catch((error) => {
         console.error(`Failed to load project from ${projectUrl}:`, error);
@@ -57,9 +57,7 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
       )
     ) {
       clearProject();
-      const url = new URL(window.location.href);
-      url.searchParams.delete("project");
-      window.history.replaceState({}, "", url);
+      clearProjectUrlParam();
     }
   }, [clearProject]);
 

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
@@ -12,11 +12,11 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import {
-  clearProjectUrlParam,
+  clearProjectURLParam,
   loadProjectFromFile,
   loadProjectFromURL,
   saveAndDownloadProjectToJSON,
-  setProjectUrlParam,
+  setProjectURLParam,
 } from "@/data/io/project";
 import { useProjectStore } from "@/stores/project";
 
@@ -42,10 +42,10 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
     }
     loadProjectFromURL(projectUrl)
       .then(() => {
-        setProjectUrlParam(projectUrl);
+        setProjectURLParam(projectUrl);
       })
       .catch((error) => {
-        console.error(`Failed to load project from ${projectUrl}:`, error);
+        console.error("Failed to load project from URL", error);
       });
   }, []);
 
@@ -57,7 +57,7 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
       )
     ) {
       clearProject();
-      clearProjectUrlParam();
+      clearProjectURLParam();
     }
   }, [clearProject]);
 
@@ -98,9 +98,13 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
             onChange={(event) => {
               const files = event.target.files;
               if (files !== null && files.length > 0) {
-                loadProjectFromFile(files[0]!).catch((error) => {
-                  console.error("Failed to load project from file", error);
-                });
+                loadProjectFromFile(files[0]!)
+                  .then(() => {
+                    clearProjectURLParam();
+                  })
+                  .catch((error) => {
+                    console.error("Failed to load project from file", error);
+                  });
               }
             }}
             hidden

--- a/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/ProjectPanel/index.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import {
   loadProjectFromFile,
+  loadProjectFromURL,
   saveAndDownloadProjectToJSON,
 } from "@/data/io/project";
 import { useProjectStore } from "@/stores/project";
@@ -30,6 +31,23 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
   const name = useProjectStore((state) => state.name);
   const setName = useProjectStore((state) => state.setName);
   const clearProject = useProjectStore((state) => state.clear);
+
+  const promptLoadProjectFromURL = useCallback(() => {
+    // TODO replace by dialog overlay
+    const projectUrl = window.prompt("Enter project URL to load")?.trim();
+    if (!projectUrl) {
+      return;
+    }
+    loadProjectFromURL(projectUrl)
+      .then(() => {
+        const url = new URL(window.location.href);
+        url.searchParams.set("project", projectUrl);
+        window.history.replaceState({}, "", url);
+      })
+      .catch((error) => {
+        console.error(`Failed to load project from ${projectUrl}:`, error);
+      });
+  }, []);
 
   const confirmClearProject = useCallback(() => {
     if (
@@ -99,7 +117,16 @@ export function ProjectPanel({ className }: ProjectPanelProps) {
                   }
                 }}
               >
-                Load project
+                Load project from file
+              </Button>
+            }
+          />
+        </Field>
+        <Field>
+          <FieldControl
+            render={
+              <Button onClick={() => promptLoadProjectFromURL()}>
+                Load project from URL
               </Button>
             }
           />

--- a/apps/tissuumaps/src/data/io/project.ts
+++ b/apps/tissuumaps/src/data/io/project.ts
@@ -9,6 +9,9 @@ import {
 
 import { projectStore } from "@/stores/project";
 
+/** The GET parameter naming the project to load */
+export const projectUrlParam = "project";
+
 /**
  * Creates a deep copy of a project, keeping only the project's own properties
  *
@@ -144,4 +147,25 @@ export function saveAndDownloadProjectToJSON(project?: Project): void {
   projectLink.href = projectUrl;
   projectLink.click();
   setTimeout(() => URL.revokeObjectURL(projectUrl), 60_000);
+}
+
+/**
+ * Records the project URL in the address bar, so that reloading the page
+ * restores the same project
+ *
+ * @param projectUrl - The URL the project was loaded from
+ */
+export function setProjectUrlParam(projectUrl: string): void {
+  const url = new URL(window.location.href);
+  url.searchParams.set(projectUrlParam, projectUrl);
+  window.history.replaceState({}, "", url);
+}
+
+/**
+ * Removes the project URL from the address bar
+ */
+export function clearProjectUrlParam(): void {
+  const url = new URL(window.location.href);
+  url.searchParams.delete(projectUrlParam);
+  window.history.replaceState({}, "", url);
 }

--- a/apps/tissuumaps/src/data/io/project.ts
+++ b/apps/tissuumaps/src/data/io/project.ts
@@ -10,7 +10,7 @@ import {
 import { projectStore } from "@/stores/project";
 
 /** The GET parameter naming the project to load */
-export const projectUrlParam = "project";
+export const projectURLParam = "project";
 
 /**
  * Creates a deep copy of a project, keeping only the project's own properties
@@ -155,17 +155,17 @@ export function saveAndDownloadProjectToJSON(project?: Project): void {
  *
  * @param projectUrl - The URL the project was loaded from
  */
-export function setProjectUrlParam(projectUrl: string): void {
+export function setProjectURLParam(projectUrl: string): void {
   const url = new URL(window.location.href);
-  url.searchParams.set(projectUrlParam, projectUrl);
+  url.searchParams.set(projectURLParam, projectUrl);
   window.history.replaceState({}, "", url);
 }
 
 /**
  * Removes the project URL from the address bar
  */
-export function clearProjectUrlParam(): void {
+export function clearProjectURLParam(): void {
   const url = new URL(window.location.href);
-  url.searchParams.delete(projectUrlParam);
+  url.searchParams.delete(projectURLParam);
   window.history.replaceState({}, "", url);
 }


### PR DESCRIPTION
# References and relevant issues

Closes [TMAP-234](https://scilifelab.atlassian.net/browse/TMAP-234)

# Type of change

<!-- If "Other", please specify. -->

- [x] New feature (non-breaking change which adds functionality)

# List of changes made

<!-- Specify what changes have been made and why. -->

- Added a "Load project from URL" button to the Project panel that prompts for a URL (`window.prompt`, temporary placeholder) and loads it via the existing `loadProjectFromURL` function in `data/io/project.ts`.
- On a successful load, the URL is written to the `?project=` search param, so the loaded project is shareable and is restored on reload by the existing startup path in `bootstrap.ts`.
- Relabeled the existing "Load project" button to "Load project from file", now that it is no longer the only way to load a project.
- Moved the `?project=` param name into `data/io/project.ts` and extracted `setProjectUrlParam` / `clearProjectUrlParam` helpers, replacing the duplicated `history.replaceState` blocks. Separate commit, no behavior change.

# Screenshot of the fix

<img width="407" height="427" alt="image" src="https://github.com/user-attachments/assets/e256b91d-0d71-4fab-a069-d75f95c930fb" />



# Use of AI

<!-- Please specify if AI was used in any way during the process of creating the pull request and the code inside it. If yes, specify in which way it was used. -->
Claude Code was used to assist with implementation.

# Testing

<!-- Please delete options that are not relevant -->

  1. Open the app and click "Load project from URL" in the Project panel.
  2. Enter a project URL, e.g.
     `https://user.it.uu.se/~chrav452/TissUUmaps4/data/heart_cropped/project.json`.
  3. Confirm the project loads and the address bar shows `?project=<url>`.
  4. Reload the page and confirm the project loads from the URL param.

<!--
Final Checklist:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
-->
