### PR TITLE
fix: use relative link to Code of Conduct in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ And if you like the project, but just don't have time to contribute, that's fine
 ## Code of Conduct
 
 This project and everyone participating in it is governed by the
-[TissUUmaps Code of Conduct](https://github.com/TissUUmaps/TissUUmaps4/blob/main/CODE_OF_CONDUCT.md).
+[TissUUmaps Code of Conduct](CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable behavior
 to any [current member](CONTRIBUTORS.md) of the core team.
 


### PR DESCRIPTION
# References and relevant issues

<!--
What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo, please link to that issue here as "Closes #(issue-number)".
If this PR depends on another PR (even in another repo), please link to it with "Depends on #(PR-number)" or "Depends on org/repo#(PR-number)".
-->

# Type of change

<!-- If "Other", please specify. -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

<!-- Specify what changes have been made and why. -->

- Updated the Code of Conduct link in `CONTRIBUTING.md` to use a relative path (`CODE_OF_CONDUCT.md`) instead of a hardcoded absolute URL pointing to the `main` branch. This keeps the link valid across branches and forks, and consistent with the other relative links in the document.

# Screenshot of the fix

<!-- Attach screenshot if relevant. -->

# Use of AI

Claude Code was used to prepare this pull request.

# Testing

<!-- Please delete options that are not relevant -->

- Instructions on how to test

# Further comments

<!-- Specify questions or related information. -->

<!--
Final Checklist:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
-->
