### PR TITLE
chore: update dependencies and revise monorepo configuration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,7 @@ jobs:
           node-version: lts/*
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Check formatting
         run: pnpm run fmt:check
   lint:
@@ -43,7 +43,7 @@ jobs:
           node-version: lts/*
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Build packages
         run: pnpm run build:packages
       - name: Run linter
@@ -62,7 +62,7 @@ jobs:
           node-version: lts/*
           cache: pnpm
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
       - name: Build packages
         run: pnpm run build:packages
       - name: Run tests

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -43,13 +43,13 @@ jobs:
             development/pnpm-lock.yaml
       - name: Build development
         working-directory: development
-        run: pnpm install && pnpm run build && pnpm run build:docs
+        run: pnpm install --frozen-lockfile && pnpm run build && pnpm run build:docs
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/live-dev/
           DOCUSAURUS_BASE_URL: /${{ github.event.repository.name }}/docs-dev/
       - name: Build production
         working-directory: production
-        run: pnpm install && pnpm run build
+        run: pnpm install --frozen-lockfile && pnpm run build
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/live/
           DOCUSAURUS_BASE_URL: /${{ github.event.repository.name }}/docs/

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -30,6 +30,8 @@
     "@docusaurus/module-type-aliases": "^3.10.1",
     "@docusaurus/tsconfig": "^3.10.1",
     "@docusaurus/types": "^3.10.1",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
     "docusaurus-plugin-typedoc": "^1.4.2",
     "typedoc": "^0.28.19",
     "typedoc-plugin-markdown": "^4.12.0",

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -1,5 +1,8 @@
 {
   // This file is not used in compilation. It is here just for a nice editor experience.
   "extends": "@docusaurus/tsconfig",
-  "exclude": [".docusaurus", "build"]
+  "exclude": [".docusaurus", "build"],
+  "compilerOptions": {
+    "ignoreDeprecations": "6.0" // Ignore deprecation warnings from Docusaurus tsconfig.json
+  }
 }

--- a/apps/tissuumaps/package.json
+++ b/apps/tissuumaps/package.json
@@ -3,14 +3,11 @@
   "private": true,
   "version": "4.0.0",
   "type": "module",
-  "files": [
-    "dist"
-  ],
   "scripts": {
     "dev": "vite",
     "build": "tsc -b tsconfig.src.json && vite build",
     "preview": "vite preview",
-    "clean": "rm -rf dist node_modules *.tsbuildinfo",
+    "clean": "rm -rf build dist node_modules *.tsbuildinfo",
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
@@ -21,9 +18,9 @@
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.14.3",
     "@tissuumaps/core": "workspace:^",
+    "@tissuumaps/plugins": "workspace:^",
     "@tissuumaps/render": "workspace:^",
     "@tissuumaps/storage": "workspace:^",
-    "@tissuumaps/plugins": "workspace:^",
     "@tissuumaps/viewer": "workspace:^",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -35,7 +32,7 @@
     "react-colorful": "^5.7.0",
     "react-dom": "^19.2.7",
     "tailwind-merge": "^3.6.0",
-    "zustand": "^5.0.14"
+    "zustand": "^5.0.15"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.3.1",

--- a/apps/tissuumaps/tsconfig.src.json
+++ b/apps/tissuumaps/tsconfig.src.json
@@ -2,7 +2,11 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "customConditions": ["development"], // align with vite
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./build",
     "lib": ["ES2025", "DOM", "DOM.Iterable"],
     "types": ["vite/client"],
     "jsx": "react-jsx",

--- a/apps/tissuumaps/tsconfig.test.json
+++ b/apps/tissuumaps/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "composite": true,
-    "types": ["vitest/globals"]
+    "types": ["vite/client", "vitest/globals"]
   },
   "references": [{ "path": "./tsconfig.src.json" }],
   "include": [

--- a/apps/tissuumaps/vite.config.ts
+++ b/apps/tissuumaps/vite.config.ts
@@ -2,7 +2,11 @@
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
-import { defineConfig } from "vite";
+import {
+  defaultClientConditions,
+  defaultServerConditions,
+  defineConfig,
+} from "vite";
 import { viteSingleFile } from "vite-plugin-singlefile";
 
 // https://vite.dev/config/
@@ -10,6 +14,11 @@ export default defineConfig(({ mode }) => ({
   plugins: [react(), tailwindcss(), mode === "production" && viteSingleFile()],
   build: {
     chunkSizeWarningLimit: 2048,
+    rolldownOptions: {
+      checks: {
+        pluginTimings: false,
+      },
+    },
   },
   test: {
     include: [
@@ -19,14 +28,26 @@ export default defineConfig(({ mode }) => ({
       "src/**/*.test.tsx",
     ],
     typecheck: {
-      tsconfig: resolve(__dirname, "tsconfig.test.json"),
+      tsconfig: resolve(import.meta.dirname, "tsconfig.test.json"),
     },
     environment: "jsdom",
   },
-  // shadcn/ui
   resolve: {
+    conditions:
+      mode === "production"
+        ? [...defaultClientConditions]
+        : ["tissuumaps-development", ...defaultClientConditions],
+    // shadcn/ui
     alias: {
-      "@": resolve(__dirname, "./src"),
+      "@": resolve(import.meta.dirname, "./src"),
+    },
+  },
+  ssr: {
+    resolve: {
+      conditions:
+        mode === "production"
+          ? [...defaultServerConditions]
+          : ["tissuumaps-development", ...defaultServerConditions],
     },
   },
 }));

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,9 +37,9 @@ export default defineConfig([
     },
     rules: {
       "no-duplicate-imports": "error",
+      "object-shorthand": "error",
       "@typescript-eslint/consistent-type-imports": "error",
       "@typescript-eslint/no-import-type-side-effects": "error",
-      "@typescript-eslint/promise-function-async": "error",
     },
   },
   {

--- a/package.json
+++ b/package.json
@@ -39,13 +39,14 @@
     "build": "pnpm run -r --filter !docs build",
     "build:docs": "pnpm run build:packages && pnpm run --filter docs build",
     "build:packages": "pnpm run -r --filter \"./packages/*\" build",
-    "clean": "rm -rf node_modules && pnpm run -r clean"
+    "clean": "pnpm run -r clean && rm -rf node_modules"
   },
   "lint-staged": {
     "**/*.{js,jsx,ts,tsx}": "eslint --fix",
     "**/*": "prettier --write --ignore-unknown"
   },
   "engines": {
-    "node": ">=22.22.1"
+    "node": ">=22.22.1",
+    "pnpm": ">=11.15.1"
   }
 }

--- a/packages/@tissuumaps-core/package.json
+++ b/packages/@tissuumaps-core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tissuumaps/core",
   "version": "0.1.0",
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "files": [
@@ -8,7 +9,7 @@
   ],
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "tissuumaps-development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
@@ -19,16 +20,20 @@
     "clean": "rm -rf build dist node_modules",
     "test": "vitest run --passWithNoTests"
   },
-  "engines": {
-    "node": ">=22.22.1"
-  },
   "dependencies": {
     "gl-matrix": "^3.4.4"
   },
   "devDependencies": {
-    "@jsonforms/core": "^3.8.0"
+    "@jsonforms/core": "^3.8.0",
+    "openseadragon": "^6.0.2",
+    "zustand": "^5.0.15"
   },
   "peerDependencies": {
-    "@jsonforms/core": "^3.8.0"
+    "@jsonforms/core": "^3.8.0",
+    "openseadragon": "^6.0.2",
+    "zustand": "^5.0.15"
+  },
+  "engines": {
+    "node": ">=22.22.1"
   }
 }

--- a/packages/@tissuumaps-core/tsconfig.test.json
+++ b/packages/@tissuumaps-core/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "composite": true,
-    "types": ["vitest/globals"]
+    "types": ["vite/client", "vitest/globals"]
   },
   "references": [{ "path": "./tsconfig.src.json" }],
   "include": ["./src/**/*.test.js", "./src/**/*.test.ts"],

--- a/packages/@tissuumaps-core/tsconfig.ts59.json
+++ b/packages/@tissuumaps-core/tsconfig.ts59.json
@@ -5,6 +5,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "outDir": "./build/dts"
   }
 }

--- a/packages/@tissuumaps-core/vite.config.ts
+++ b/packages/@tissuumaps-core/vite.config.ts
@@ -1,30 +1,51 @@
 /// <reference types="vitest/config" />
 import { resolve } from "node:path";
 import dts from "unplugin-dts/vite";
-import { defineConfig } from "vite";
+import {
+  defaultClientConditions,
+  defaultServerConditions,
+  defineConfig,
+} from "vite";
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     dts({
       bundleTypes: true,
-      tsconfigPath: resolve(__dirname, "tsconfig.ts59.json"),
+      tsconfigPath: resolve(import.meta.dirname, "tsconfig.ts59.json"),
     }),
   ],
   build: {
     lib: {
-      entry: resolve(__dirname, "src/index.ts"),
+      entry: resolve(import.meta.dirname, "src/index.ts"),
       formats: ["es"],
       fileName: "index",
     },
-    rollupOptions: {
-      external: ["gl-matrix"],
+    rolldownOptions: {
+      external: ["@jsonforms/core", "gl-matrix", "openseadragon", "zustand"],
+      checks: {
+        pluginTimings: false,
+      },
     },
   },
   test: {
     include: ["./src/**/*.test.js", "./src/**/*.test.ts"],
     typecheck: {
-      tsconfig: resolve(__dirname, "tsconfig.test.json"),
+      tsconfig: resolve(import.meta.dirname, "tsconfig.test.json"),
     },
   },
-});
+  resolve: {
+    conditions:
+      mode === "production"
+        ? [...defaultClientConditions]
+        : ["tissuumaps-development", ...defaultClientConditions],
+  },
+  ssr: {
+    resolve: {
+      conditions:
+        mode === "production"
+          ? [...defaultServerConditions]
+          : ["tissuumaps-development", ...defaultServerConditions],
+    },
+  },
+}));

--- a/packages/@tissuumaps-plugins/package.json
+++ b/packages/@tissuumaps-plugins/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tissuumaps/plugins",
   "version": "0.1.0",
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "files": [
@@ -8,13 +9,13 @@
   ],
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "tissuumaps-development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./spatialdata": {
-      "development": "./src/spatialdata/index.ts",
+      "tissuumaps-development": "./src/spatialdata/index.ts",
       "types": "./dist/spatialdata.d.ts",
       "import": "./dist/spatialdata.js",
       "default": "./dist/spatialdata.js"

--- a/packages/@tissuumaps-plugins/tsconfig.test.json
+++ b/packages/@tissuumaps-plugins/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "composite": true,
-    "types": ["vitest/globals"]
+    "types": ["vite/client", "vitest/globals"]
   },
   "references": [{ "path": "./tsconfig.src.json" }],
   "include": ["./src/**/*.test.js", "./src/**/*.test.ts"],

--- a/packages/@tissuumaps-plugins/tsconfig.ts59.json
+++ b/packages/@tissuumaps-plugins/tsconfig.ts59.json
@@ -5,6 +5,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "outDir": "./build/dts"
   }
 }

--- a/packages/@tissuumaps-plugins/vite.config.ts
+++ b/packages/@tissuumaps-plugins/vite.config.ts
@@ -1,32 +1,53 @@
 /// <reference types="vitest/config" />
 import { resolve } from "node:path";
 import dts from "unplugin-dts/vite";
-import { defineConfig } from "vite";
+import {
+  defaultClientConditions,
+  defaultServerConditions,
+  defineConfig,
+} from "vite";
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     dts({
       bundleTypes: true,
-      tsconfigPath: resolve(__dirname, "tsconfig.ts59.json"),
+      tsconfigPath: resolve(import.meta.dirname, "tsconfig.ts59.json"),
     }),
   ],
   build: {
     lib: {
       entry: {
-        index: resolve(__dirname, "src/index.ts"),
-        spatialdata: resolve(__dirname, "src/spatialdata/index.ts"),
+        index: resolve(import.meta.dirname, "src/index.ts"),
+        spatialdata: resolve(import.meta.dirname, "src/spatialdata/index.ts"),
       },
       formats: ["es"],
     },
-    rollupOptions: {
+    rolldownOptions: {
       external: ["@tissuumaps/core"],
+      checks: {
+        pluginTimings: false,
+      },
     },
   },
   test: {
     include: ["./src/**/*.test.js", "./src/**/*.test.ts"],
     typecheck: {
-      tsconfig: resolve(__dirname, "tsconfig.test.json"),
+      tsconfig: resolve(import.meta.dirname, "tsconfig.test.json"),
     },
   },
-});
+  resolve: {
+    conditions:
+      mode === "production"
+        ? [...defaultClientConditions]
+        : ["tissuumaps-development", ...defaultClientConditions],
+  },
+  ssr: {
+    resolve: {
+      conditions:
+        mode === "production"
+          ? [...defaultServerConditions]
+          : ["tissuumaps-development", ...defaultServerConditions],
+    },
+  },
+}));

--- a/packages/@tissuumaps-render/package.json
+++ b/packages/@tissuumaps-render/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tissuumaps/render",
   "version": "0.1.0",
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "files": [
@@ -8,7 +9,7 @@
   ],
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "tissuumaps-development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/@tissuumaps-render/tsconfig.test.json
+++ b/packages/@tissuumaps-render/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "composite": true,
-    "types": ["vitest/globals"]
+    "types": ["vite/client", "vitest/globals"]
   },
   "references": [{ "path": "./tsconfig.src.json" }],
   "include": ["./src/**/*.test.js", "./src/**/*.test.ts"],

--- a/packages/@tissuumaps-render/tsconfig.ts59.json
+++ b/packages/@tissuumaps-render/tsconfig.ts59.json
@@ -5,6 +5,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "outDir": "./build/dts"
   }
 }

--- a/packages/@tissuumaps-render/vite.config.ts
+++ b/packages/@tissuumaps-render/vite.config.ts
@@ -1,35 +1,56 @@
 /// <reference types="vitest/config" />
 import { resolve } from "node:path";
 import dts from "unplugin-dts/vite";
-import { defineConfig } from "vite";
+import {
+  defaultClientConditions,
+  defaultServerConditions,
+  defineConfig,
+} from "vite";
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     dts({
       bundleTypes: true,
-      tsconfigPath: resolve(__dirname, "tsconfig.ts59.json"),
+      tsconfigPath: resolve(import.meta.dirname, "tsconfig.ts59.json"),
     }),
   ],
   build: {
     lib: {
-      entry: resolve(__dirname, "src/index.ts"),
+      entry: resolve(import.meta.dirname, "src/index.ts"),
       formats: ["es"],
       fileName: "index",
     },
-    rollupOptions: {
+    rolldownOptions: {
       external: [
         "@tissuumaps/core",
-        "openseadragon",
-        "gl-matrix",
         "fast-equals",
+        "gl-matrix",
+        "openseadragon",
       ],
+      checks: {
+        pluginTimings: false,
+      },
     },
   },
   test: {
     include: ["./src/**/*.test.js", "./src/**/*.test.ts"],
     typecheck: {
-      tsconfig: resolve(__dirname, "tsconfig.test.json"),
+      tsconfig: resolve(import.meta.dirname, "tsconfig.test.json"),
     },
   },
-});
+  resolve: {
+    conditions:
+      mode === "production"
+        ? [...defaultClientConditions]
+        : ["tissuumaps-development", ...defaultClientConditions],
+  },
+  ssr: {
+    resolve: {
+      conditions:
+        mode === "production"
+          ? [...defaultServerConditions]
+          : ["tissuumaps-development", ...defaultServerConditions],
+    },
+  },
+}));

--- a/packages/@tissuumaps-storage/package.json
+++ b/packages/@tissuumaps-storage/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tissuumaps/storage",
   "version": "0.1.0",
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "files": [
@@ -8,43 +9,43 @@
   ],
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "tissuumaps-development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
     "./csv": {
-      "development": "./src/csv/index.ts",
+      "tissuumaps-development": "./src/csv/index.ts",
       "types": "./dist/csv.d.ts",
       "import": "./dist/csv.js",
       "default": "./dist/csv.js"
     },
     "./geojson": {
-      "development": "./src/geojson/index.ts",
+      "tissuumaps-development": "./src/geojson/index.ts",
       "types": "./dist/geojson.d.ts",
       "import": "./dist/geojson.js",
       "default": "./dist/geojson.js"
     },
     "./ome-zarr": {
-      "development": "./src/ome-zarr/index.ts",
+      "tissuumaps-development": "./src/ome-zarr/index.ts",
       "types": "./dist/ome-zarr.d.ts",
       "import": "./dist/ome-zarr.js",
       "default": "./dist/ome-zarr.js"
     },
     "./openseadragon": {
-      "development": "./src/openseadragon/index.ts",
+      "tissuumaps-development": "./src/openseadragon/index.ts",
       "types": "./dist/openseadragon.d.ts",
       "import": "./dist/openseadragon.js",
       "default": "./dist/openseadragon.js"
     },
     "./parquet": {
-      "development": "./src/parquet/index.ts",
+      "tissuumaps-development": "./src/parquet/index.ts",
       "types": "./dist/parquet.d.ts",
       "import": "./dist/parquet.js",
       "default": "./dist/parquet.js"
     },
     "./table": {
-      "development": "./src/table/index.ts",
+      "tissuumaps-development": "./src/table/index.ts",
       "types": "./dist/table.d.ts",
       "import": "./dist/table.js",
       "default": "./dist/table.js"
@@ -63,12 +64,13 @@
     "@tissuumaps/core": "workspace:^",
     "@types/geojson": "^7946.0.16",
     "@types/papaparse": "^5.5.2",
-    "geojson": "^0.5.0",
     "hyparquet": "^1.26.1",
-    "hyparquet-compressors": "^1.1.1"
+    "hyparquet-compressors": "^1.1.1",
+    "openseadragon": "^6.0.2"
   },
   "peerDependencies": {
-    "@tissuumaps/core": "workspace:^"
+    "@tissuumaps/core": "workspace:^",
+    "openseadragon": ">=5.0.1 <7.0.0"
   },
   "engines": {
     "node": ">=22.22.1"

--- a/packages/@tissuumaps-storage/tsconfig.test.json
+++ b/packages/@tissuumaps-storage/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "composite": true,
-    "types": ["vitest/globals"]
+    "types": ["vite/client", "vitest/globals"]
   },
   "references": [{ "path": "./tsconfig.src.json" }],
   "include": ["./src/**/*.test.js", "./src/**/*.test.ts"],

--- a/packages/@tissuumaps-storage/tsconfig.ts59.json
+++ b/packages/@tissuumaps-storage/tsconfig.ts59.json
@@ -5,6 +5,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "outDir": "./build/dts"
   }
 }

--- a/packages/@tissuumaps-storage/vite.config.ts
+++ b/packages/@tissuumaps-storage/vite.config.ts
@@ -1,14 +1,18 @@
 /// <reference types="vitest/config" />
 import { resolve } from "node:path";
 import dts from "unplugin-dts/vite";
-import { defineConfig } from "vite";
+import {
+  defaultClientConditions,
+  defaultServerConditions,
+  defineConfig,
+} from "vite";
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     dts({
       bundleTypes: true,
-      tsconfigPath: resolve(__dirname, "tsconfig.ts59.json"),
+      tsconfigPath: resolve(import.meta.dirname, "tsconfig.ts59.json"),
     }),
   ],
   worker: {
@@ -17,27 +21,48 @@ export default defineConfig({
   build: {
     lib: {
       entry: {
-        index: resolve(__dirname, "src/index.ts"),
-        csv: resolve(__dirname, "src/csv/index.ts"),
-        geojson: resolve(__dirname, "src/geojson/index.ts"),
-        "ome-zarr": resolve(__dirname, "src/ome-zarr/index.ts"),
-        openseadragon: resolve(__dirname, "src/openseadragon/index.ts"),
-        parquet: resolve(__dirname, "src/parquet/index.ts"),
-        table: resolve(__dirname, "src/table/index.ts"),
+        index: resolve(import.meta.dirname, "src/index.ts"),
+        csv: resolve(import.meta.dirname, "src/csv/index.ts"),
+        geojson: resolve(import.meta.dirname, "src/geojson/index.ts"),
+        "ome-zarr": resolve(import.meta.dirname, "src/ome-zarr/index.ts"),
+        openseadragon: resolve(
+          import.meta.dirname,
+          "src/openseadragon/index.ts",
+        ),
+        parquet: resolve(import.meta.dirname, "src/parquet/index.ts"),
+        table: resolve(import.meta.dirname, "src/table/index.ts"),
       },
       formats: ["es"],
     },
-    // Worker-only deps (hyparquet, hyparquet-compressors) are intentionally not
+    // Worker-only deps (hyparquet, hyparquet-compressors) are intentionally NOT
     // externalized: the workers are imported with `?worker&inline`, so they must
-    // be self-contained and their deps get bundled into the inline worker.
-    rollupOptions: {
+    // be self-contained and their deps get bundled into the inline worker. Also,
+    // openseadragon is not externalized, because nothing imports it.
+    rolldownOptions: {
       external: ["@tissuumaps/core", "omezarr-tilesource", "papaparse"],
+      checks: {
+        pluginTimings: false,
+      },
     },
   },
   test: {
     include: ["./src/**/*.test.js", "./src/**/*.test.ts"],
     typecheck: {
-      tsconfig: resolve(__dirname, "tsconfig.test.json"),
+      tsconfig: resolve(import.meta.dirname, "tsconfig.test.json"),
     },
   },
-});
+  resolve: {
+    conditions:
+      mode === "production"
+        ? [...defaultClientConditions]
+        : ["tissuumaps-development", ...defaultClientConditions],
+  },
+  ssr: {
+    resolve: {
+      conditions:
+        mode === "production"
+          ? [...defaultServerConditions]
+          : ["tissuumaps-development", ...defaultServerConditions],
+    },
+  },
+}));

--- a/packages/@tissuumaps-viewer/package.json
+++ b/packages/@tissuumaps-viewer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@tissuumaps/viewer",
   "version": "0.1.0",
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "files": [
@@ -8,7 +9,7 @@
   ],
   "exports": {
     ".": {
-      "development": "./src/index.ts",
+      "tissuumaps-development": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"

--- a/packages/@tissuumaps-viewer/tsconfig.test.json
+++ b/packages/@tissuumaps-viewer/tsconfig.test.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "composite": true,
-    "types": ["vitest/globals"]
+    "types": ["vite/client", "vitest/globals"]
   },
   "references": [{ "path": "./tsconfig.src.json" }],
   "include": [

--- a/packages/@tissuumaps-viewer/tsconfig.ts59.json
+++ b/packages/@tissuumaps-viewer/tsconfig.ts59.json
@@ -5,6 +5,7 @@
   "extends": "./tsconfig.src.json",
   "compilerOptions": {
     "target": "ESNext",
-    "lib": ["ESNext", "DOM", "DOM.Iterable"]
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
+    "outDir": "./build/dts"
   }
 }

--- a/packages/@tissuumaps-viewer/vite.config.ts
+++ b/packages/@tissuumaps-viewer/vite.config.ts
@@ -2,30 +2,37 @@
 import react from "@vitejs/plugin-react";
 import { resolve } from "node:path";
 import dts from "unplugin-dts/vite";
-import { defineConfig } from "vite";
+import {
+  defaultClientConditions,
+  defaultServerConditions,
+  defineConfig,
+} from "vite";
 
 // https://vite.dev/config/
-export default defineConfig({
+export default defineConfig(({ mode }) => ({
   plugins: [
     dts({
       bundleTypes: true,
-      tsconfigPath: resolve(__dirname, "tsconfig.ts59.json"),
+      tsconfigPath: resolve(import.meta.dirname, "tsconfig.ts59.json"),
     }),
     react(),
   ],
   build: {
     lib: {
-      entry: resolve(__dirname, "src/index.ts"),
+      entry: resolve(import.meta.dirname, "src/index.ts"),
       formats: ["es"],
       fileName: "index",
     },
-    rollupOptions: {
+    rolldownOptions: {
       external: [
-        "react",
-        "react-dom",
         "@tissuumaps/core",
         "@tissuumaps/render",
+        "react",
+        "react-dom",
       ],
+      checks: {
+        pluginTimings: false,
+      },
     },
   },
   test: {
@@ -36,8 +43,22 @@ export default defineConfig({
       "./src/**/*.test.tsx",
     ],
     typecheck: {
-      tsconfig: resolve(__dirname, "tsconfig.test.json"),
+      tsconfig: resolve(import.meta.dirname, "tsconfig.test.json"),
     },
     environment: "jsdom",
   },
-});
+  resolve: {
+    conditions:
+      mode === "production"
+        ? [...defaultClientConditions]
+        : ["tissuumaps-development", ...defaultClientConditions],
+  },
+  ssr: {
+    resolve: {
+      conditions:
+        mode === "production"
+          ? [...defaultServerConditions]
+          : ["tissuumaps-development", ...defaultServerConditions],
+    },
+  },
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,40 +9,40 @@ importers:
     devDependencies:
       "@eslint/js":
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
+        version: 10.0.1(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))
       "@microsoft/api-extractor":
         specifier: ^7.58.9
-        version: 7.58.9(@types/node@26.1.1)
+        version: 7.59.0(@types/node@26.2.0)
       "@trivago/prettier-plugin-sort-imports":
         specifier: ^6.0.2
-        version: 6.0.2(prettier@3.9.4)
+        version: 6.0.2(prettier@3.9.6)(supports-color@8.1.1)
       "@types/node":
         specifier: ^26.0.1
-        version: 26.1.1
+        version: 26.2.0
       "@vitejs/plugin-react":
         specifier: ^6.0.3
-        version: 6.0.3(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 6.1.0(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       "@vitest/coverage-v8":
         specifier: ^4.1.9
-        version: 4.1.10(vitest@4.1.10)
+        version: 4.1.11(vitest@4.1.11)
       canvas:
         specifier: ^3.2.3
         version: 3.2.3
       eslint:
         specifier: ^10.5.0
-        version: 10.6.0(jiti@2.7.0)
+        version: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.6.0(jiti@2.7.0))
+        version: 10.1.8(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))
       eslint-plugin-react-hooks:
         specifier: ^7.1.1
-        version: 7.1.1(eslint@10.6.0(jiti@2.7.0))
+        version: 7.1.1(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
       eslint-plugin-react-refresh:
         specifier: ^0.5.3
-        version: 0.5.3(eslint@10.6.0(jiti@2.7.0))
+        version: 0.5.4(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))
       globals:
         specifier: ^17.7.0
-        version: 17.7.0
+        version: 17.11.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -51,65 +51,71 @@ importers:
         version: 29.1.1(canvas@3.2.3)
       lint-staged:
         specifier: ^17.0.8
-        version: 17.0.8
+        version: 17.3.0
       prettier:
         specifier: ^3.8.4
-        version: 3.9.4
+        version: 3.9.6
       typescript:
         specifier: ^6.0.3
         version: 6.0.3
       typescript-eslint:
         specifier: ^8.62.0
-        version: 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       unplugin-dts:
         specifier: ^1.0.3
-        version: 1.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(@rspack/core@1.7.12)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4)
+        version: 1.0.3(@microsoft/api-extractor@7.59.0(@types/node@26.2.0))(@rspack/core@1.7.12)(rolldown@1.2.5)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       vite:
         specifier: ^8.1.0
-        version: 8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
+        version: 8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(canvas@3.2.3))(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(canvas@3.2.3))(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
 
   apps/docs:
     dependencies:
       "@docusaurus/core":
         specifier: ^3.10.1
-        version: 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
       "@docusaurus/faster":
         specifier: ^3.10.1
-        version: 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16)
+        version: 3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26)
       "@docusaurus/preset-classic":
         specifier: ^3.10.1
-        version: 3.10.1(@algolia/client-search@5.55.2)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(@types/react@19.2.17)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@6.0.3)
+        version: 3.10.2(@algolia/client-search@5.57.0)(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(@types/react@19.2.18)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@6.0.3)
       "@docusaurus/theme-mermaid":
         specifier: ^3.10.1
-        version: 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+        version: 3.10.2(2490df0a9605874396a568ec3788caa5)
       "@mdx-js/react":
         specifier: ^3.1.1
-        version: 3.1.1(@types/react@19.2.17)(react@19.2.7)
+        version: 3.1.1(@types/react@19.2.18)(react@19.2.8)
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
       prism-react-renderer:
         specifier: ^2.4.1
-        version: 2.4.1(react@19.2.7)
+        version: 2.4.1(react@19.2.8)
       react:
         specifier: ^19.2.7
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
     devDependencies:
       "@docusaurus/module-type-aliases":
         specifier: ^3.10.1
-        version: 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       "@docusaurus/tsconfig":
         specifier: ^3.10.1
-        version: 3.10.1
+        version: 3.10.2
       "@docusaurus/types":
         specifier: ^3.10.1
-        version: 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@types/react":
+        specifier: ^19.2.17
+        version: 19.2.18
+      "@types/react-dom":
+        specifier: ^19.2.3
+        version: 19.2.4(@types/react@19.2.18)
       docusaurus-plugin-typedoc:
         specifier: ^1.4.2
         version: 1.4.2(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3)))
@@ -127,22 +133,22 @@ importers:
     dependencies:
       "@base-ui/react":
         specifier: ^1.6.0
-        version: 1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       "@dnd-kit/react":
         specifier: ^0.5.0
-        version: 0.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 0.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       "@jsonforms/core":
         specifier: ^3.8.0
         version: 3.8.0
       "@jsonforms/react":
         specifier: ^3.8.0
-        version: 3.8.0(@jsonforms/core@3.8.0)(react@19.2.7)
+        version: 3.8.0(@jsonforms/core@3.8.0)(react@19.2.8)
       "@tanstack/react-table":
         specifier: ^8.21.3
-        version: 8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       "@tanstack/react-virtual":
         specifier: ^3.14.3
-        version: 3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       "@tissuumaps/core":
         specifier: workspace:^
         version: link:../../packages/@tissuumaps-core
@@ -166,50 +172,50 @@ importers:
         version: 2.1.1
       dockview-react:
         specifier: ^7.0.2
-        version: 7.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 7.0.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       fast-equals:
         specifier: ^6.0.0
         version: 6.0.2
       immer:
         specifier: ^11.1.8
-        version: 11.1.11
+        version: 11.1.18
       lucide-react:
         specifier: ^1.21.0
-        version: 1.24.0(react@19.2.7)
+        version: 1.33.0(react@19.2.8)
       react:
         specifier: ^19.2.7
-        version: 19.2.7
+        version: 19.2.8
       react-colorful:
         specifier: ^5.7.0
-        version: 5.7.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        version: 5.8.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       react-dom:
         specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
       tailwind-merge:
         specifier: ^3.6.0
         version: 3.6.0
       zustand:
-        specifier: ^5.0.14
-        version: 5.0.14(@types/react@19.2.17)(immer@11.1.11)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+        specifier: ^5.0.15
+        version: 5.0.15(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
     devDependencies:
       "@tailwindcss/vite":
         specifier: ^4.3.1
-        version: 4.3.2(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 4.3.3(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       "@types/react":
         specifier: ^19.2.17
-        version: 19.2.17
+        version: 19.2.18
       "@types/react-dom":
         specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
+        version: 19.2.4(@types/react@19.2.18)
       tailwindcss:
         specifier: ^4.3.1
-        version: 4.3.2
+        version: 4.3.3
       tw-animate-css:
         specifier: ^1.4.0
         version: 1.4.0
       vite-plugin-singlefile:
         specifier: ^2.3.3
-        version: 2.3.3(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+        version: 2.3.3(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
 
   packages/@tissuumaps-core:
     dependencies:
@@ -220,6 +226,12 @@ importers:
       "@jsonforms/core":
         specifier: ^3.8.0
         version: 3.8.0
+      openseadragon:
+        specifier: ^6.0.2
+        version: 6.1.0
+      zustand:
+        specifier: ^5.0.15
+        version: 5.0.15(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8))
 
   packages/@tissuumaps-plugins:
     devDependencies:
@@ -237,7 +249,7 @@ importers:
         version: 3.4.4
       openseadragon:
         specifier: ^6.0.2
-        version: 6.0.2
+        version: 6.1.0
     devDependencies:
       "@tissuumaps/core":
         specifier: workspace:^
@@ -247,10 +259,10 @@ importers:
     dependencies:
       omezarr-tilesource:
         specifier: ^0.2.0
-        version: 0.2.0(openseadragon@6.0.2)
+        version: 0.2.0(openseadragon@6.1.0)
       papaparse:
         specifier: ^5.5.4
-        version: 5.5.4
+        version: 5.6.0
     devDependencies:
       "@tissuumaps/core":
         specifier: workspace:^
@@ -261,15 +273,15 @@ importers:
       "@types/papaparse":
         specifier: ^5.5.2
         version: 5.5.2
-      geojson:
-        specifier: ^0.5.0
-        version: 0.5.0
       hyparquet:
         specifier: ^1.26.1
-        version: 1.26.2
+        version: 1.29.1
       hyparquet-compressors:
         specifier: ^1.1.1
         version: 1.1.1
+      openseadragon:
+        specifier: ^6.0.2
+        version: 6.1.0
 
   packages/@tissuumaps-viewer:
     devDependencies:
@@ -281,22 +293,29 @@ importers:
         version: link:../@tissuumaps-render
       "@types/react":
         specifier: ^19.2.17
-        version: 19.2.17
+        version: 19.2.18
       "@types/react-dom":
         specifier: ^19.2.3
-        version: 19.2.3(@types/react@19.2.17)
+        version: 19.2.4(@types/react@19.2.18)
       react:
         specifier: ^19.2.7
-        version: 19.2.7
+        version: 19.2.8
       react-dom:
         specifier: ^19.2.7
-        version: 19.2.7(react@19.2.7)
+        version: 19.2.8(react@19.2.8)
 
 packages:
-  "@algolia/abtesting@1.21.2":
+  "@11ty/gray-matter@1.0.0":
     resolution:
       {
-        integrity: sha512-uXj0rgk30EpsKvOpuS+R+1XFDrnm56hED1Lz56e8uBkZdKCxw99LS2U8eXBqAHYU8kpkbsnV1GC8velBG070Hg==,
+        integrity: sha512-7mJJl+wf1AByoT0PknQiQfOPnVNT4fevGrUBVWO4HXsnYn1aQPyRyrELYrNUFleUBM++KzMKN6QaxHPk0t/6/g==,
+      }
+    engines: { node: ">=11" }
+
+  "@algolia/abtesting@1.23.0":
+    resolution:
+      {
+        integrity: sha512-j45MBISstltys9QyQ4xf6quRiN1g7vMuwQL9VM4dx8YuRZvCQ173b9royZAx6iAbRX3IB1VnG1z//NuwyQ8jpQ==,
       }
     engines: { node: ">= 14.0.0" }
 
@@ -346,52 +365,52 @@ packages:
       "@algolia/client-search": ">= 4.9.1 < 6"
       algoliasearch: ">= 4.9.1 < 6"
 
-  "@algolia/client-abtesting@5.55.2":
+  "@algolia/client-abtesting@5.57.0":
     resolution:
       {
-        integrity: sha512-y7Epol8HcjlBxKXHhyhfFPFhm78B3P6x9cCbCyGTdxjsdVCptXCy5hpkZWxjGpnaLHvWsHS4QRF0TiBOLst2xg==,
+        integrity: sha512-JVFFujiZUCguk5tz3LZr4fTQxqpIrj4/Jw3SI7kMljSqtfLxYn/s/TWH0J2s4iNfsDpxPhgFGMotCpmDI4kZ8w==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-analytics@5.55.2":
+  "@algolia/client-analytics@5.57.0":
     resolution:
       {
-        integrity: sha512-8Pxj2VVmpM2d+UZufnlTq7T1QIcYPVugLV5XC50PnHsV5uRM9CSoYkg2Y+CwqwRk2La0xK5QsfZ0obIU+9XftQ==,
+        integrity: sha512-6KqECK4ED3JJQEoDrQWnGPQzElA828xAD4qK5ceawNNyP/LcSvzAoLHjFkoTPksZ/kxj6VUtCRH+IHZesLltng==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-common@5.55.2":
+  "@algolia/client-common@5.57.0":
     resolution:
       {
-        integrity: sha512-9L4IpIYUqA63a7sw1trnHQGUvwiAjKz67nsgDnal98JGAc7wyposRb0Iag+eiMuyzFFaSHLe2/rGyIo+PafRBA==,
+        integrity: sha512-uqpGF3oXYsoCbQq5d7BzNrNTfIfuvJyGP1CKvSW27T9boUg7KOwyxsAw1AX0a3jSW2HrYEJ/NN+Z4MiGivbpeQ==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-insights@5.55.2":
+  "@algolia/client-insights@5.57.0":
     resolution:
       {
-        integrity: sha512-ZBm2ytY5EHFcj+kjNsXxMNO/TGlOHe2fBFXGKHJOM1bk1rAy4o2YI+d9oV/w/jrqx44pvJMJlc8X6vKnCuDgUQ==,
+        integrity: sha512-u5NboJVJXDEFplvNnqqX4CxkXPYysjJRj47hOSh9329H8kG5gFLKJBIiS5utMQ+GZm8xQl3Te7NInDk6elEADQ==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-personalization@5.55.2":
+  "@algolia/client-personalization@5.57.0":
     resolution:
       {
-        integrity: sha512-3FGVW/jDk7sdYwqa2NKnF/qXWcttc4bvGrwNbvqz3VoWSRv42CNvRk+3Y9QJFIUf1vY50hAuVWUoFKdyc8vaXA==,
+        integrity: sha512-uzc0b2LmHAK9/QID4xeo35OG84AkZl4YewkCqawqAOGLjT2eZpM/OZx45ESygMHG30Ws+ZTSdluPtMJcUnrbWQ==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-query-suggestions@5.55.2":
+  "@algolia/client-query-suggestions@5.57.0":
     resolution:
       {
-        integrity: sha512-JsG8LovDAYul5t8e533tZ3O1uZILxso5zsTtB7ONc5RJ8ACdTxAAC/jaOnsBNYb+x+STP7fzx/Iro55v5DNgoQ==,
+        integrity: sha512-dIAhnM6ue/ssa5PjgNfu4g8A4yTojl9ZOUzZU3wIaIKRerL2R/3Emuf9n/D6ICXXP167KC6XCeC7nliSw7cuSw==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/client-search@5.55.2":
+  "@algolia/client-search@5.57.0":
     resolution:
       {
-        integrity: sha512-5wDnoIfC75zJ2MSHv5SSzTlRL2z7jQMbqQ5jrzottuq2p3oBObv8pD/JpXWu8pRaimaxNr3/Bs/KZIGVXxJ7hg==,
+        integrity: sha512-2TTPTTKSJmCptvhCm4Xf3bBYMqZni+Pgc2hVdqc4l9wsBpSJNVTVIKpnd10OubUgkGcmppVDj1XQqYaf6EnPSQ==,
       }
     engines: { node: ">= 14.0.0" }
 
@@ -401,45 +420,45 @@ packages:
         integrity: sha512-FQzvOCgoFXAbf5Y6mYozw2aj5KCJoA3m4heImceldzPSMbdyS4atVjJzXKMsfX3wnZTFYwkkt8/z8UesLHlSBQ==,
       }
 
-  "@algolia/ingestion@1.55.2":
+  "@algolia/ingestion@1.57.0":
     resolution:
       {
-        integrity: sha512-da+SC6ikpza98W7C5ChsKEQDvZc8PQLQ0sxmQ5yMRsHpdD3iPKnclJA6ViB5Nr5T9qOX+IDswC6AyqY4V3rtug==,
+        integrity: sha512-W4JseHKt+pzOxlFV+T3MWEG0h4Z2Se5zjoXUD0ewlw8aOWMG/yjRdopUdLQsXULepB/My2tDuZjkwk2sMfsUrQ==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/monitoring@1.55.2":
+  "@algolia/monitoring@1.57.0":
     resolution:
       {
-        integrity: sha512-Y8kEcPqCiIEeaGv83l9RRA09mfYECqAJHNnOyEtZc9UirI6XBMUyFVss/sSeYUiV/Lf30hkbWcl00V1uXsf86Q==,
+        integrity: sha512-BrxJVE0/eLinEPICCD7BKN/2xnt0nkjge70u8zzE2ISP3fuB3tjLgcwpanUycvlHBFLI4gK0l5ol54p6IYuR/Q==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/recommend@5.55.2":
+  "@algolia/recommend@5.57.0":
     resolution:
       {
-        integrity: sha512-5zmobuCQqFZkx+84Nt+suL7vo6jTh2CfAs2ndDSeTS2QHvnzP8YEEGWtWftjyACI0cK/FuH8urWwCHP+d2j8TA==,
+        integrity: sha512-Gc29jkeiLKlVfHvyrIgyUHHE+aYTdXEeLfK42rjr5/1TTVsYwUJz0XkvoIBIqfMjcDg6gXeHb1jTUZ0H+SYIlQ==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/requester-browser-xhr@5.55.2":
+  "@algolia/requester-browser-xhr@5.57.0":
     resolution:
       {
-        integrity: sha512-qnGUUuWG66dRMnr33owLsrYIh9fHVxtU4R2rd3SpneAHuoAUcGbDOWNrj05glVU6M8yOqo9gQ22K8zpz0I8Xpg==,
+        integrity: sha512-PIPnPN7MP3fp2VAi01BVXhCWmD366ZB2Hkq5TlYKtThd4KxUtMmaaNDpFgVCTXtSIqWVZLJntOHRvxg/sIPd8Q==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/requester-fetch@5.55.2":
+  "@algolia/requester-fetch@5.57.0":
     resolution:
       {
-        integrity: sha512-lKZ5uhafMvR7dWCJEyuaeyZitid1I3ICx+k0vGf5x/ktdIQvc7bndCiOPpmIDqUmN26FE3jTehkAzSqee95G2Q==,
+        integrity: sha512-AX3RlOudXMdTwtwUqdAf5hAVLvXfOZZH1FZh6ALDdrhVLT0TtAIe48N6nYcWcTnwoTxK/wDIQqZ19IMjK8zJAA==,
       }
     engines: { node: ">= 14.0.0" }
 
-  "@algolia/requester-node-http@5.55.2":
+  "@algolia/requester-node-http@5.57.0":
     resolution:
       {
-        integrity: sha512-Zc90xvKWUvxcNicvvTO9Pr/hT2TAnkixOIzJm/KMj5Ptm2pKjk71ngTsdkbRtJQvhZ2Kr9N1YdIjLrNHB5P2xw==,
+        integrity: sha512-cWZc1dKb7wy9/wPpwMtL1y89gK2G7y2A47Coa7zwf1ydtIeJm4+S+XxoQ2b/ZRiQnrC1YHavLjYUPDCdnT7Khg==,
       }
     engines: { node: ">= 14.0.0" }
 
@@ -497,10 +516,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/generator@7.29.7":
+  "@babel/generator@7.29.8":
     resolution:
       {
-        integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==,
+        integrity: sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==,
       }
     engines: { node: ">=6.9.0" }
 
@@ -648,10 +667,10 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/parser@7.29.7":
+  "@babel/parser@7.29.8":
     resolution:
       {
-        integrity: sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==,
+        integrity: sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==,
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
@@ -997,10 +1016,10 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
 
-  "@babel/plugin-transform-modules-systemjs@7.29.7":
+  "@babel/plugin-transform-modules-systemjs@7.29.8":
     resolution:
       {
-        integrity: sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==,
+        integrity: sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==,
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
@@ -1168,10 +1187,10 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
 
-  "@babel/plugin-transform-regenerator@7.29.7":
+  "@babel/plugin-transform-regenerator@7.29.8":
     resolution:
       {
-        integrity: sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==,
+        integrity: sha512-0UpIXPtdDtMXfnV2OJAVMLpj3H/92vmkA6lpSRakmycJvj3VUy6Xs1dM8tXRugupykr5WB+LpiVl0J8LMVg2mg==,
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
@@ -1213,10 +1232,10 @@ packages:
     peerDependencies:
       "@babel/core": ^7.0.0-0
 
-  "@babel/plugin-transform-spread@7.29.7":
+  "@babel/plugin-transform-spread@7.29.8":
     resolution:
       {
-        integrity: sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==,
+        integrity: sha512-4S9ksMGVWUshvgK0mKfvZky7leuG5/uoFVwMpAomJ8bMoDJiNHRVmc1EglwW/CmGVSqqWpEbXm9FmbRit22qoA==,
       }
     engines: { node: ">=6.9.0" }
     peerDependencies:
@@ -1343,24 +1362,24 @@ packages:
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/traverse@7.29.7":
+  "@babel/traverse@7.29.8":
     resolution:
       {
-        integrity: sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==,
+        integrity: sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==,
       }
     engines: { node: ">=6.9.0" }
 
-  "@babel/types@7.29.7":
+  "@babel/types@7.29.8":
     resolution:
       {
-        integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==,
+        integrity: sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==,
       }
     engines: { node: ">=6.9.0" }
 
-  "@base-ui/react@1.6.0":
+  "@base-ui/react@1.7.0":
     resolution:
       {
-        integrity: sha512-/jzjTWJYXhRFO45Bev9lc3cHbmjzCMpUqbMZ2AgKy/z25mY9B6shGSNcXcjQar9n5doM0KYW1W8fcFv2jZBuMw==,
+        integrity: sha512-j+8QjX44C32jrXD/qyEAGpFr70FRpGL2CY61mQd9nBPWN737CK0xxD1ceJ055rW4RtdvFDT1e7otzdlfxvsYug==,
       }
     engines: { node: ">=14.0.0" }
     peerDependencies:
@@ -1377,10 +1396,10 @@ packages:
       date-fns:
         optional: true
 
-  "@base-ui/utils@0.3.1":
+  "@base-ui/utils@0.3.2":
     resolution:
       {
-        integrity: sha512-gFFiltORVmW/N6IILTGxizP3PBpVpysqML1ALY5Vk0mH+7faVkCknOU31goYHN5Aoek2dkjxva1XOD2Ce9WuIg==,
+        integrity: sha512-oWy1aq/I2GmYjpl4PhEAhzflF8VPGKgZeq0xAWTbfD5KBWyxcN0ZP2+WHSUm/5Z6lVMBDLReLcoXwSYoRc/zNQ==,
       }
     peerDependencies:
       "@types/react": ^17 || ^18 || ^19
@@ -1440,10 +1459,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  "@csstools/color-helpers@6.1.0":
+  "@csstools/color-helpers@6.1.1":
     resolution:
       {
-        integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==,
+        integrity: sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==,
       }
     engines: { node: ">=20.19.0" }
 
@@ -1457,10 +1476,10 @@ packages:
       "@csstools/css-parser-algorithms": ^3.0.5
       "@csstools/css-tokenizer": ^3.0.4
 
-  "@csstools/css-calc@3.2.1":
+  "@csstools/css-calc@3.3.0":
     resolution:
       {
-        integrity: sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==,
+        integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==,
       }
     engines: { node: ">=20.19.0" }
     peerDependencies:
@@ -1477,10 +1496,10 @@ packages:
       "@csstools/css-parser-algorithms": ^3.0.5
       "@csstools/css-tokenizer": ^3.0.4
 
-  "@csstools/css-color-parser@4.1.9":
+  "@csstools/css-color-parser@4.2.0":
     resolution:
       {
-        integrity: sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==,
+        integrity: sha512-5+5LEmFuY1AjXdYhmgjTJogtQnP1evJ1zrBZGUNZ0thkpwnnmKxcHdAMn/OtFjAb25zA+jKDVYVRl+5G7rjv1A==,
       }
     engines: { node: ">=20.19.0" }
     peerDependencies:
@@ -1505,10 +1524,10 @@ packages:
     peerDependencies:
       "@csstools/css-tokenizer": ^4.0.0
 
-  "@csstools/css-syntax-patches-for-csstree@1.1.6":
+  "@csstools/css-syntax-patches-for-csstree@1.1.8":
     resolution:
       {
-        integrity: sha512-TcJCWFbXLPpJYq6z7bfOyjWYJDiDg2/I4gyUC9pqPNqHFRIey0EB0q0L5cSnQDfWJg8Jd6VadakxdIez/3zkqQ==,
+        integrity: sha512-CpMLjAvwQg3BL5S0IeqsZNMH7EQrEWi0kLKOC13ZBF0ZwERiLWlibNPJr8G1kdU3Ms/r2KiNrF81pUh2HwAHdg==,
       }
     peerDependencies:
       css-tree: ^3.2.1
@@ -1973,10 +1992,10 @@ packages:
         integrity: sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w==,
       }
 
-  "@docsearch/core@4.6.3":
+  "@docsearch/core@4.7.0":
     resolution:
       {
-        integrity: sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==,
+        integrity: sha512-p/9xVKmPDj3FPvMfPf5naVO3Ej8SCbcUugGvx1+8GgkuBNbqxqN2Irx3WLBv8VY0jH7XpRwKWdlmjXLZsmTLsg==,
       }
     peerDependencies:
       "@types/react": ">= 16.8.0 < 20.0.0"
@@ -1990,16 +2009,16 @@ packages:
       react-dom:
         optional: true
 
-  "@docsearch/css@4.6.3":
+  "@docsearch/css@4.7.0":
     resolution:
       {
-        integrity: sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==,
+        integrity: sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==,
       }
 
-  "@docsearch/react@4.6.3":
+  "@docsearch/react@4.7.0":
     resolution:
       {
-        integrity: sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==,
+        integrity: sha512-x6oedjJ8O8/pIDBsMo5Orca3/6cQCz616/CwthVe68l43mqnj2lrJ9kFQITBqy8hMsS3nWeBWFoVO5dJ1DCFKA==,
       }
     peerDependencies:
       "@types/react": ">= 16.8.0 < 20.0.0"
@@ -2016,17 +2035,17 @@ packages:
       search-insights:
         optional: true
 
-  "@docusaurus/babel@3.10.1":
+  "@docusaurus/babel@3.10.2":
     resolution:
       {
-        integrity: sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==,
+        integrity: sha512-aJ1hpGyvfkte3dDAfNbWM4biW4yWZBVz7TIGLZP+v+tWOBgxX3e0N5ZIXHIvmfNNXTI77pcHUx3KmtOk05Ze3Q==,
       }
     engines: { node: ">=20.0" }
 
-  "@docusaurus/bundler@3.10.1":
+  "@docusaurus/bundler@3.10.2":
     resolution:
       {
-        integrity: sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==,
+        integrity: sha512-i0ZNcy0f0WhaOlYVgzLsWhIoEXO9kS3HRoKPtgE6vQtZUq7arKZaYdNBudr3mqCmd+TyOkwtwfHgs1ENj07r5g==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
@@ -2035,10 +2054,10 @@ packages:
       "@docusaurus/faster":
         optional: true
 
-  "@docusaurus/core@3.10.1":
+  "@docusaurus/core@3.10.2":
     resolution:
       {
-        integrity: sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==,
+        integrity: sha512-EYByj6nk+aD9KeVxV6Hmo2/nAAT79P21Y82ycTBOBtrmqilloIbIEhgL2/8Xpt2Jz/pgNqHAwyusOGwmbKeJmA==,
       }
     engines: { node: ">=20.0" }
     hasBin: true
@@ -2051,52 +2070,52 @@ packages:
       "@docusaurus/faster":
         optional: true
 
-  "@docusaurus/cssnano-preset@3.10.1":
+  "@docusaurus/cssnano-preset@3.10.2":
     resolution:
       {
-        integrity: sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==,
+        integrity: sha512-4gCnHRbJLTloiwfvFAa92tgb2gI4KYhvjfQVYnEaiMO/EgvWfCo1LwytHXen+1oZAN0VAlS0JAPxp3MsvKDa3A==,
       }
     engines: { node: ">=20.0" }
 
-  "@docusaurus/faster@3.10.1":
+  "@docusaurus/faster@3.10.2":
     resolution:
       {
-        integrity: sha512-XTZhE5C1gZ/DaYYMlSk02dwP5vhpQON5QHVz1s3892mSESAywgWanURpXEDAvt4GvGuq7s+XP8rTWHZvfaJmdQ==,
+        integrity: sha512-p/5E5/RyHv+QWusJMPN5i3OMJTqTgkhuwzVbB1AReDWTUHXQCmf5mlTFzGiDrWeQWIDOKsuOPn1jJh0s9LUOHA==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       "@docusaurus/types": "*"
 
-  "@docusaurus/logger@3.10.1":
+  "@docusaurus/logger@3.10.2":
     resolution:
       {
-        integrity: sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==,
+        integrity: sha512-gSEwqtPfCAnC3ZSJY6xL7tcIfgg0vFD39jbv93eakuweyvO2864xR0K+kmKwBhkTCtWRNjuGGnb5rdmkD/ndqw==,
       }
     engines: { node: ">=20.0" }
 
-  "@docusaurus/mdx-loader@3.10.1":
+  "@docusaurus/mdx-loader@3.10.2":
     resolution:
       {
-        integrity: sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==,
+        integrity: sha512-9Fd4V/SFjfrVQ0JH5EN0+iPWyFunvTeQE3gfyFeetqPaXMP0OylIjOw16dCuXG4NZJrYdBqwzjh18/h3gRi47w==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/module-type-aliases@3.10.1":
+  "@docusaurus/module-type-aliases@3.10.2":
     resolution:
       {
-        integrity: sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==,
+        integrity: sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==,
       }
     peerDependencies:
       react: "*"
       react-dom: "*"
 
-  "@docusaurus/plugin-content-blog@3.10.1":
+  "@docusaurus/plugin-content-blog@3.10.2":
     resolution:
       {
-        integrity: sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==,
+        integrity: sha512-0cbEnNKf0InmLkhj/+nVRmqEnWEoOE8Mh+2x1qOXI0qYpCnphq4RXknVJ8BvybKRXqYVvbmdMfiJSup+k4tm5w==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
@@ -2104,97 +2123,97 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/plugin-content-docs@3.10.1":
+  "@docusaurus/plugin-content-docs@3.10.2":
     resolution:
       {
-        integrity: sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==,
+        integrity: sha512-Sqwl4FPoZBDrlY8I2VU2H8O0M91CHp9T8ToMSkTZmjvHCif+1laqfXi6sTk8IfyVS/trN5yNjcWd1bFsGB6W5Q==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/plugin-content-pages@3.10.1":
+  "@docusaurus/plugin-content-pages@3.10.2":
     resolution:
       {
-        integrity: sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==,
+        integrity: sha512-h5R12sZ/vV9EPiVjvIl9YFCOwkpwXes7dQMYt3EvP6Pphu4amHxxTqWxf08Fl5DR8h+oZMbWpFTNw5vKEYfvzQ==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/plugin-css-cascade-layers@3.10.1":
+  "@docusaurus/plugin-css-cascade-layers@3.10.2":
     resolution:
       {
-        integrity: sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==,
+        integrity: sha512-UkdvQby5OQUKWrw3lLnSTJXQ6VETaUVTuPQX9AABtmFm5h+ifEBx1OQ+LN726Q4byuwBf2ElHkf4qU4hTxdvRg==,
       }
     engines: { node: ">=20.0" }
 
-  "@docusaurus/plugin-debug@3.10.1":
+  "@docusaurus/plugin-debug@3.10.2":
     resolution:
       {
-        integrity: sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==,
-      }
-    engines: { node: ">=20.0" }
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
-
-  "@docusaurus/plugin-google-analytics@3.10.1":
-    resolution:
-      {
-        integrity: sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==,
+        integrity: sha512-8vbZNOSCpnsT57EY6CgN7sgRVmx3KTYwO8Uvo2pbxOyb8tbqAwtT9SslqaQ41HbA1v1hpn5RP7u5s2KvRwAFpQ==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/plugin-google-gtag@3.10.1":
+  "@docusaurus/plugin-google-analytics@3.10.2":
     resolution:
       {
-        integrity: sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==,
+        integrity: sha512-kMHMBK9j4VAtgd5owwrRLRIi0EjkrpXlX7ePj1+y68XfVZV9I1T4S+koPDm+Hfw2TtnyHvh0uNrDvjz+DjQGVA==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/plugin-google-tag-manager@3.10.1":
+  "@docusaurus/plugin-google-gtag@3.10.2":
     resolution:
       {
-        integrity: sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==,
+        integrity: sha512-Vt90nNFhtAChRe9+it1hcHFgFvETdSnOkL5Bma+p6E/yU2tAYrvvyk+gv+LJGM2ZUkyKuKXLRsZ2Lb0bO7+Vog==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/plugin-sitemap@3.10.1":
+  "@docusaurus/plugin-google-tag-manager@3.10.2":
     resolution:
       {
-        integrity: sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==,
+        integrity: sha512-MLCffCldysi/R0nzJQP7ZWd0xAoGNnSTiVOo6TTR6mKVGFhE+/XArGe67ZcaZv1uytgQXoXs92VJrgVDrz80rQ==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/plugin-svgr@3.10.1":
+  "@docusaurus/plugin-sitemap@3.10.2":
     resolution:
       {
-        integrity: sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==,
+        integrity: sha512-PODkwg5XetLML3hU/3xpCKJUZ9cqExLaBnD/Fzzwj2VHogLeqnDisLIujae87zuze7T4mCm2A6KEqZkyiz07EQ==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/preset-classic@3.10.1":
+  "@docusaurus/plugin-svgr@3.10.2":
     resolution:
       {
-        integrity: sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==,
+        integrity: sha512-JgfT3jWM0TJ8Uw0cEcqxHpybngQY1vlBYpuuNO+gEh5iPh5Ar+vxq/u9CFrYsWeXy48BN7Db76Pzp2edNXUQ8A==,
+      }
+    engines: { node: ">=20.0" }
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  "@docusaurus/preset-classic@3.10.2":
+    resolution:
+      {
+        integrity: sha512-a4B3VczmDl99zK0EufDQYomdJ186WDingjmDXxhN2PNPS9Ty/Y2M5CLFX1KQMRKqRTLiRDKfutzG5IY1FC/ceg==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
@@ -2209,20 +2228,20 @@ packages:
     peerDependencies:
       react: "*"
 
-  "@docusaurus/theme-classic@3.10.1":
+  "@docusaurus/theme-classic@3.10.2":
     resolution:
       {
-        integrity: sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==,
+        integrity: sha512-JqTSLQmqmA9uKWZsD5iwBGJ4JyKB4/yTw6PsSXVPRJG/6GAm/u+add9Iip+hvwP12/AnPNztrdxsI14NJW4KeA==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/theme-common@3.10.1":
+  "@docusaurus/theme-common@3.10.2":
     resolution:
       {
-        integrity: sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==,
+        integrity: sha512-R9b/vMpK1yye6hNZTA6x/ivRv+at6GhxnXcxkpzCGzO1R1RwiquqiFg2wMFh6aqlJTpWRFKpFD2TzCDQcyOU0A==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
@@ -2230,10 +2249,10 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/theme-mermaid@3.10.1":
+  "@docusaurus/theme-mermaid@3.10.2":
     resolution:
       {
-        integrity: sha512-2gxpmln8Pc4EN1oWzshQEx2HTs67jk14v7MmgqGs8ZU7Nm8oihg+fTouof2u4vN8DtB3Fln4cDJu4UprSX1S3Q==,
+        integrity: sha512-Stssh5MYQJ+EdYugUXf+ZcpeJFQPKXf0KCd/SWp10o3CmXNaOoh5IEgVjVqY1e1XhQf3on4+Y4BnrMiD95E2SQ==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
@@ -2244,81 +2263,81 @@ packages:
       "@mermaid-js/layout-elk":
         optional: true
 
-  "@docusaurus/theme-search-algolia@3.10.1":
+  "@docusaurus/theme-search-algolia@3.10.2":
     resolution:
       {
-        integrity: sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==,
+        integrity: sha512-1msxllyhi/5m77JukXtp5UFnUAriwZIC1oJ7MTnpQpCwLTbclJi5BK5n28CTZuSXpQN2ewbbnqRgAhMM6c6ihg==,
       }
     engines: { node: ">=20.0" }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/theme-translations@3.10.1":
+  "@docusaurus/theme-translations@3.10.2":
     resolution:
       {
-        integrity: sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==,
+        integrity: sha512-iv20wrxnyXkY89LM3TzRlzGlt5fIGO5UnaR6UL1ZVfB9RRFjxQFQ6awDrwAc6Km8Y5gD8pInuwYPF+6/TiCxXA==,
       }
     engines: { node: ">=20.0" }
 
-  "@docusaurus/tsconfig@3.10.1":
+  "@docusaurus/tsconfig@3.10.2":
     resolution:
       {
-        integrity: sha512-rYvB7yqkdqWIpAbDzQljGfM4cDBkLTbhmagZBEcsyj6oPUsz47lmW2pYdN1j+7sGFgltbAmQH62xfbrij4Eh6Q==,
+        integrity: sha512-5GiB7h/nFsMFPO9mCqcRNE1yA5TSXXNCshNIgHPL6fCPOjcTDixs6qjQBu8ddkgPcicwCvOA7n3jeK2rGdJk6g==,
       }
 
-  "@docusaurus/types@3.10.1":
+  "@docusaurus/types@3.10.2":
     resolution:
       {
-        integrity: sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==,
+        integrity: sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==,
       }
     peerDependencies:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  "@docusaurus/utils-common@3.10.1":
+  "@docusaurus/utils-common@3.10.2":
     resolution:
       {
-        integrity: sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==,
+        integrity: sha512-x3Dz6jv6iQKBNjBmVTu8p57abMp/VNTUgKBMgRVXJc5444orBTsArv0+cdfrXTiz/VMmHfDRVkPbL7GH2B7T7w==,
       }
     engines: { node: ">=20.0" }
 
-  "@docusaurus/utils-validation@3.10.1":
+  "@docusaurus/utils-validation@3.10.2":
     resolution:
       {
-        integrity: sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==,
+        integrity: sha512-sn8unbDfUL585NtR3cwHefPicOyaHvPaX7VD0aOg/siIxUBoKyKKaGEqzJZDS64mM43TnxurkYDtmB1wsJlZsw==,
       }
     engines: { node: ">=20.0" }
 
-  "@docusaurus/utils@3.10.1":
+  "@docusaurus/utils@3.10.2":
     resolution:
       {
-        integrity: sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==,
+        integrity: sha512-xx0W3eav2uW1NRIpuHJWNwLTC15xPNjU4Uxi9NSnd3swYC96BE3vFiT93SD8s24kmAAWNwgZwfZ2fghGZ01Lcw==,
       }
     engines: { node: ">=20.0" }
 
-  "@emnapi/core@1.11.1":
+  "@emnapi/core@1.11.3":
     resolution:
       {
-        integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==,
+        integrity: sha512-zLpS5asjEb7lq8jYLq37N6XKaE41DIexlY1rF/z4/tIl3wo13Sqm28fRyfIsKZD+NZ8mM5RoKkpW/rBcuoSZSg==,
       }
 
-  "@emnapi/runtime@1.11.1":
+  "@emnapi/runtime@1.11.3":
     resolution:
       {
-        integrity: sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==,
+        integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==,
       }
 
-  "@emnapi/wasi-threads@1.2.2":
+  "@emnapi/wasi-threads@1.2.3":
     resolution:
       {
-        integrity: sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==,
+        integrity: sha512-ELEBe8PsLvvJ6QMr0zLt8ffvOHW/dc1m3CEzNMg7aJUv3bMaoDtw2TXyDAwkYBuroxxuHEwhRTLJSe5sya547g==,
       }
 
-  "@eslint-community/eslint-utils@4.9.1":
+  "@eslint-community/eslint-utils@4.10.1":
     resolution:
       {
-        integrity: sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==,
+        integrity: sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==,
       }
     engines: { node: ^12.22.0 || ^14.17.0 || >=16.0.0 }
     peerDependencies:
@@ -2338,10 +2357,10 @@ packages:
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  "@eslint/config-helpers@0.6.0":
+  "@eslint/config-helpers@0.7.0":
     resolution:
       {
-        integrity: sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==,
+        integrity: sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==,
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
@@ -2390,31 +2409,31 @@ packages:
       "@noble/hashes":
         optional: true
 
-  "@floating-ui/core@1.7.5":
+  "@floating-ui/core@1.8.0":
     resolution:
       {
-        integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==,
+        integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==,
       }
 
-  "@floating-ui/dom@1.7.6":
+  "@floating-ui/dom@1.8.0":
     resolution:
       {
-        integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==,
+        integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==,
       }
 
-  "@floating-ui/react-dom@2.1.8":
+  "@floating-ui/react-dom@2.1.9":
     resolution:
       {
-        integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==,
+        integrity: sha512-JDjEFGCpImxDCA7JJKviA0M9+RtmJdj0m/NVU5IMgBK+AmZouAQQ7/+2GLH0GXXY0YMw9oXPB8hKdbPYg5QLYg==,
       }
     peerDependencies:
       react: ">=16.8.0"
       react-dom: ">=16.8.0"
 
-  "@floating-ui/utils@0.2.11":
+  "@floating-ui/utils@0.2.12":
     resolution:
       {
-        integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==,
+        integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==,
       }
 
   "@gerrit0/mini-shiki@3.23.0":
@@ -2602,73 +2621,73 @@ packages:
     peerDependencies:
       tslib: "2"
 
-  "@jsonjoy.com/fs-core@4.64.0":
+  "@jsonjoy.com/fs-core@4.68.1":
     resolution:
       {
-        integrity: sha512-zs2TAq7Six5jgMuoMNjpspAvOP3mhtgq/k1UyQodEzCtQi/N83y2/y+zcvnZSGp/Rxq96DBN+bValOBQAyn/ew==,
+        integrity: sha512-V5oZ4Gt9WJKyQef0n9cAd0N9qjSkIBm3E4MYsgNIWBk5aINCDPKxMPo1i29rBxqiT4Ixf1epklqV9VJMKIxwlw==,
       }
     engines: { node: ">=10.0" }
     peerDependencies:
       tslib: "2"
 
-  "@jsonjoy.com/fs-fsa@4.64.0":
+  "@jsonjoy.com/fs-fsa@4.68.1":
     resolution:
       {
-        integrity: sha512-nMWOVbkLFyEgmXZih3wyvxA9XpgyyqyfrINMHvEFqhi7uqfRl7c9ERJt6yX7vgMPrB9Uo+OJO+Spa0cFzPD01w==,
+        integrity: sha512-HCG72UioncuO7Gw09XNVG+S85e3cq2hrUC/mexBrsWsa3mI7eePkkqWie3uVYbtsb64OR9YGQs5SqaufDRYBcg==,
       }
     engines: { node: ">=10.0" }
     peerDependencies:
       tslib: "2"
 
-  "@jsonjoy.com/fs-node-builtins@4.64.0":
+  "@jsonjoy.com/fs-node-builtins@4.68.1":
     resolution:
       {
-        integrity: sha512-/o7WRFhUWaM/fOrslwLZGnzn4RmRILykn+lAL+mNObqqRNw+CQSiij6hpCeZ+C7buhdoVo7go/OYqzaSUfDYmA==,
+        integrity: sha512-HK1BTksysokNZxNspqDH0yPaqN9YgR/AYIlYiIaU2Ys4BOk5CdybI7r6BgiZuiiPiV8n4sK/kZdice7Znpy2Kw==,
       }
     engines: { node: ">=10.0" }
     peerDependencies:
       tslib: "2"
 
-  "@jsonjoy.com/fs-node-to-fsa@4.64.0":
+  "@jsonjoy.com/fs-node-to-fsa@4.68.1":
     resolution:
       {
-        integrity: sha512-WDD9WVs0hb7UAEKTgZW2f66WDrbj7gIIWwpP3spbLyXa0rghtUaFTB8L4gdR3ZCWwiKIsj38/CNijpVmpnuPUw==,
+        integrity: sha512-lpKmU4X9e/oh8GIuAI7EXaS5QiLNM3KD15CkdhfS6PYmrGvoJqKQcyEfnLgnnaGslh/PFUMYSIZBCf2ejJGw8g==,
       }
     engines: { node: ">=10.0" }
     peerDependencies:
       tslib: "2"
 
-  "@jsonjoy.com/fs-node-utils@4.64.0":
+  "@jsonjoy.com/fs-node-utils@4.68.1":
     resolution:
       {
-        integrity: sha512-k5Indsx9hWW9xSF7Y6oSKKwtCUNhzZxadub3owhIlitc+iMRVlPPdX2duTKQWBL3qNWpXya8jykgaaWpheeS4w==,
+        integrity: sha512-/GxfW1DWm9SCdkfbvqevLO/P5duobQfmKkHXxdMIDbcZMQeAgooAstIfZhkXpATzq9QbCQsnoWFM/dGHdZfndw==,
       }
     engines: { node: ">=10.0" }
     peerDependencies:
       tslib: "2"
 
-  "@jsonjoy.com/fs-node@4.64.0":
+  "@jsonjoy.com/fs-node@4.68.1":
     resolution:
       {
-        integrity: sha512-dO+NNkODbUli4uV42bcNrrLvq5rE7SNpdZ5TNd0dtbLsAaNK3MDiIC9lUi+brboGoIjW6vd2fB1qao60nrk5xA==,
+        integrity: sha512-R5D9mWtqdURzcOWj1vdXr3APCwX0xchtFT+kmW7fXLNDifWdDrnh26jSID8pdnUfFBxTyfHtFtTL/NWKzIH7kQ==,
       }
     engines: { node: ">=10.0" }
     peerDependencies:
       tslib: "2"
 
-  "@jsonjoy.com/fs-print@4.64.0":
+  "@jsonjoy.com/fs-print@4.68.1":
     resolution:
       {
-        integrity: sha512-PHZFccchvkhWrwPWHjmVAhbC3vSHCtyZvlZfJJ3ho2bnzl450hXri6/8e6pbkWdH+SkmLXNml0sV8e5HDAfxKw==,
+        integrity: sha512-oGeZOGPYKK9v1CgeVeEDsLomH1lCnslSpqUN5GmPzrmAVGQlsmsdcXNA2O4lV8Y4xkuSuynx2ITBkUHJVaTbow==,
       }
     engines: { node: ">=10.0" }
     peerDependencies:
       tslib: "2"
 
-  "@jsonjoy.com/fs-snapshot@4.64.0":
+  "@jsonjoy.com/fs-snapshot@4.68.1":
     resolution:
       {
-        integrity: sha512-oM7UDeL83q6NBzzsfKAsYKXKVXlykKFqqOLh4xZZKAzzROTlInkPbc6LTDGThEOnPiFiUzA7tYziHG9xavd76Q==,
+        integrity: sha512-XZfP0FDZN32bbc4t2bZN2qRrYHg5AktJnzk22HRoKGK4BprrbNRH2k5ceSNS/kupKYcofCs+O841+xaAbjnxwQ==,
       }
     engines: { node: ">=10.0" }
     peerDependencies:
@@ -2749,23 +2768,25 @@ packages:
       "@types/react": ">=16"
       react: ">=16"
 
-  "@mermaid-js/parser@1.2.0":
+  "@mermaid-js/parser@1.2.1":
     resolution:
       {
-        integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==,
+        integrity: sha512-n12NohV3mrUyUL2o93IgG/ifeW9FTyeJn3zDxkhwa8MJ9Fxg3HQMlA3RiGmD/3UnJvheztkjjQAjA2T4LmUcpw==,
       }
 
-  "@microsoft/api-extractor-model@7.33.8":
+  "@microsoft/api-extractor-model@7.33.11":
     resolution:
       {
-        integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==,
+        integrity: sha512-iDu1AtuRC2Z8XVs2SieZieVavF1FXPBX1C9pMexJh8Dx/Dd/3ZZ4nRQp/PU2Vk2rUHWuBz1wOyL4DcuhVnBXwg==,
       }
+    engines: { node: ">=20.9.0" }
 
-  "@microsoft/api-extractor@7.58.9":
+  "@microsoft/api-extractor@7.59.0":
     resolution:
       {
-        integrity: sha512-S2UF4yza5GoxCmf7hJQNxJNZN9ltOVuOQv8Dy+Z21aol5ERoBNMdWcQHm4MJMPPItW4H/4rZD906iaf4mUojJA==,
+        integrity: sha512-KDYV8kSVjmG8JJWVg1f1aKxteNG1IQ44D07Rjhlcci8wlqrSFNhUfgv7dJhwT0W2h3NDIL5Vz2f+/DfO4OpDHw==,
       }
+    engines: { node: ">=20.9.0" }
     hasBin: true
 
   "@microsoft/tsdoc-config@0.18.1":
@@ -2822,15 +2843,6 @@ packages:
         integrity: sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==,
       }
 
-  "@napi-rs/wasm-runtime@1.1.6":
-    resolution:
-      {
-        integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==,
-      }
-    peerDependencies:
-      "@emnapi/core": ^1.7.1
-      "@emnapi/runtime": ^1.7.1
-
   "@noble/hashes@1.4.0":
     resolution:
       {
@@ -2859,71 +2871,81 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  "@oxc-project/types@0.139.0":
+  "@oxc-project/types@0.146.0":
     resolution:
       {
-        integrity: sha512-r9gHphtCs+1M7J0pw6Sn/hh/Wpa/iQrOOkrNAlVLF/gHq+/CJmHIWKKUUhdWjcD6CIa8idarspCsASiXCXvFUw==,
+        integrity: sha512-XC0QsnnhVe7sLIWmYmdPw7x5P0h4W8vUU3Nv1ySgWXtvCz8NizoAEpGXA0sOYoJQV2Rl13LgURAHQ5cI5ILCSA==,
       }
 
-  "@peculiar/asn1-cms@2.8.0":
+  "@peculiar/asn1-cms@2.9.4":
     resolution:
       {
-        integrity: sha512-NgekZOrSJFSBFLFoLfwePguAWAx7z1+f2TEsWFUMyiqqfntZ4+S/S5hzqME3q4pCA0iOsFKdwiQ35dwY24eVqA==,
+        integrity: sha512-cben7oxmQsUGZqotus7yt0srYdncOT6RNWcTQ77T2RFOXejYVYkXadrfePdRcrVpO9K95IRLKKglG2k38jKXuw==,
       }
+    engines: { node: ">=14" }
 
-  "@peculiar/asn1-csr@2.8.0":
+  "@peculiar/asn1-csr@2.9.4":
     resolution:
       {
-        integrity: sha512-akbF8+uvleHs8sejNPQxwmVFuInAg6FMNHOwMILXfP518YfFJwdR3jr6oNUPOaEJfuEhn/vkNOCIT6ASUd4mbg==,
+        integrity: sha512-xd4YN4vpRjkDAQWVfZZkeu12IEND7DOpkqaHSIHxZl1uggUNa9Ju0QxY2jHvDAS9pP0zhRBytg8ifsnGo3V0jw==,
       }
+    engines: { node: ">=14" }
 
-  "@peculiar/asn1-ecc@2.8.0":
+  "@peculiar/asn1-ecc@2.9.4":
     resolution:
       {
-        integrity: sha512-ohwlk+u9Rv2NOAY1c6MfHj45ATVF8R1DUN/WCgABiRtLi2ZftlZWZX7KvpAbU8v9xPcmoILfELeEABj/rn18AQ==,
+        integrity: sha512-JJXefFshRAuVAjWQo/39bkg1ywc1VaiO44S8RRC+Ykvf/u2KDmYffoDb0ZBPCR5uJy4AGKQhl8mX+Q8ShcWaXQ==,
       }
+    engines: { node: ">=14" }
 
-  "@peculiar/asn1-pfx@2.8.0":
+  "@peculiar/asn1-pfx@2.9.4":
     resolution:
       {
-        integrity: sha512-5yof1ytoB++RQtaFbqSUJ8pxDJtZT6vbVqZ8XoJ61ph7UjNVvfFwAilnCodqkNsAodpy13gDhoxZXw00pghnyg==,
+        integrity: sha512-khuGzHTzNzk4GDlIBEILyIs6Lce0yn0ZBdoI9v93kmNncfZRhD+AQ5ODFqdhvoE8cMJF/JMTQ8yA+t1D14kqCw==,
       }
+    engines: { node: ">=14" }
 
-  "@peculiar/asn1-pkcs8@2.8.0":
+  "@peculiar/asn1-pkcs8@2.9.4":
     resolution:
       {
-        integrity: sha512-qAKXtLpBEw9LqhKpjw3ajZSXlBur+ipW+y2ivVBQAG6F6qRx94yO+1ZR4mvw+YaCfKSaOzLeYEzsPaBp4SJELA==,
+        integrity: sha512-duRdotlUx9eDZe6QrQpQKl61RbWykCHBCkKayP8V8XdEFwlKHZ8qGGDMyS6Pye7OX7nLFttTTpRkJeet78ckwQ==,
       }
+    engines: { node: ">=14" }
 
-  "@peculiar/asn1-pkcs9@2.8.0":
+  "@peculiar/asn1-pkcs9@2.9.4":
     resolution:
       {
-        integrity: sha512-b5nDWCnkV60+cQ141D6sVVwK9nz64R5n3zSVnklGd+ECdkW2Ol3U1a6yYFlalpSOaD557yuJB64A+q42jG7lUQ==,
+        integrity: sha512-kaL4cNxBpdQE2dKlyZBqz4ygCrwffO+8wfoxTEqM1Z8RadvCeELBRzcv0dzM8aY9azHMwODO5nxU65zXmhToOQ==,
       }
+    engines: { node: ">=14" }
 
-  "@peculiar/asn1-rsa@2.8.0":
+  "@peculiar/asn1-rsa@2.9.4":
     resolution:
       {
-        integrity: sha512-zHEUlCqB2mk7x2lxDwHHJy7hWZOPdGHVlsmITWKB5/PbQo61atbu9PJ/0r9dQNMwFzbKPXZ8uK8/91eUhRznSg==,
+        integrity: sha512-pZ96eD1PptovcWQ/GSmuNFXd/7EQJNlKfDaNCyE2rx3W0v6QFelkzquVqRSRyyDXXCYD69ZXJDzZ8GhIiQzKoA==,
       }
+    engines: { node: ">=14" }
 
-  "@peculiar/asn1-schema@2.8.0":
+  "@peculiar/asn1-schema@2.9.4":
     resolution:
       {
-        integrity: sha512-7YT0U/ze0tF2QOBbE15gKZwy5tvgGyLRiRHLzhlbOpf7BT032oBSd0haZqXn5W6l26WLlu3dyxzjM+2638/z2Q==,
+        integrity: sha512-GjzePcT9Iw8NzeOPf73iNS9xM+TBhd/FilAfP+RQGkTMQJTVWtytN3JHJACCjf/ABNau5S7mS3g+DcuxmRgYEg==,
       }
+    engines: { node: ">=14" }
 
-  "@peculiar/asn1-x509-attr@2.8.0":
+  "@peculiar/asn1-x509-attr@2.9.4":
     resolution:
       {
-        integrity: sha512-tHjkfS/qhMnmrlB2J9NhflQlQ7In3khO3CfmVrriOlpTeErY9ZIKOso1hQ5JQiyrJ7ShvqVPk7E5fQmbclkSKA==,
+        integrity: sha512-ehQXbpQaQYycgu8OrvigwSPTFfVRcu0ECNYCWw+yzBp02Lw5paRqzzhUpfOgO2K38+WfFZuEz/0RPtam5g0OMg==,
       }
+    engines: { node: ">=14" }
 
-  "@peculiar/asn1-x509@2.8.0":
+  "@peculiar/asn1-x509@2.9.4":
     resolution:
       {
-        integrity: sha512-N0CMuhWUzsWEVq6F1q9X6+VKUnWzSW+cSVg+aPaGGwDdbFoFWTYgin5MHwXgpWd6y9COMBxnfy/Qc+Xc7F0Zwg==,
+        integrity: sha512-CxhBo/RdEbMMob7T31ZdQjGuoyRFLVwrDzTn25bihzBasRg9kRm/0IxIPvhgQtcK/9dNcO1XQL2fuPugwELL0Q==,
       }
+    engines: { node: ">=14" }
 
   "@peculiar/utils@2.0.3":
     resolution:
@@ -2971,141 +2993,142 @@ packages:
         integrity: sha512-HNB6HYeYKhQbJ1aKl+YRjrS4+QWHLKX6qKoUsfS/m0vqzsVaEBiZiaKbG/e+NKk2ch5ALQr/ihWaMHxiCuuWHA==,
       }
 
-  "@rolldown/binding-android-arm64@1.1.5":
+  "@rolldown/binding-android-arm-eabi@1.2.5":
     resolution:
       {
-        integrity: sha512-lZg8fqIv2v7FF237bwMgzGZEJvGL79/s5knJ/i6FmsGF4XXlzccZ4jb+TrFIxtSSxFtIpdsgrPZeMk1I9AFcyQ==,
+        integrity: sha512-DLe/i+l8ynIBY7XEQ191TeZvCoowIGa18R+dIV30GW7DiOtp74i/xX8hs8GUjW5ARV7VZuie3d6AumSmCwbeRA==,
+      }
+    engines: { node: ^20.19.0 || >=22.12.0 }
+    cpu: [arm]
+    os: [android]
+
+  "@rolldown/binding-android-arm64@1.2.5":
+    resolution:
+      {
+        integrity: sha512-zXcwKlQApYAOELHd8PwKDFkagYF9Wy4e0RJ+0qnzl9Pjnpj75TEG8ufv40p2J7kCEfwZAsNiuzRIyNNMWT38ig==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [android]
 
-  "@rolldown/binding-darwin-arm64@1.1.5":
+  "@rolldown/binding-darwin-arm64@1.2.5":
     resolution:
       {
-        integrity: sha512-51Bnx9pNiMRKSUNtBfySkNJ9vMU9Hh3I1ozDd6gyPPYzaXCfnptUcEZxXGYFn+ul2dtcMUiqGR1Yai2K10uoTw==,
+        integrity: sha512-dK4QakI42nzWgJT5sm4y4y/O//D4OxM75/cH28RLV+nzIN9AY+YsbuUVrUTjlLjXR6vpyxFbSsbmNuJ6BP9sww==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [darwin]
 
-  "@rolldown/binding-darwin-x64@1.1.5":
+  "@rolldown/binding-darwin-x64@1.2.5":
     resolution:
       {
-        integrity: sha512-Tm+gbfC0aHu1tBA/JvKQh32S0K6YgCHkiAF4/W6xX0K0RmNuc94VeK419dJoE65R5aRxmo+noZQSWrAMF6yb6g==,
+        integrity: sha512-fqSALaUu1Wjd1nK2uW2kJDWdLCc8lx1IcY+MTY26Aurfdx19anlzhqXOgCFbBFQnlFDTn4TC1/7Nz4Bl2mLP3A==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [darwin]
 
-  "@rolldown/binding-freebsd-x64@1.1.5":
+  "@rolldown/binding-freebsd-x64@1.2.5":
     resolution:
       {
-        integrity: sha512-JMzDKCCXq93YccG5gz3hvOs1oXRKAf0XYpfOS88e+wZrC8Iugj6j68867vrYZkvpDDpKn/KoKORThmchMpF6TA==,
+        integrity: sha512-/vCnNxlkxs9tKxNDcyWUePpJ/PgTzxIaVhoM5SmG8UV+GR/IcPam4VYxi7GIMo7PSDuNqlJqvprqii9NqqVCMw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [freebsd]
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.1.5":
+  "@rolldown/binding-linux-arm-gnueabihf@1.2.5":
     resolution:
       {
-        integrity: sha512-uML21j2K5TfPGutKxub+M+nLjZIrWjXQ5Grx4lCe/nimTj9B4L63zHpjXLl4y0L3mcm2htEQIb06oCG/szerNw==,
+        integrity: sha512-abk0NLA519LxRCszmbE0jYKuQ9YPocOXTiOXOo6Yr+YAT95VH+PtqYAjOJvGKt3viEd/x4qzabAlwd5bHOOARg==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm]
     os: [linux]
 
-  "@rolldown/binding-linux-arm64-gnu@1.1.5":
+  "@rolldown/binding-linux-arm64-gnu@1.2.5":
     resolution:
       {
-        integrity: sha512-navSiuTMogvnQoZoM/v+l3ZWo50/NTwSHSzheABx/RCnmUPaKwq9qSo4Br2OYRs21+Fz8uFqITZM3H4opOB0/Q==,
+        integrity: sha512-Y7eALiJ8lr0M2HH103Js+g7V34wf6snlpZLAsHI90uLhr3PVlNsbFVAXJC9d/V6BnPyKtpSwI+NcB/RLxsQxuA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-arm64-musl@1.1.5":
+  "@rolldown/binding-linux-arm64-musl@1.2.5":
     resolution:
       {
-        integrity: sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==,
+        integrity: sha512-xMvZgnbZg4YVnR/AX2b3oOPDTFYJvUVaJg5FedA/LuvexAtXibZQej4cnTkw3rjsJ/ggUROB64TdtETiim+FYA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-linux-ppc64-gnu@1.1.5":
+  "@rolldown/binding-linux-ppc64-gnu@1.2.5":
     resolution:
       {
-        integrity: sha512-fsK/sNBnxzBlL4O1JNrZakVQxPspqpED5dLtNsZS9oOKmtSpdNIzxH2kkol5HYTWJN47sE20ztMJPxfZ89qGOg==,
+        integrity: sha512-GRjeqTUDHTo5GwntsLaAMcBahG3nlpjftXWZLN73HiYQlhwEowvarFgQnRnQZtIp4keXX7quXFbG38uPZBa2EA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-s390x-gnu@1.1.5":
+  "@rolldown/binding-linux-s390x-gnu@1.2.5":
     resolution:
       {
-        integrity: sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==,
+        integrity: sha512-vLNTR45F2Uwc8AufkNXPmB4VliaXs+FvcheEogIzOXzO4l+LzieXF5A/TWxLy5HtqpsRCHUfd0lPVrrdgXdLHQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-x64-gnu@1.1.5":
+  "@rolldown/binding-linux-x64-gnu@1.2.5":
     resolution:
       {
-        integrity: sha512-FjcpEKUyJygHgs1o50VYNvkt5+7Le/VEdYt0AkRpkL33MnyQfwr8l5mXwMmfmTbyMPr5vJLC+8/Gd9gXnwU1QQ==,
+        integrity: sha512-Mgj59/HTuYeK9Gz2MA+mBWKnHsAgkBSec15ZMb1st3oIfFbX7gCjOae7GydHhzcyQi9Z/7M1QuN9bR3oFqF0jQ==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@rolldown/binding-linux-x64-musl@1.1.5":
+  "@rolldown/binding-linux-x64-musl@1.2.5":
     resolution:
       {
-        integrity: sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==,
+        integrity: sha512-mY8AP0/ichsbhAxGnLa3d3+MwV0EfgrPND2bplI3Ym8T6R2pJ0N87bvrKVwNXmdy3jnr6eQBecdqx/HMknBmpA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@rolldown/binding-openharmony-arm64@1.1.5":
+  "@rolldown/binding-openharmony-arm64@1.2.5":
     resolution:
       {
-        integrity: sha512-yc5WrLzXks6zCQfn9Oxr8pORKyl/pF+QjHmW/Qx3qu0oyrrNC+y2JLTU1E2rcWYAmzlnqngWXHQjy51VzW70Vw==,
+        integrity: sha512-8SLssA2oweAxyRgDp789ACfRb/3P+zNRJpzZxSizxF9m8NUDQ4+3xjo8ttjhVGGw6Qxb70oZiEtIjaKikCO7Yw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [openharmony]
 
-  "@rolldown/binding-wasm32-wasi@1.1.5":
+  "@rolldown/binding-win32-arm64-msvc@1.2.5":
     resolution:
       {
-        integrity: sha512-VbQGPX2b4r48TAMIM2cjgluIM1HYutm4pcTEJsle7iEP7sB1dFqtPLBVbdLAZCxy1txCcPxf4QFf4v8uvltPqA==,
-      }
-    engines: { node: ^20.19.0 || >=22.12.0 }
-    cpu: [wasm32]
-
-  "@rolldown/binding-win32-arm64-msvc@1.1.5":
-    resolution:
-      {
-        integrity: sha512-gHv82k63z4qpV5+Q1y/12KrK0ltWBukVDI8nZcbT7Tt/ZlOIVwppazneq0F93oDxTo3IgAMEDIoQh3E2n6mVsw==,
+        integrity: sha512-vGbruD5zquhoc8D9SViXgN2FBJtNdTyQ4DtG+SWiEGlJiAzoKcZ2xp+xuXCffhubVdt0NJlTZqkeRuERy7g8Cw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [arm64]
     os: [win32]
 
-  "@rolldown/binding-win32-x64-msvc@1.1.5":
+  "@rolldown/binding-win32-x64-msvc@1.2.5":
     resolution:
       {
-        integrity: sha512-tTZuDBPw85tEN5PQi1pnEBzDy0Z49HtScLAbD5t6hyeU92A95pRWaSMw1GZZi/RwgSgUIl0xrSlXIT/9QzvYSA==,
+        integrity: sha512-e/SXpgISz+IoqVcSSI0rx/d/he8zqLex+/rCWpnHpmVfmPIUjag9H6P7zotf0gJHwPUhQxZ/mF8tr6acebT9yw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     cpu: [x64]
@@ -3236,11 +3259,12 @@ packages:
         integrity: sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==,
       }
 
-  "@rushstack/node-core-library@5.23.1":
+  "@rushstack/node-core-library@5.24.0":
     resolution:
       {
-        integrity: sha512-wlKmIKIYCKuCASbITvOxLZXepPbwXvrv7S6ig6XNWFchSyhL/E2txmVXspHY49Wu2dzf7nI27a2k/yV5BA3EiA==,
+        integrity: sha512-g/Z47ZwARn/VkTnHcyJslrR26erRf1G5JbqPlfGZGBCrOcrEt8fTQXXDVhUDDNl/g/v3TXI1dNiAAT5FEks8BA==,
       }
+    engines: { node: ">=20.9.0" }
     peerDependencies:
       "@types/node": "*"
     peerDependenciesMeta:
@@ -3264,22 +3288,24 @@ packages:
         integrity: sha512-aAA518n6wxxjCfnTAOjQnm7ngNE0FVHxHAw2pxKlIhxrMn0XQjGcXKF0oKWpjBgJOmsaJpVob/v+zr3zxgPWuA==,
       }
 
-  "@rushstack/terminal@0.24.0":
+  "@rushstack/terminal@0.24.3":
     resolution:
       {
-        integrity: sha512-8ZQS4MMaGsv27EXCBiH7WMPkRZrffeDoIevs6z9TM5dzqiY6+Hn4evfK/G+gvgBTjfvfkHIZPQQmalmI2sM4TQ==,
+        integrity: sha512-KxphDhPGC4xDrKg8O4yrWCEpPMi87aJc1iycXqMVh1dLgV0M34hiH9ZTgWjBRmcrT/OIHoOeWf48npcQFzgp+g==,
       }
+    engines: { node: ">=20.9.0" }
     peerDependencies:
       "@types/node": "*"
     peerDependenciesMeta:
       "@types/node":
         optional: true
 
-  "@rushstack/ts-command-line@5.3.10":
+  "@rushstack/ts-command-line@5.3.13":
     resolution:
       {
-        integrity: sha512-fwI076HYknC0IrMXdY6UmjDv+PH7NHhNJX3/pY2UblSE5XrXgndXZPiOe/6ZtuFpn6DvVDVNhtkIzQ+Qu/MhVQ==,
+        integrity: sha512-+jNbxhh8CkrZYxMk9X3GRYM2+Myr1xCCj+eHbJ9Vp+PCdNHS0TUl5QQFT6UbM/aTFRCzs5jiBTKYzBRpe5uYbQ==,
       }
+    engines: { node: ">=20.9.0" }
 
   "@shikijs/engine-oniguruma@3.23.0":
     resolution:
@@ -3329,10 +3355,10 @@ packages:
         integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==,
       }
 
-  "@sinclair/typebox@0.27.10":
+  "@sinclair/typebox@0.27.12":
     resolution:
       {
-        integrity: sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==,
+        integrity: sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==,
       }
 
   "@sindresorhus/is@4.6.0":
@@ -3490,124 +3516,124 @@ packages:
       }
     engines: { node: ">=14" }
 
-  "@swc/core-darwin-arm64@1.15.43":
+  "@swc/core-darwin-arm64@1.16.1":
     resolution:
       {
-        integrity: sha512-v1aVuvXdo/BHxJzco9V2xpHrvwWmhfS8t6gziY5wJxd+Z2h8AeJRnAwPD8itCDaGXVBwJ/CaKfxEzTkG0Va0OA==,
+        integrity: sha512-zlJblJ8ncErD43lKdxjbUaUskJQf+LxiPXYcWXD8/8ZMV+7uuAT+CwjciLXpyZBd5Pq/S726bMpeeAwSeL1hhg==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [darwin]
 
-  "@swc/core-darwin-x64@1.15.43":
+  "@swc/core-darwin-x64@1.16.1":
     resolution:
       {
-        integrity: sha512-lp3d4Lamc8dt5huYdGLSR+9hLxmfr1jb0l+4XXG2zPqZwYWRN9R0U2qYoTrggiU2RWW0oV9VbWM3kBnqIc2kdQ==,
+        integrity: sha512-IN0BmPWb0YAh/17mmlWB/HDBtTw2MfuW4hulf/tQAgTQBRH17l+z499bNJLK6LizSjqs0P7V+jU38Zj+vJC1DA==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [darwin]
 
-  "@swc/core-linux-arm-gnueabihf@1.15.43":
+  "@swc/core-linux-arm-gnueabihf@1.16.1":
     resolution:
       {
-        integrity: sha512-JWTQQELtsG5GgphDrr/XqqmM2pDN3cZqbMS0Mrg+iTiXL3F74sn/S2IyYE/5u4h2KLkTf9qQ7dXyxsbx7YzkeA==,
+        integrity: sha512-EYgrx2YOCQ2Twz2S793kqNjPkpvYVUPzzR95bIb7by+VQcyaai4lZZ2iz/tZvcFVKSNcN3/JTKwx+aBn2ZL52A==,
       }
     engines: { node: ">=10" }
     cpu: [arm]
     os: [linux]
 
-  "@swc/core-linux-arm64-gnu@1.15.43":
+  "@swc/core-linux-arm64-gnu@1.16.1":
     resolution:
       {
-        integrity: sha512-B4otJRdPWIsmiSBf0uG7Z/+vMWmkufjz5MmYxubwKuZazDW14Zd3symga1N62QR4RT+kEFeHEgsXfZGyn/w0hw==,
+        integrity: sha512-moyKm0YZlHdHohzm1YwgAyesqnE853rO0REMfJLFAova51wF9BNi+3ZW2PeS7Vqvn6HeJuepLpAHbBdZctxpHA==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@swc/core-linux-arm64-musl@1.15.43":
+  "@swc/core-linux-arm64-musl@1.16.1":
     resolution:
       {
-        integrity: sha512-6zB6OnpViBxYy4tgY3v2i6AZY9fwkcHZ032UOwtwUuW1d19sdT07qF0kZe6/3UR1tUaK6jjg2rmVcUIBCEYVjQ==,
+        integrity: sha512-kKGBO9wdapiSzuf5ZzZ2fYtlu1BNSYtIIUxvH1ir/gcelTOREEHGDCLTDFx/2Knf878nU11A40z7LxwasEFxqA==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@swc/core-linux-ppc64-gnu@1.15.43":
+  "@swc/core-linux-ppc64-gnu@1.16.1":
     resolution:
       {
-        integrity: sha512-coxE1ZWdB3uSDVNoEtYNrRi/1epvckZx9cTJ8ICUxTMTxGk+yvQ/Twacp3ruZSaMPGCriUjP86C37VhaT6nyRg==,
+        integrity: sha512-nZ6qahtLxC3PM54cWOQZHxt4lTCF/3J4LIoWWzz6v7A+rLs8Dx54anYQf7mH3eIi8KlNpgKci/ie8ZSqFN8O7A==,
       }
     engines: { node: ">=10" }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@swc/core-linux-s390x-gnu@1.15.43":
+  "@swc/core-linux-s390x-gnu@1.16.1":
     resolution:
       {
-        integrity: sha512-lXfLhs+LpBsD5inuYx+YDH5WsPPBQ95KPUiy8P5wq9ob9xKDZFqwNfU2QW6bGO8NqRO/H9JQomTSt5Yyh+FGfA==,
+        integrity: sha512-4ji5PNzhYq193Z4/4xUaSoNJza6iCkDJSzhetrbB6KOYxsr+kxtQr8ePWhMJUiMt6JUWtXaZ1PYT8FhtED+nGA==,
       }
     engines: { node: ">=10" }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@swc/core-linux-x64-gnu@1.15.43":
+  "@swc/core-linux-x64-gnu@1.16.1":
     resolution:
       {
-        integrity: sha512-07XnKwTmKy8TGOZG3D9fRnLWGynxPjwQnZLVmBFbo6F+7vHYzBIOuwXEhemrChBWb6yDNZsVCcMWCPX6FDD2xg==,
+        integrity: sha512-VJQxqrisHV+B394IgrOu8YsIIXZgffnf5tO+yc9Z/hoUpuZEvuQTjWwlnpZdpyD+0nx6LTD1/3k646JYm43yJA==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@swc/core-linux-x64-musl@1.15.43":
+  "@swc/core-linux-x64-musl@1.16.1":
     resolution:
       {
-        integrity: sha512-TJc+bsSIaBh+hZvZ5GRtW/K1bw66TJ9vsUwvVIsZdiWxU5ObLwZvfcnZ3UpgVfMnFibRes9uriJrQNBHEEogRQ==,
+        integrity: sha512-r9oV1mwxxsIGcLV1IQ/tw76MW3doatKze1QFWuC+a7QqJUkhY/bKTSVk6NpKKUGm2LDsE33Va8VqSClfA7vSiQ==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@swc/core-win32-arm64-msvc@1.15.43":
+  "@swc/core-win32-arm64-msvc@1.16.1":
     resolution:
       {
-        integrity: sha512-jfd7s2/bUQYkOHLs+LWQNKZdmDa8+sufKLllhpWAhVQ2GDCwsHe3vR/j+OSiItZNtkzFuaawa3+SAKz9y5gYfw==,
+        integrity: sha512-6huNRessoBLxWEqBm5zJXyCQ27TO7anvkdiuQ5MDO4CJni0nOXEqKtV9RllQ2TdyENKKsUMXVnIfW2hIXx/R5Q==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [win32]
 
-  "@swc/core-win32-ia32-msvc@1.15.43":
+  "@swc/core-win32-ia32-msvc@1.16.1":
     resolution:
       {
-        integrity: sha512-rLAE8JvucqEW1ZGohxPQrQWPBQeJG4+ypKbWfdlU/qmKScvCkxf9/Jxnzki1dkUQCQ7P5Enp13RlvqOlvx/32g==,
+        integrity: sha512-OVKJFUzphrGmsh+BGtcZDesx0YryV7/Yvy5XGgTqnrZfjnyfcr5uaqYQugCckdIlupc5Vs3XtDjRAj12z4ZPlw==,
       }
     engines: { node: ">=10" }
     cpu: [ia32]
     os: [win32]
 
-  "@swc/core-win32-x64-msvc@1.15.43":
+  "@swc/core-win32-x64-msvc@1.16.1":
     resolution:
       {
-        integrity: sha512-h8MLDHZcfIukwQWj03rIJZx1I0E81AYj2X7J/nGErG4nz+QAv6G1Z+peotvinL3lqpbo32tLYSMFo32/ySzxKg==,
+        integrity: sha512-Bt+VIhWYCGk4urklnkkteLUOeLv1VxigwTCeB/xC6rBZxY6IIKdDwCJf6on3E3SUGsIqmQS6QqtuJQc1VxF4Aw==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [win32]
 
-  "@swc/core@1.15.43":
+  "@swc/core@1.16.1":
     resolution:
       {
-        integrity: sha512-1CuKjFkPxIgGdeHVuNbkxmBxkcbdc08u0aiI43pFq6yY1tTVKmXT9hFEooyyKs/sJ3xf1GPHyEwTtk9Xl8dvQw==,
+        integrity: sha512-nUaeu91O5QZKrQdaDCHd402ogUIoNOOjpkZNq0UomWK0G6gDaGmLhvddF1/3BXf5O8aLyo6ZPY/aMDWvaJQ/hg==,
       }
     engines: { node: ">=10" }
     peerDependencies:
@@ -3622,131 +3648,131 @@ packages:
         integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==,
       }
 
-  "@swc/html-darwin-arm64@1.15.43":
+  "@swc/html-darwin-arm64@1.16.1":
     resolution:
       {
-        integrity: sha512-+PFbHbeeN+zB0zfvR1V1NmvPriuWPI+sijQXpI+wq/nLIujxvtENWjOKVHgouC9TIN/uKmL2zu9HAq6L6YxnPA==,
+        integrity: sha512-kFs0Rk9pMb/FiX7BaRhSKsw4J4VoBR0J/iO1h5WtegcXz5kuR3L2VHhde0zSJt6irZU+NgiAw5ULLJJo/+yDCQ==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [darwin]
 
-  "@swc/html-darwin-x64@1.15.43":
+  "@swc/html-darwin-x64@1.16.1":
     resolution:
       {
-        integrity: sha512-LQJ2U8Oxcx4T1rRF25y4h+/p05nn58FugTe/uGxC5OT3K83c2MftcSZLYaahOu4GVHRZeS1NI94CkSvQV++TVw==,
+        integrity: sha512-oItqtVJ2WnHVxI2TqcQJ/VM1LNHwJhhf0a2syioT0dhYiR6b6jidMFRmlgTTTSBxqxwiSHhAeDYyx7HHAn7b1g==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [darwin]
 
-  "@swc/html-linux-arm-gnueabihf@1.15.43":
+  "@swc/html-linux-arm-gnueabihf@1.16.1":
     resolution:
       {
-        integrity: sha512-DKIen6DuIRO7Xc5gAbgBT5QyRHJGEGXreIdM1VBosYWTGnnrQ//Hwd7bLD6UbT8X8eU1vqvpXwQ1E24QRqRaBQ==,
+        integrity: sha512-5+VAuNhby3fuciNmLe5R5ypZemE5Qq3DJUM0cp9JPb7oVJVM/KqXbxedhI70J5chqFSrfAR7/7OWDxxL8CBNvg==,
       }
     engines: { node: ">=10" }
     cpu: [arm]
     os: [linux]
 
-  "@swc/html-linux-arm64-gnu@1.15.43":
+  "@swc/html-linux-arm64-gnu@1.16.1":
     resolution:
       {
-        integrity: sha512-0AuHiyfcE86CZ/CajFIszLzZVzbM2wn5p01oet8Q9RikflCGwyH79Nv9TrAKD1Cx7juUrONzDk+f2b/x73wLTg==,
+        integrity: sha512-27mr1L1WR1bsC9t3NkK6JWK5TMIC9fbz0QlM1yzaqRwn9Hs7S48ZkJAk5TC0lNxsU/BLrEr4kMLaDAJ8aVkjig==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@swc/html-linux-arm64-musl@1.15.43":
+  "@swc/html-linux-arm64-musl@1.16.1":
     resolution:
       {
-        integrity: sha512-TweIdl/g9ugkoiYvcL/qbu+gbglDY3TqNxfXH84WXc4rSqEP20owVlxLya2NjVct8LIP2wDrtutpOwAXWC+Eew==,
+        integrity: sha512-jKLc+AiR64y8RdMpBbpccgmMfVvcPOhrgMyewCLgyB3qS0wXa107KLzdFSOFdsCJiOGdzuoHygImmptek7vgBg==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@swc/html-linux-ppc64-gnu@1.15.43":
+  "@swc/html-linux-ppc64-gnu@1.16.1":
     resolution:
       {
-        integrity: sha512-4oue1pB38/W6mbudp+w0q1jbwxuwdbdbaOj85ay0pisCs213WkgP+MPN8Zqa5VVPjQnVk2CTY9kmEc74XQI/sA==,
+        integrity: sha512-BGWhTWe8ef2Z76GE8MTxNpyDiHAqnjtQ2LFi4qb4XuoCoBSCxYC0+7kw72D/98+gSCvjWqGBFY9kz6QiSalS4g==,
       }
     engines: { node: ">=10" }
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  "@swc/html-linux-s390x-gnu@1.15.43":
+  "@swc/html-linux-s390x-gnu@1.16.1":
     resolution:
       {
-        integrity: sha512-/tceMNvAxK70SKUZtcn3X+K0vcElMGk3i8Sz0CmPdtooso8MZ7WfAvVP1qi3TWgh1rpQ3cC+Al3433AHlET6+w==,
+        integrity: sha512-8VYsjv33X1afDdXfVVV9m3lkvjAnMUNHWSSmqf9+LIXwg6GfNynf88U8w6MYS6809+9EtuBBxhePF3u9J0EaVw==,
       }
     engines: { node: ">=10" }
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  "@swc/html-linux-x64-gnu@1.15.43":
+  "@swc/html-linux-x64-gnu@1.16.1":
     resolution:
       {
-        integrity: sha512-YE7ltlTt5ZFl59GsoHTDrIHnCBY8EDBio66CVj4bqkElFXbE/28xmpVE5ksdGoI5c5aQ/8byUCfHxqzCzQQSVg==,
+        integrity: sha512-VUr08k9KncdAJGWO8dSNzY0JdZPKo1+7PjH/eNo5p1Fv9AwL4lzzh2uRvmYn9Ill2qfazPY+0Gse8BCWPL3KIw==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@swc/html-linux-x64-musl@1.15.43":
+  "@swc/html-linux-x64-musl@1.16.1":
     resolution:
       {
-        integrity: sha512-nS20HmbOk+dEEzdosJqqxAeyjMIiS5yrCAti8LUf0+dgr4eRmjkH4MlkjfPjf49aayR8o+eMJ1jsDZ7whx4zog==,
+        integrity: sha512-1i7cIhBoRlglaAOdOBv4rKH5N7MZygH4z7R5QloBuQVlQ/5lkL00yKU5ZdCa0tR5/ri6Q/JuR5PeuYNg63P67g==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@swc/html-win32-arm64-msvc@1.15.43":
+  "@swc/html-win32-arm64-msvc@1.16.1":
     resolution:
       {
-        integrity: sha512-Yz7aQQhXT/Yc6QcuMDQDZP9jqf2phkVyU+qSu8ZRWEcJgIorrPL6q7YLqMk+MB5PpZyu5XJEODvc1/UVDE1Kyg==,
+        integrity: sha512-zOKTv8W1y2ir5+uylfS/s0D64DxU0PtH0G1bjCxOKsQVDURwZmZ1Ehdyinv+CCM/kNDlgLJz2ssaynHiYlmQaQ==,
       }
     engines: { node: ">=10" }
     cpu: [arm64]
     os: [win32]
 
-  "@swc/html-win32-ia32-msvc@1.15.43":
+  "@swc/html-win32-ia32-msvc@1.16.1":
     resolution:
       {
-        integrity: sha512-muUgfsSQRZk6YBRuhaGKSLvXy0bV9BW6/mHLI0N/06btWuf0hekoHhIzR7dUmS98NXKCA7Hv+buBPE/0vXUwyA==,
+        integrity: sha512-A1o1FujsjwaJbi8riZt5nxsJI//95elt9O0ryt43zlyVKB/WdGdPu2fPS4jkDhQov9baqcQkHLv210aFl9rzbQ==,
       }
     engines: { node: ">=10" }
     cpu: [ia32]
     os: [win32]
 
-  "@swc/html-win32-x64-msvc@1.15.43":
+  "@swc/html-win32-x64-msvc@1.16.1":
     resolution:
       {
-        integrity: sha512-tuLDy4MxPXsLi6jW+ozCdFWO61AoMMnlhePWJxMafefC2Ojm+iILxP2zI2Hgfu6F16y1q7ITdXdpEuqptu5fHw==,
+        integrity: sha512-b14EbrfRC7Qmy1nGHEBk2qlsgoIQAtCV93a09ibHVZ5IH9JBy8o+tCcsn9KcLdhGmYM+nLP3zJ90czixPZGshg==,
       }
     engines: { node: ">=10" }
     cpu: [x64]
     os: [win32]
 
-  "@swc/html@1.15.43":
+  "@swc/html@1.16.1":
     resolution:
       {
-        integrity: sha512-SKbkbdGi9SDO9cTdV+6H0/AYifnb2nDOlz5BlWxlWMXACV3kmX6WwZDo0bBdyGlO/G4jCVWdR5r84qfotU2now==,
+        integrity: sha512-OYkogBdrxP4kziTlIrFoXgpGfjgoqVjoQKbPleHw4XEXrSgbHeQkkQXYOSZGLl6Q1d1JFsFHuL6Tars/IN9EWQ==,
       }
     engines: { node: ">=14" }
 
-  "@swc/types@0.1.27":
+  "@swc/types@0.1.28":
     resolution:
       {
-        integrity: sha512-K6h3iUlqeM946U4sXFYeahefR1YBbXJvko+hv8WS8/0BNJ4OHiHRywMnQUJCqkR7Y9+hqQ1TvEpiKqUhz7NEFg==,
+        integrity: sha512-V6Mnml8v09QALx6K0elJ7o9K/MkVDtW3t6L+7Ou/JcWtb3xwId2AH4FeOceySd2JaO87IMw4+6vSZxLm34LPbw==,
       }
 
   "@szmarczak/http-timer@5.0.1":
@@ -3756,101 +3782,101 @@ packages:
       }
     engines: { node: ">=14.16" }
 
-  "@tailwindcss/node@4.3.2":
+  "@tailwindcss/node@4.3.3":
     resolution:
       {
-        integrity: sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==,
+        integrity: sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==,
       }
 
-  "@tailwindcss/oxide-android-arm64@4.3.2":
+  "@tailwindcss/oxide-android-arm64@4.3.3":
     resolution:
       {
-        integrity: sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==,
+        integrity: sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==,
       }
     engines: { node: ">= 20" }
     cpu: [arm64]
     os: [android]
 
-  "@tailwindcss/oxide-darwin-arm64@4.3.2":
+  "@tailwindcss/oxide-darwin-arm64@4.3.3":
     resolution:
       {
-        integrity: sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==,
+        integrity: sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==,
       }
     engines: { node: ">= 20" }
     cpu: [arm64]
     os: [darwin]
 
-  "@tailwindcss/oxide-darwin-x64@4.3.2":
+  "@tailwindcss/oxide-darwin-x64@4.3.3":
     resolution:
       {
-        integrity: sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==,
+        integrity: sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==,
       }
     engines: { node: ">= 20" }
     cpu: [x64]
     os: [darwin]
 
-  "@tailwindcss/oxide-freebsd-x64@4.3.2":
+  "@tailwindcss/oxide-freebsd-x64@4.3.3":
     resolution:
       {
-        integrity: sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==,
+        integrity: sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==,
       }
     engines: { node: ">= 20" }
     cpu: [x64]
     os: [freebsd]
 
-  "@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2":
+  "@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3":
     resolution:
       {
-        integrity: sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==,
+        integrity: sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==,
       }
     engines: { node: ">= 20" }
     cpu: [arm]
     os: [linux]
 
-  "@tailwindcss/oxide-linux-arm64-gnu@4.3.2":
+  "@tailwindcss/oxide-linux-arm64-gnu@4.3.3":
     resolution:
       {
-        integrity: sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==,
+        integrity: sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==,
       }
     engines: { node: ">= 20" }
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  "@tailwindcss/oxide-linux-arm64-musl@4.3.2":
+  "@tailwindcss/oxide-linux-arm64-musl@4.3.3":
     resolution:
       {
-        integrity: sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==,
+        integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==,
       }
     engines: { node: ">= 20" }
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  "@tailwindcss/oxide-linux-x64-gnu@4.3.2":
+  "@tailwindcss/oxide-linux-x64-gnu@4.3.3":
     resolution:
       {
-        integrity: sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==,
+        integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==,
       }
     engines: { node: ">= 20" }
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  "@tailwindcss/oxide-linux-x64-musl@4.3.2":
+  "@tailwindcss/oxide-linux-x64-musl@4.3.3":
     resolution:
       {
-        integrity: sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==,
+        integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==,
       }
     engines: { node: ">= 20" }
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  "@tailwindcss/oxide-wasm32-wasi@4.3.2":
+  "@tailwindcss/oxide-wasm32-wasi@4.3.3":
     resolution:
       {
-        integrity: sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==,
+        integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==,
       }
     engines: { node: ">=14.0.0" }
     cpu: [wasm32]
@@ -3862,35 +3888,35 @@ packages:
       - "@emnapi/wasi-threads"
       - tslib
 
-  "@tailwindcss/oxide-win32-arm64-msvc@4.3.2":
+  "@tailwindcss/oxide-win32-arm64-msvc@4.3.3":
     resolution:
       {
-        integrity: sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==,
+        integrity: sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==,
       }
     engines: { node: ">= 20" }
     cpu: [arm64]
     os: [win32]
 
-  "@tailwindcss/oxide-win32-x64-msvc@4.3.2":
+  "@tailwindcss/oxide-win32-x64-msvc@4.3.3":
     resolution:
       {
-        integrity: sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==,
+        integrity: sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==,
       }
     engines: { node: ">= 20" }
     cpu: [x64]
     os: [win32]
 
-  "@tailwindcss/oxide@4.3.2":
+  "@tailwindcss/oxide@4.3.3":
     resolution:
       {
-        integrity: sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==,
+        integrity: sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==,
       }
     engines: { node: ">= 20" }
 
-  "@tailwindcss/vite@4.3.2":
+  "@tailwindcss/vite@4.3.3":
     resolution:
       {
-        integrity: sha512-eHpMeX4JXfVNJDEcsouTeCBubJBTcTLigeaw/NTUW6PB5ATKKXdyonnXgTBX2VuRbjz1hjfz6C5XAhr52ImQXA==,
+        integrity: sha512-yYU8cogLeSh/ms2jh8Fj7jaba/EWa7Ja6GoUqYZaraEuCI5YS6ms6ObZgjjedm+jm6XZjdNRWBpPP6Z86oOxcw==,
       }
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
@@ -3905,10 +3931,10 @@ packages:
       react: ">=16.8"
       react-dom: ">=16.8"
 
-  "@tanstack/react-virtual@3.14.5":
+  "@tanstack/react-virtual@3.14.10":
     resolution:
       {
-        integrity: sha512-4EKRXh7zBLkbKbFmG3AUVkircuHd+7OdT1pocJSepxtfBd3qnrJgJ5rtPkRYyo9fmyVb2+pI2xPy5oYvMLQy6A==,
+        integrity: sha512-SRyoUbdFMRHuYXMijV5H4ZarQWpXkj3iANq8OFre+pybeVap8ZJjZ3Nz9bVjx4d8PfobVUQUdKyyyHYk3E+djw==,
       }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -3921,10 +3947,10 @@ packages:
       }
     engines: { node: ">=12" }
 
-  "@tanstack/virtual-core@3.17.3":
+  "@tanstack/virtual-core@3.17.8":
     resolution:
       {
-        integrity: sha512-8Np/TFELpI0ySuJoVmjvOrQYXH/8sTX0Biv9szhFhY39xOdAAY+smrMxjxOum/ux3eM8MUJQsEJ0/R0UpvC8dw==,
+        integrity: sha512-BfEvehNpOT75r5Ksc5xW6NZuXujTfb7nlSEyVu4XHG3gdxNg1KqXruWbDewXOUaUYIo4oRbSfkjIajz4MAT8tA==,
       }
 
   "@trivago/prettier-plugin-sort-imports@6.0.2":
@@ -4075,10 +4101,10 @@ packages:
         integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==,
       }
 
-  "@types/d3-geo@3.1.0":
+  "@types/d3-geo@3.1.1":
     resolution:
       {
-        integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==,
+        integrity: sha512-65Emv9fQiQQqphLlRkuQ5ypPsOmWPhtBGCMv61JDPEPMvsx+gzhGf74yw1a78xFKPj6zw4AgQICJoQv0vK9M2w==,
       }
 
   "@types/d3-hierarchy@3.1.7":
@@ -4135,10 +4161,10 @@ packages:
         integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==,
       }
 
-  "@types/d3-shape@3.1.8":
+  "@types/d3-shape@3.2.0":
     resolution:
       {
-        integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==,
+        integrity: sha512-kVd74ta9eof3eJOvbNd1vGKS/XERRyQbT26Og63hIsvDO84cjD5gEOhsXf26w3FSoNlPVz84DOFcKv/oou+fMw==,
       }
 
   "@types/d3-time-format@4.0.3":
@@ -4223,12 +4249,6 @@ packages:
     resolution:
       {
         integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==,
-      }
-
-  "@types/gtag.js@0.0.20":
-    resolution:
-      {
-        integrity: sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==,
       }
 
   "@types/hast@3.0.5":
@@ -4321,10 +4341,10 @@ packages:
         integrity: sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==,
       }
 
-  "@types/node@26.1.1":
+  "@types/node@26.2.0":
     resolution:
       {
-        integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==,
+        integrity: sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==,
       }
 
   "@types/papaparse@5.5.2":
@@ -4351,10 +4371,10 @@ packages:
         integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==,
       }
 
-  "@types/react-dom@19.2.3":
+  "@types/react-dom@19.2.4":
     resolution:
       {
-        integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==,
+        integrity: sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==,
       }
     peerDependencies:
       "@types/react": ^19.2.0
@@ -4377,10 +4397,10 @@ packages:
         integrity: sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==,
       }
 
-  "@types/react@19.2.17":
+  "@types/react@19.2.18":
     resolution:
       {
-        integrity: sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==,
+        integrity: sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==,
       }
 
   "@types/retry@0.12.2":
@@ -4461,99 +4481,99 @@ packages:
         integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==,
       }
 
-  "@typescript-eslint/eslint-plugin@8.63.0":
+  "@typescript-eslint/eslint-plugin@8.67.0":
     resolution:
       {
-        integrity: sha512-rvwSgqT+DHpWdzfSzPatRLm02a0GlESt++9iy3hLCDY4BgkaLcl8LBi9Yh7XGFBpwcBE/K3024QuXWTpbz4FfQ==,
+        integrity: sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
-      "@typescript-eslint/parser": ^8.63.0
+      "@typescript-eslint/parser": ^8.67.0
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/parser@8.63.0":
+  "@typescript-eslint/parser@8.67.0":
     resolution:
       {
-        integrity: sha512-gwh4gvvlaVDKKxyfxMG+Gnu1u9X0OQBwyGLkbwB65dIzBKnxeRiJlNFqlI3zwVhNXJIs6qV7mlFCn/BIajlVig==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/project-service@8.63.0":
-    resolution:
-      {
-        integrity: sha512-e5dh0/UI0ok53AlZ5wRkXCB32z/f2jUZqPR/ygAw5WYaSw8j9EoJWlS7wQjr/dmOaqWjnPIn2m+HhVPCMWGZVQ==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/scope-manager@8.63.0":
-    resolution:
-      {
-        integrity: sha512-uUyfMWCnDSN8bCpcrY8nGP2BLkQ9Xn0GsipcONcpIDWhwhO4ZSyHvyS14U3X75mzxWxL3I2UZIrenTzdzcJO8A==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/tsconfig-utils@8.63.0":
-    resolution:
-      {
-        integrity: sha512-sUAbkulqBAsncKnbRP3+7CtQFRKicexnj7ZwNC6ddCR7EmrXvjvdCYMJbUIqMd6lwoEriZjwLo08aS5tSjVMHg==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-    peerDependencies:
-      typescript: ">=4.8.4 <6.1.0"
-
-  "@typescript-eslint/type-utils@8.63.0":
-    resolution:
-      {
-        integrity: sha512-Nzzh/OGxVCOjObjaj1CQF2RUasyYy2Jfuh+zZ3PjLzG2fYRriAiZLib9UKtO+CpQAS3YHiAS+ckZDclwqI1TPA==,
+        integrity: sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/types@8.63.0":
+  "@typescript-eslint/project-service@8.67.0":
     resolution:
       {
-        integrity: sha512-xyLtl9DUBBFrcJS4x2pIqGLH68/tC2uOa4Z7pUteW09D3bXnnXUom4dyPikzWgB7llmIc1zoeI3aoUdC4rPK/Q==,
-      }
-    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
-
-  "@typescript-eslint/typescript-estree@8.63.0":
-    resolution:
-      {
-        integrity: sha512-ygBkU+B7ex5UI/gKhaqexWev79uISfIv7XQCRNYO/jmD8rGLPyWLAb3KMRT6nd8Gt9bmUBi9+iX6tBdYfOY81Q==,
+        integrity: sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/utils@8.63.0":
+  "@typescript-eslint/scope-manager@8.67.0":
     resolution:
       {
-        integrity: sha512-fUKaeAvrTuQg/Tgt3nliAUSZHJM6DlCcfyEmxCvlX8kieWSStBX+5O5Fnidtc3i2JrH+9c/GL4RY2iasd/GPTA==,
+        integrity: sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@typescript-eslint/tsconfig-utils@8.67.0":
+    resolution:
+      {
+        integrity: sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/type-utils@8.67.0":
+    resolution:
+      {
+        integrity: sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: ">=4.8.4 <6.1.0"
 
-  "@typescript-eslint/visitor-keys@8.63.0":
+  "@typescript-eslint/types@8.67.0":
     resolution:
       {
-        integrity: sha512-UexrHGnGTpbuQHct2ExOc2ZcFbGUS9FOesCxxqdBGcpI1BxYu/LZ6U8Aq6/72XtF/qRBk9nhuGHFJIXXMhPMdw==,
+        integrity: sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
 
-  "@ungap/structured-clone@1.3.2":
+  "@typescript-eslint/typescript-estree@8.67.0":
     resolution:
       {
-        integrity: sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==,
+        integrity: sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/utils@8.67.0":
+    resolution:
+      {
+        integrity: sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: ">=4.8.4 <6.1.0"
+
+  "@typescript-eslint/visitor-keys@8.67.0":
+    resolution:
+      {
+        integrity: sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==,
+      }
+    engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
+
+  "@ungap/structured-clone@1.3.3":
+    resolution:
+      {
+        integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==,
       }
 
   "@upsetjs/venn.js@2.0.0":
@@ -4562,44 +4582,47 @@ packages:
         integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==,
       }
 
-  "@vitejs/plugin-react@6.0.3":
+  "@vitejs/plugin-react@6.1.0":
     resolution:
       {
-        integrity: sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg==,
+        integrity: sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     peerDependencies:
       "@rolldown/plugin-babel": ^0.1.7 || ^0.2.0
       babel-plugin-react-compiler: ^1.0.0
+      oxc-transform-react: ^0.145.0
       vite: ^8.0.0
     peerDependenciesMeta:
       "@rolldown/plugin-babel":
         optional: true
       babel-plugin-react-compiler:
         optional: true
+      oxc-transform-react:
+        optional: true
 
-  "@vitest/coverage-v8@4.1.10":
+  "@vitest/coverage-v8@4.1.11":
     resolution:
       {
-        integrity: sha512-IM49HmthevbgAO4anp1hwtoT9wYe59w0LR00gr+eagHE+ZJ5lK4sLPeO0ubgoJcwLk6dehU3R24N+FbEEKDc8g==,
+        integrity: sha512-8MVGEFnJIcdGjcbfKmeq8z0pZHH0JlVtoVZH9Q/qwUp6wyFnEJUBMrw9DCaj+ra3vShGmhavjalMIhPNxZAUcw==,
       }
     peerDependencies:
-      "@vitest/browser": 4.1.10
-      vitest: 4.1.10
+      "@vitest/browser": 4.1.11
+      vitest: 4.1.11
     peerDependenciesMeta:
       "@vitest/browser":
         optional: true
 
-  "@vitest/expect@4.1.10":
+  "@vitest/expect@4.1.11":
     resolution:
       {
-        integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==,
+        integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==,
       }
 
-  "@vitest/mocker@4.1.10":
+  "@vitest/mocker@4.1.11":
     resolution:
       {
-        integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==,
+        integrity: sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==,
       }
     peerDependencies:
       msw: ^2.4.9
@@ -4610,34 +4633,34 @@ packages:
       vite:
         optional: true
 
-  "@vitest/pretty-format@4.1.10":
+  "@vitest/pretty-format@4.1.11":
     resolution:
       {
-        integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==,
+        integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==,
       }
 
-  "@vitest/runner@4.1.10":
+  "@vitest/runner@4.1.11":
     resolution:
       {
-        integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==,
+        integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==,
       }
 
-  "@vitest/snapshot@4.1.10":
+  "@vitest/snapshot@4.1.11":
     resolution:
       {
-        integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==,
+        integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==,
       }
 
-  "@vitest/spy@4.1.10":
+  "@vitest/spy@4.1.11":
     resolution:
       {
-        integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==,
+        integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==,
       }
 
-  "@vitest/utils@4.1.10":
+  "@vitest/utils@4.1.11":
     resolution:
       {
-        integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==,
+        integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==,
       }
 
   "@volar/language-core@2.4.28":
@@ -4779,15 +4802,6 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
-  acorn-import-phases@1.0.4:
-    resolution:
-      {
-        integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==,
-      }
-    engines: { node: ">=10.13.0" }
-    peerDependencies:
-      acorn: ^8.14.0
-
   acorn-jsx@5.3.2:
     resolution:
       {
@@ -4803,20 +4817,20 @@ packages:
       }
     engines: { node: ">=0.4.0" }
 
-  acorn@8.17.0:
+  acorn@8.18.0:
     resolution:
       {
-        integrity: sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==,
+        integrity: sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==,
       }
     engines: { node: ">=0.4.0" }
     hasBin: true
 
-  address@1.2.2:
+  address@2.0.3:
     resolution:
       {
-        integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==,
+        integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==,
       }
-    engines: { node: ">= 10.0.0" }
+    engines: { node: ">= 16.0.0" }
 
   aggregate-error@3.1.0:
     resolution:
@@ -4892,18 +4906,18 @@ packages:
         integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==,
       }
 
-  algoliasearch-helper@3.29.2:
+  algoliasearch-helper@3.29.3:
     resolution:
       {
-        integrity: sha512-SaV+rZM3drExb0punEYYjT+sNcH74YFwN8ocjya7IDOyQvKWeQpEaSMVG3+IGTVos+feuatj7ljQ4BXlXdUp3w==,
+        integrity: sha512-gVOMbbPVrCO3Xs+B+BLAIGFqIQow6qHMTYCEeBqLQB9m4ZmKUqMwkEumlal2iyyezHEd4Y0FvFTLbCRutCutIQ==,
       }
     peerDependencies:
       algoliasearch: ">= 3.1 < 6"
 
-  algoliasearch@5.55.2:
+  algoliasearch@5.57.0:
     resolution:
       {
-        integrity: sha512-OyacJsaeuLUvGWOynNqYc6sx88XvyoG39wMT8SYqL3l9wwaorDW/LPRbUPfhzw0bWsUWzNCZTnFYOrWFBKsUaw==,
+        integrity: sha512-HpND7MBGctOAkd1GoQoDZCGoCpqNTS5NG1LuhElFet3RdLJkwnyTYZXZhXwtpAQPrI36fqQ3eT6KQrdKDTKu3A==,
       }
     engines: { node: ">= 14.0.0" }
 
@@ -4912,13 +4926,6 @@ packages:
       {
         integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==,
       }
-
-  ansi-escapes@7.3.0:
-    resolution:
-      {
-        integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==,
-      }
-    engines: { node: ">=18" }
 
   ansi-html-community@0.0.8:
     resolution:
@@ -4935,10 +4942,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  ansi-regex@6.2.2:
+  ansi-regex@6.3.0:
     resolution:
       {
-        integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==,
+        integrity: sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==,
       }
     engines: { node: ">=12" }
 
@@ -5015,10 +5022,10 @@ packages:
       }
     engines: { node: ">=12" }
 
-  ast-v8-to-istanbul@1.0.4:
+  ast-v8-to-istanbul@1.0.5:
     resolution:
       {
-        integrity: sha512-0bC0/4bTSrnwdhU3IsZDwEdojvuPrSg59OYZfKsLRtJZ0u8VBx9DebfqqG8bRdCC0I7vjgxmPi41P0lpkhJHtA==,
+        integrity: sha512-UPAgKJFSEGMWSDr3LX4tqnAb4f7KGT8O40Tyx8wbYmmZ/yn58lNCm8h3svs3eXgiGd5AXxz8NDOvXWvicq+rJA==,
       }
 
   astring@1.9.0:
@@ -5028,10 +5035,10 @@ packages:
       }
     hasBin: true
 
-  autoprefixer@10.5.2:
+  autoprefixer@10.5.4:
     resolution:
       {
-        integrity: sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==,
+        integrity: sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==,
       }
     engines: { node: ^10 || ^12 || >=14 }
     hasBin: true
@@ -5111,10 +5118,10 @@ packages:
         integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==,
       }
 
-  baseline-browser-mapping@2.10.42:
+  baseline-browser-mapping@2.11.17:
     resolution:
       {
-        integrity: sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==,
+        integrity: sha512-KAUDn1OSS0fmPlGO+NOUMRcOQ/b/shUBH3OgkG73mPgdf+JD/BQ6fHboGxNOxnUmlwcq+lLq3dTkayRPuSfXwg==,
       }
     engines: { node: ">=6.0.0" }
     hasBin: true
@@ -5157,10 +5164,10 @@ packages:
       }
     engines: { node: ">= 0.8", npm: 1.2.8000 || >= 1.4.16 }
 
-  bonjour-service@1.4.3:
+  bonjour-service@1.4.4:
     resolution:
       {
-        integrity: sha512-2Kd5UYlFUVgAKMTyuBLl6w49wqfOnbxHqmuH0oCl/n7TfAikR0zoowNOP5BU4dfXmm+Vr9JyEN370auSMx+CNg==,
+        integrity: sha512-jCZcVv7eoc4QesRscwEZtSROBen+6LpKAmBIsQYQrsAeVHLyMXWX/t6eIV5KiRZYNUBl8eVqImEEMQ8L5+c/Kw==,
       }
 
   boolbase@1.0.0:
@@ -5183,24 +5190,24 @@ packages:
       }
     engines: { node: ">=14.16" }
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     resolution:
       {
-        integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==,
+        integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==,
       }
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     resolution:
       {
-        integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==,
+        integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==,
       }
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     resolution:
       {
-        integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==,
+        integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==,
       }
-    engines: { node: 18 || 20 || >=22 }
+    engines: { node: 20 || >=22 }
 
   braces@3.0.3:
     resolution:
@@ -5209,10 +5216,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  browserslist@4.28.5:
+  browserslist@4.28.8:
     resolution:
       {
-        integrity: sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==,
+        integrity: sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==,
       }
     engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
     hasBin: true
@@ -5325,10 +5332,10 @@ packages:
         integrity: sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==,
       }
 
-  caniuse-lite@1.0.30001803:
+  caniuse-lite@1.0.30001809:
     resolution:
       {
-        integrity: sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==,
+        integrity: sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==,
       }
 
   canvas@3.2.3:
@@ -5463,26 +5470,12 @@ packages:
       }
     engines: { node: ">=10" }
 
-  cli-cursor@5.0.0:
-    resolution:
-      {
-        integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==,
-      }
-    engines: { node: ">=18" }
-
   cli-table3@0.6.5:
     resolution:
       {
         integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==,
       }
     engines: { node: 10.* || >= 12.* }
-
-  cli-truncate@5.2.0:
-    resolution:
-      {
-        integrity: sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==,
-      }
-    engines: { node: ">=20" }
 
   clone-deep@4.0.1:
     resolution:
@@ -5517,10 +5510,10 @@ packages:
         integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
       }
 
-  colord@2.9.3:
+  colord@2.10.0:
     resolution:
       {
-        integrity: sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==,
+        integrity: sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==,
       }
 
   colorette@2.0.20:
@@ -5703,16 +5696,17 @@ packages:
     peerDependencies:
       webpack: ^5.1.0
 
-  core-js-compat@3.49.0:
+  core-js-compat@3.50.0:
     resolution:
       {
-        integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==,
+        integrity: sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==,
       }
+    engines: { node: ">=6.4.0" }
 
-  core-js@3.49.0:
+  core-js@3.50.0:
     resolution:
       {
-        integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==,
+        integrity: sha512-BRWgOLKkFeCgRudR6zrs8p9XJZcE14grzKMMssoYrk6krtuEZ7MTKPIY5RzOnqsEKIR9kst7wNzphttraT+Yqw==,
       }
 
   core-util-is@1.0.3:
@@ -5878,10 +5872,10 @@ packages:
       }
     engines: { node: ">= 6" }
 
-  cssdb@8.9.0:
+  cssdb@8.10.0:
     resolution:
       {
-        integrity: sha512-J8jOU/hLjaXcO1LldOLraJSQpfLXRKof0I7mtbRyOy2AAXgqst0x9rlgi2qXeD6d0ou3ZLqcPAMqYVbpCbrxEw==,
+        integrity: sha512-+JWEEjjoqkPY7iGHps3SaCT2w67Zpaj9zHvhCJ2iPBavKHwgtOOD2YEbZSCU8VO2uVGpKdYjVz+j6bhkNSjZ0g==,
       }
 
   cssesc@3.0.0:
@@ -5957,10 +5951,10 @@ packages:
     peerDependencies:
       cytoscape: ^3.2.0
 
-  cytoscape@3.34.0:
+  cytoscape@3.34.1:
     resolution:
       {
-        integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==,
+        integrity: sha512-Lr0RvH9H75y9ar8h9Toy6u4lxRSCcxUq+hHcQ26sVWo6BnaQp1gwEZOYqwuYTZhyW7npyKnNLP8oJ2p1/3OZ7g==,
       }
     engines: { node: ">=0.10" }
 
@@ -6221,10 +6215,10 @@ packages:
       }
     engines: { node: ^20.19.0 || ^22.12.0 || >=24.0.0 }
 
-  dayjs@1.11.21:
+  dayjs@1.11.23:
     resolution:
       {
-        integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==,
+        integrity: sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==,
       }
 
   debounce@1.2.1:
@@ -6302,10 +6296,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  default-browser@5.5.0:
+  default-browser@5.5.1:
     resolution:
       {
-        integrity: sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==,
+        integrity: sha512-m1pAzaJgZ/gssEqlOhJkPJp8Xly7QyW6xcrkUa2KKcDeDSEMP7X8xipU3snUcfisTQx0w1AGae+9UtJSfVnXGw==,
       }
     engines: { node: ">=18" }
 
@@ -6391,12 +6385,12 @@ packages:
         integrity: sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==,
       }
 
-  detect-port@1.6.1:
+  detect-port@2.1.0:
     resolution:
       {
-        integrity: sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==,
+        integrity: sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==,
       }
-    engines: { node: ">= 4.0.0" }
+    engines: { node: ">= 16.0.0" }
     hasBin: true
 
   devlop@1.1.0:
@@ -6426,25 +6420,25 @@ packages:
       }
     engines: { node: ">=6" }
 
-  dockview-core@7.0.2:
+  dockview-core@7.0.4:
     resolution:
       {
-        integrity: sha512-i666ndkUdT4U+Bo2Yu3d6KwCJNqe21VJ0oschdgcXucZ5TquzBFX94zcUBEfg4IewTv2BuiPJ7r/2JTGLLv6ig==,
+        integrity: sha512-AiIzD6ov153L/VuhqVBg5KD5oSAgJGH7L1xvzV/X+ghIEOTFfEQYEBGNd/ys+ZjQfdGRogHSeQ0v9JF/L6JrPg==,
       }
 
-  dockview-react@7.0.2:
+  dockview-react@7.0.4:
     resolution:
       {
-        integrity: sha512-tnbRM1C/Ok1n/HXGMF0OWmc6Qlx5pbsSJucxX+3XcuNYkZgKiaNJX3BpdBlSxexjytTI/Xywh0ZNGF3/4Fa9LA==,
+        integrity: sha512-eUhR3J3prpuFcaPJwQ4rzcRAghO3p4JVXlj5zfdQTlb3Qwa8VUpy3KvyV6BCsIjNk1toTdd8/NyADcZXMvpmtA==,
       }
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  dockview@7.0.2:
+  dockview@7.0.4:
     resolution:
       {
-        integrity: sha512-QhgbJ7RTFsWvrs1lQZKPGCLTGjKU7kI5ZWX5lwU03arM9lIoQlbfv1b/uQ7V5zTkRw7JDndEqjKMgEFw2I8Kow==,
+        integrity: sha512-n6n9WpYZgp/WY8SgvP4hr9qh01ZXhSGIRmlhoJXxRU3f34bwxCbFyOhBArV4W8quolX8OQe1yPfAUwUUjdnZPA==,
       }
 
   docusaurus-plugin-typedoc@1.4.2:
@@ -6493,10 +6487,10 @@ packages:
       }
     engines: { node: ">= 4" }
 
-  dompurify@3.4.11:
+  dompurify@3.4.14:
     resolution:
       {
-        integrity: sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==,
+        integrity: sha512-dVoH9z+MY+C9IilgGCk3YfFqjLi3fChm2OiKJMzh6axrJ5qwxqWaZamgmHrpv22CN/KdbZJuGEGgfQoL00LTdg==,
       }
 
   domutils@2.8.0:
@@ -6549,16 +6543,10 @@ packages:
         integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==,
       }
 
-  electron-to-chromium@1.5.389:
+  electron-to-chromium@1.5.412:
     resolution:
       {
-        integrity: sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==,
-      }
-
-  emoji-regex@10.6.0:
-    resolution:
-      {
-        integrity: sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==,
+        integrity: sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==,
       }
 
   emoji-regex@8.0.0:
@@ -6605,17 +6593,10 @@ packages:
         integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==,
       }
 
-  enhanced-resolve@5.21.6:
+  enhanced-resolve@5.24.5:
     resolution:
       {
-        integrity: sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==,
-      }
-    engines: { node: ">=10.13.0" }
-
-  enhanced-resolve@5.24.2:
-    resolution:
-      {
-        integrity: sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==,
+        integrity: sha512-L1l8TNvomm6UVW5B253AGxQagSQr+vGwhMlrrfRS2qmhx46AMpMVJKQYLvWYbysTMY8VoicOvzHzoHMbyzB+4A==,
       }
     engines: { node: ">=10.13.0" }
 
@@ -6646,13 +6627,6 @@ packages:
       }
     engines: { node: ">=20.19.0" }
 
-  environment@1.1.0:
-    resolution:
-      {
-        integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==,
-      }
-    engines: { node: ">=18" }
-
   error-ex@1.3.4:
     resolution:
       {
@@ -6673,10 +6647,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  es-module-lexer@2.3.0:
+  es-module-lexer@2.3.2:
     resolution:
       {
-        integrity: sha512-KLdwQm2NvGLDkQDCGvmiQrhkd0JbMzXthwQAUgWjQuQdBLFa3eiBP5arXZyA+f8x+x7OXgud6bq2rxjGtHV2tw==,
+        integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==,
       }
 
   es-object-atoms@1.1.2:
@@ -6686,10 +6660,10 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  es-toolkit@1.49.0:
+  es-toolkit@1.51.0:
     resolution:
       {
-        integrity: sha512-G5iZ6Pc/FNRY/soKZHC+TxGDD83rHUDXxzaWhGCX44vAv/tMs56WMusnm/KMNK+luUPsgA9U28cGr4RDlSzL2g==,
+        integrity: sha512-zC2lQGkM7QX+Gm6iM3+WIdZJzthsEd14LvRNJneSO2hzyz/zNBENR8+YXWo1cKxgPBtV6ksPYHELbcwBRzmdCw==,
       }
 
   esast-util-from-estree@2.0.0:
@@ -6756,10 +6730,10 @@ packages:
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
-  eslint-plugin-react-refresh@0.5.3:
+  eslint-plugin-react-refresh@0.5.4:
     resolution:
       {
-        integrity: sha512-5EMmLCV98Pi4o/f/3DP/v/tNqLHMIc9I8LKClNDWhZ9JTho89/kQcitCXQBMG7sAfVRK0Ie3T2EDOzp1YXYiVA==,
+        integrity: sha512-7bqTKz7T0r+HKWFarNXByDE9/5+73wI2ru+M3zuqGbR7s/b/5/pQJXZoufWlrngqGqoZto73ZkGumCdLxk+4rw==,
       }
     peerDependencies:
       eslint: ^9 || ^10
@@ -6792,10 +6766,10 @@ packages:
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
 
-  eslint@10.6.0:
+  eslint@10.9.0:
     resolution:
       {
-        integrity: sha512-6lVbcqSodALYo+4ELD0heG6lFiFxnLMuLkiMi2qV8LMp54N8tE8FT1GMH+ev4Ti00nFjNze2+Su6DsV5OQW3Dg==,
+        integrity: sha512-5KeEOJZBfEVA47boFiBsf+6MmmJpffM7qEBg4pLla2e4nlKgdKlqCW0oSLOGsT8Wl5uCGJptLV1bkaiShj90Gw==,
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
     hasBin: true
@@ -6811,14 +6785,6 @@ packages:
         integrity: sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==,
       }
     engines: { node: ^20.19.0 || ^22.13.0 || >=24 }
-
-  esprima@4.0.1:
-    resolution:
-      {
-        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
-      }
-    engines: { node: ">=4" }
-    hasBin: true
 
   esquery@1.7.0:
     resolution:
@@ -6936,12 +6902,6 @@ packages:
         integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==,
       }
 
-  eventemitter3@5.0.4:
-    resolution:
-      {
-        integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==,
-      }
-
   events@3.3.0:
     resolution:
       {
@@ -6977,10 +6937,10 @@ packages:
       }
     engines: { node: ">= 0.10.0" }
 
-  exsolve@1.1.0:
+  exsolve@1.1.1:
     resolution:
       {
-        integrity: sha512-D+42+T12DdIlJM3uepa55qGiL3sYdLBOxIl2ifQCzCHz4c7eiolaHsi3BIqEr7JxBzxv2pYZQX9kw16ziMcEmw==,
+        integrity: sha512-9U/jZUgjnSGyntRr6y5Muu1MJcwFl6kPu7k8qLF0IMNfLqvw0NZ4nnVDq0RVoZ0RvCyumib4Ez3KYrVfilrw+g==,
       }
 
   extend-shallow@2.0.1:
@@ -7028,10 +6988,16 @@ packages:
         integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==,
       }
 
-  fast-uri@3.1.3:
+  fast-uri@3.1.5:
     resolution:
       {
-        integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==,
+        integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==,
+      }
+
+  fastdom@1.0.12:
+    resolution:
+      {
+        integrity: sha512-LB+xjSTEbjHE1cWsxu+tN2Xqr1kpi+V9aADI7sVM5ZMaXyYGPHULQMzpJMYqOTULK/73pUkWVzzObFRBkPr+hg==,
       }
 
   fastq@1.20.1:
@@ -7143,10 +7109,10 @@ packages:
       }
     hasBin: true
 
-  flatted@3.4.2:
+  flatted@3.4.4:
     resolution:
       {
-        integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==,
+        integrity: sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==,
       }
 
   follow-redirects@1.16.0:
@@ -7208,6 +7174,13 @@ packages:
       }
     engines: { node: ">=14.14" }
 
+  fs-extra@11.4.0:
+    resolution:
+      {
+        integrity: sha512-EQsFzMUJkCKGr1ePqlYADkIUmHW1s3ZXr5Yqy6wbGrfUCphpl2maM/kyOIRA2HpP3AaFQTZXD4ldjek+nccddA==,
+      }
+    engines: { node: ">=14.14" }
+
   fsevents@2.3.3:
     resolution:
       {
@@ -7234,20 +7207,6 @@ packages:
         integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
       }
     engines: { node: ">=6.9.0" }
-
-  geojson@0.5.0:
-    resolution:
-      {
-        integrity: sha512-/Bx5lEn+qRF4TfQ5aLu6NH+UKtvIv7Lhc487y/c8BdludrCTpiWf9wyI0RTyqg49MFefIAvFDuEi5Dfd/zgNxQ==,
-      }
-    engines: { node: ">= 0.10" }
-
-  get-east-asian-width@1.6.0:
-    resolution:
-      {
-        integrity: sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==,
-      }
-    engines: { node: ">=18" }
 
   get-intrinsic@1.3.0:
     resolution:
@@ -7324,10 +7283,10 @@ packages:
       }
     engines: { node: ">=10" }
 
-  globals@17.7.0:
+  globals@17.11.0:
     resolution:
       {
-        integrity: sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg==,
+        integrity: sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==,
       }
     engines: { node: ">=18" }
 
@@ -7370,13 +7329,6 @@ packages:
       {
         integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==,
       }
-
-  gray-matter@4.0.3:
-    resolution:
-      {
-        integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==,
-      }
-    engines: { node: ">=6.0" }
 
   gzip-size@6.0.0:
     resolution:
@@ -7558,14 +7510,14 @@ packages:
         integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==,
       }
 
-  html-webpack-plugin@5.6.7:
+  html-webpack-plugin@5.6.8:
     resolution:
       {
-        integrity: sha512-md+vXtdCAe60s1k6AU3dUyMJnDxUyQAwfwPKoLisvgUF1IXjtlLsk2se54+qfL9Mdm26bbwvjJybpNx48NKRLw==,
+        integrity: sha512-MZmKQcTnhEh1SPSyMiEytIeDZDUoBZVorNHivQGXMASHf/BSGGOrKa2xQ5bGx3TCe1n109ecCt+cpww7wwWhKA==,
       }
     engines: { node: ">=10.13.0" }
     peerDependencies:
-      "@rspack/core": 0.x || 1.x
+      "@rspack/core": 0.x || 1.x || 2.x
       webpack: ^5.20.0
     peerDependenciesMeta:
       "@rspack/core":
@@ -7664,10 +7616,10 @@ packages:
         integrity: sha512-yx7aA3Rhj0YycbdV71+XznQSLAefa4cT0urpgNXy4aM6eSeCknaVDNne8y45Uz74Fb15yyXUzOStlceOJBan7A==,
       }
 
-  hyparquet@1.26.2:
+  hyparquet@1.29.1:
     resolution:
       {
-        integrity: sha512-6qjyK7R2tZ4vnYP1J8NpcCeDPK1UIYk3xh5XgtQUnUM1iwkYbvI6Mz3xtmpMd6AfCCeoUoJVbEq29k5GReZRWA==,
+        integrity: sha512-Wa57A2KxGFtRTeDTJp4pT0TaqN8btb7/XTrMs17iM+xJxsbBxRyzaGaRRPQ4lOPbmso/qohDafJD7b+cFMZq8A==,
       }
 
   hyperdyperid@1.2.0:
@@ -7719,10 +7671,10 @@ packages:
       }
     engines: { node: ">= 4" }
 
-  ignore@7.0.5:
+  ignore@7.0.6:
     resolution:
       {
-        integrity: sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==,
+        integrity: sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==,
       }
     engines: { node: ">= 4" }
 
@@ -7734,10 +7686,10 @@ packages:
     engines: { node: ">=16.x" }
     hasBin: true
 
-  immer@11.1.11:
+  immer@11.1.18:
     resolution:
       {
-        integrity: sha512-qzXuyXAkPySAGYkfsAwodDPWT8Zm7/Uo5BNt4BjhMhG5WlWyZZ4wQqnWwdS8kjlQ1Cwu6gjw3A6+0gTQwlyYtw==,
+        integrity: sha512-EQyQtLiYW029lyoczMl/Hh4Xu7cDecSc58JRYpHyL4tIAu3eqd1yJzQX04d2BZHDkzFFvm6qJEJWOtfDSWAXbQ==,
       }
 
   import-fresh@3.3.1:
@@ -7832,10 +7784,10 @@ packages:
       }
     engines: { node: ">= 0.10" }
 
-  ipaddr.js@2.4.0:
+  ipaddr.js@2.5.0:
     resolution:
       {
-        integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==,
+        integrity: sha512-aq+t5NAc+cS6rZQQVWC2x98CPqGtKKTMDd4Gaodv0wShnItdKg/51djkGJ1hqH+Oy0ivDftCbSLCQob8zso01w==,
       }
     engines: { node: ">= 10" }
 
@@ -7920,13 +7872,6 @@ packages:
         integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
       }
     engines: { node: ">=8" }
-
-  is-fullwidth-code-point@5.1.0:
-    resolution:
-      {
-        integrity: sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==,
-      }
-    engines: { node: ">=18" }
 
   is-glob@4.0.3:
     resolution:
@@ -8159,10 +8104,10 @@ packages:
         integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==,
       }
 
-  joi@17.13.4:
+  joi@17.13.6:
     resolution:
       {
-        integrity: sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==,
+        integrity: sha512-ImNZaq/LSysofih+xIGYfR0WUXMA9GLUNB//YTCSrZptoRmVgaNAdJyi6K1kXi9pkLEoSkoI8I4UwtNiu/D7nw==,
       }
 
   js-tokens@10.0.0:
@@ -8177,17 +8122,10 @@ packages:
         integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
       }
 
-  js-yaml@3.15.0:
+  js-yaml@4.3.1:
     resolution:
       {
-        integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==,
-      }
-    hasBin: true
-
-  js-yaml@4.3.0:
-    resolution:
-      {
-        integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==,
+        integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==,
       }
     hasBin: true
 
@@ -8342,10 +8280,28 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  lightningcss-android-arm64@1.33.0:
+    resolution:
+      {
+        integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.32.0:
     resolution:
       {
         integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution:
+      {
+        integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==,
       }
     engines: { node: ">= 12.0.0" }
     cpu: [arm64]
@@ -8360,10 +8316,28 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.33.0:
+    resolution:
+      {
+        integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.32.0:
     resolution:
       {
         integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution:
+      {
+        integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==,
       }
     engines: { node: ">= 12.0.0" }
     cpu: [x64]
@@ -8378,10 +8352,29 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution:
+      {
+        integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution:
       {
         integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution:
+      {
+        integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==,
       }
     engines: { node: ">= 12.0.0" }
     cpu: [arm64]
@@ -8398,10 +8391,30 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution:
+      {
+        integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-linux-x64-gnu@1.32.0:
     resolution:
       {
         integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution:
+      {
+        integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==,
       }
     engines: { node: ">= 12.0.0" }
     cpu: [x64]
@@ -8418,10 +8431,29 @@ packages:
     os: [linux]
     libc: [musl]
 
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution:
+      {
+        integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution:
       {
         integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution:
+      {
+        integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==,
       }
     engines: { node: ">= 12.0.0" }
     cpu: [arm64]
@@ -8436,10 +8468,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution:
+      {
+        integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==,
+      }
+    engines: { node: ">= 12.0.0" }
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.32.0:
     resolution:
       {
         integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==,
+      }
+    engines: { node: ">= 12.0.0" }
+
+  lightningcss@1.33.0:
+    resolution:
+      {
+        integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==,
       }
     engines: { node: ">= 12.0.0" }
 
@@ -8462,27 +8510,13 @@ packages:
         integrity: sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==,
       }
 
-  lint-staged@17.0.8:
+  lint-staged@17.3.0:
     resolution:
       {
-        integrity: sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==,
+        integrity: sha512-woZS3vNe3UKqBaLPvbLOtKRY4tLANpWQhom12MGWqC8Mh1lCOO+WgSwmX2amjJAqTY9BkXYW87fCUH5H9Ph6xw==,
       }
     engines: { node: ">=22.22.1" }
     hasBin: true
-
-  listr2@10.2.2:
-    resolution:
-      {
-        integrity: sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==,
-      }
-    engines: { node: ">=22.13.0" }
-
-  loader-runner@4.3.2:
-    resolution:
-      {
-        integrity: sha512-DFEqQ3ihfS9blba08cLfYf1NRAIEm+dDjic073DRDc3/JspI/8wYmtDsHwd3+4hwvdxSK7PGaElfTmm0awWJ4w==,
-      }
-    engines: { node: ">=6.11.5" }
 
   loader-utils@2.0.4:
     resolution:
@@ -8542,13 +8576,6 @@ packages:
         integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==,
       }
 
-  log-update@6.1.0:
-    resolution:
-      {
-        integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==,
-      }
-    engines: { node: ">=18" }
-
   longest-streak@3.1.0:
     resolution:
       {
@@ -8588,10 +8615,10 @@ packages:
         integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
       }
 
-  lucide-react@1.24.0:
+  lucide-react@1.33.0:
     resolution:
       {
-        integrity: sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==,
+        integrity: sha512-MTRwMy0ZlL8Ur/vOAiJ9XGHE+kFPC7brq6MxAm0GiGXEBj0qy0jA/pG4N675oSzciO/UCdX8T+5yUQdmDeTLxg==,
       }
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -8608,10 +8635,10 @@ packages:
         integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==,
       }
 
-  magicast@0.5.3:
+  magicast@0.5.4:
     resolution:
       {
-        integrity: sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==,
+        integrity: sha512-llBEhWm1SacoRwgHUoQJYtwp4PBLF4faQi5TCpIGyGs9n4y5+juI0tDgyKIfpqxckRHaHzouUEph3THklWh03w==,
       }
 
   make-dir@4.0.0:
@@ -8782,10 +8809,10 @@ packages:
         integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==,
       }
 
-  mdurl@2.0.0:
+  mdurl@2.1.0:
     resolution:
       {
-        integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==,
+        integrity: sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==,
       }
 
   media-typer@0.3.0:
@@ -8795,13 +8822,11 @@ packages:
       }
     engines: { node: ">= 0.6" }
 
-  memfs@4.64.0:
+  memfs@4.68.1:
     resolution:
       {
-        integrity: sha512-Kw72fgY7Wn+sD8KmtNWSafl1dz0UvAsE/PHs3YVfLiaZuA3HxNm9sRLqAu0ATiBGJvME1PxZXbBZPv5GycDeAw==,
+        integrity: sha512-OD+IDRUvIxu3QHL+nFm9gdyugInD27FDJ+sl4B5QgomPHXMlbw+GP918P8VNKu2FkNlVeqBkpzkwROpamVifRw==,
       }
-    peerDependencies:
-      tslib: "2"
 
   merge-descriptors@1.0.3:
     resolution:
@@ -8822,10 +8847,10 @@ packages:
       }
     engines: { node: ">= 8" }
 
-  mermaid@11.16.0:
+  mermaid@11.17.0:
     resolution:
       {
-        integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==,
+        integrity: sha512-Jo9N377Wb4MSnHFPTbLi2SxFpsQl4eVHoxnW5U1Md9EazvgMp3s+4ohDxr81YNTgbn5Kj7HJ3yslrSJ52kwpbA==,
       }
 
   methods@1.1.2:
@@ -9145,13 +9170,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  mimic-function@5.0.1:
-    resolution:
-      {
-        integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==,
-      }
-    engines: { node: ">=18" }
-
   mimic-response@3.1.0:
     resolution:
       {
@@ -9188,10 +9206,10 @@ packages:
       }
     engines: { node: 18 || 20 || >=22 }
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     resolution:
       {
-        integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==,
+        integrity: sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==,
       }
     engines: { node: 18 || 20 || >=22 }
 
@@ -9298,10 +9316,10 @@ packages:
       }
     hasBin: true
 
-  nanoid@3.3.15:
+  nanoid@3.3.18:
     resolution:
       {
-        integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==,
+        integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==,
       }
     engines: { node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1 }
     hasBin: true
@@ -9364,10 +9382,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  node-releases@2.0.51:
+  node-releases@2.0.53:
     resolution:
       {
-        integrity: sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==,
+        integrity: sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==,
       }
     engines: { node: ">=18" }
 
@@ -9453,10 +9471,10 @@ packages:
         integrity: sha512-PX1wu0AmAdPqOL1mWhqmlOd8kOIZQwGZw6rh7uby9fTc5lhaOWFLX3I6R1hrF9k3zUY40e6igsLGkDXK92LJNg==,
       }
 
-  obug@2.1.3:
+  obug@2.1.4:
     resolution:
       {
-        integrity: sha512-9miFgM2OFba7hB+pRgvtV84pYTBaoTHohvmIgiRt6dRIzbwEOIaNaP+dIlGs2fNFoB0SeISs0Jz5WFVRid6Xyg==,
+        integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==,
       }
     engines: { node: ">=12.20.0" }
 
@@ -9502,13 +9520,6 @@ packages:
       }
     engines: { node: ">=6" }
 
-  onetime@7.0.0:
-    resolution:
-      {
-        integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==,
-      }
-    engines: { node: ">=18" }
-
   open@10.2.0:
     resolution:
       {
@@ -9530,10 +9541,10 @@ packages:
       }
     hasBin: true
 
-  openseadragon@6.0.2:
+  openseadragon@6.1.0:
     resolution:
       {
-        integrity: sha512-WNPPQWp9sHunyzkV9J2yhfxnSfDF9CfBsE6unmkdxh1uTWzFcueMvBPhmuZdY7M1v/ffJ3NdaF3Qq3jogphIbA==,
+        integrity: sha512-S2kEBO6zd2pbUByMVZ6PkEldvXHbB2kemL3tAhSltnHyjpArJPgXeM/AH/g8qsoXHy9pMHzx63XyJftE556MbA==,
       }
 
   optionator@0.9.4:
@@ -9620,16 +9631,16 @@ packages:
       }
     engines: { node: ">=14.16" }
 
-  package-manager-detector@1.7.0:
+  package-manager-detector@1.8.0:
     resolution:
       {
-        integrity: sha512-xg1eHpwYL/D/HEdWw2goFZP6vV0FH7W+PZ5rFkGjdIDLtxq7EkzBUeT3m+lndYCt8wKbmofUu1MUdMCXkCk9ZQ==,
+        integrity: sha512-yQA4H19AmPEoMUeavPMDIe1higySl/gH/yaQrkT/s07Qp+7pp2hYz30N3z2l5BkjVkF9Ow6o0wjJamm2y7Sn0A==,
       }
 
-  papaparse@5.5.4:
+  papaparse@5.6.0:
     resolution:
       {
-        integrity: sha512-SwzWD9gl/ElwYLCI0nUja1mFJzjq2D8ziShfNBa7zCHzkOozeOGDwHWQ+tvCzEZcewecWZ5U7kUopDnG+DFYEQ==,
+        integrity: sha512-N2vuNQAYGK1/4vs6HJX86+VYU6OkiSTgdJz3JQfTk1y51cFCO/U8gnaeTF4iNE4r57Tt0sV47dUua1/19pxO6Q==,
       }
 
   param-case@3.0.4:
@@ -10377,10 +10388,10 @@ packages:
       }
     engines: { node: ">=4" }
 
-  postcss-selector-parser@7.1.4:
+  postcss-selector-parser@7.1.5:
     resolution:
       {
-        integrity: sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==,
+        integrity: sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==,
       }
     engines: { node: ">=4" }
 
@@ -10426,10 +10437,10 @@ packages:
     peerDependencies:
       postcss: ^8.4.31
 
-  postcss@8.5.16:
+  postcss@8.5.26:
     resolution:
       {
-        integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==,
+        integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==,
       }
     engines: { node: ^10 || ^12 || >=14 }
 
@@ -10449,10 +10460,10 @@ packages:
       }
     engines: { node: ">= 0.8.0" }
 
-  prettier@3.9.4:
+  prettier@3.9.6:
     resolution:
       {
-        integrity: sha512-yWG/o/4oJfo036EKAfK6ACAoDOfHeRHx4tuxkfBZiauURiaSmYwlpOr5LQqKtIkRD2z1PLteme2WoxEnj4tHTg==,
+        integrity: sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==,
       }
     engines: { node: ">=14" }
     hasBin: true
@@ -10556,10 +10567,10 @@ packages:
         integrity: sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg==,
       }
 
-  pvutils@1.1.5:
+  pvutils@1.2.0:
     resolution:
       {
-        integrity: sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA==,
+        integrity: sha512-BbubeCEyTuQjVMakvJQ/Sxbc93F2pwmbsxONT/ZRrwU7Ua38d8unYTwXpTVLAKJ4BDuH9IGztCjQcd/N/39Dvg==,
       }
     engines: { node: ">=16.0.0" }
 
@@ -10630,22 +10641,22 @@ packages:
       }
     hasBin: true
 
-  react-colorful@5.7.0:
+  react-colorful@5.8.0:
     resolution:
       {
-        integrity: sha512-fuesYIemttah97XmsIHmz4OORDHiSFzyc9HMAIrCHJou2jaRQmL8cFJ76K4zQhhj8jzwOBlOi4BaGTjjOZCfTg==,
+        integrity: sha512-Wy9OzPfjSN9bF12OB8N7UQvlsZ0I+7wHxpN+bV5BjNQGxOj6IiwkRjevJK9yOBjJWGQvAaf1OXtn8rUeEatAng==,
       }
     peerDependencies:
       react: ">=16.8.0"
       react-dom: ">=16.8.0"
 
-  react-dom@19.2.7:
+  react-dom@19.2.8:
     resolution:
       {
-        integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==,
+        integrity: sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==,
       }
     peerDependencies:
-      react: ^19.2.7
+      react: ^19.2.8
 
   react-fast-compare@3.2.2:
     resolution:
@@ -10703,10 +10714,10 @@ packages:
     peerDependencies:
       react: ">=15"
 
-  react@19.2.7:
+  react@19.2.8:
     resolution:
       {
-        integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==,
+        integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==,
       }
     engines: { node: ">=0.10.0" }
 
@@ -10948,13 +10959,6 @@ packages:
       }
     engines: { node: ">=14.16" }
 
-  restore-cursor@5.1.0:
-    resolution:
-      {
-        integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==,
-      }
-    engines: { node: ">=18" }
-
   retry@0.13.1:
     resolution:
       {
@@ -10969,22 +10973,16 @@ packages:
       }
     engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
 
-  rfdc@1.4.1:
-    resolution:
-      {
-        integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==,
-      }
-
   robust-predicates@3.0.3:
     resolution:
       {
         integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==,
       }
 
-  rolldown@1.1.5:
+  rolldown@1.2.5:
     resolution:
       {
-        integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==,
+        integrity: sha512-VD2IE5PUG4Oj8zz2VGykiYd5wbnjdIiSsNQb8Qu5B+noEp+A78mu2iVvpp27g8es14Tk9rofNs5Tku9iQCS4fA==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
@@ -11040,10 +11038,10 @@ packages:
         integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
       }
 
-  sax@1.6.0:
+  sax@1.6.1:
     resolution:
       {
-        integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==,
+        integrity: sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==,
       }
     engines: { node: ">=11.0.0" }
 
@@ -11209,10 +11207,10 @@ packages:
       }
     engines: { node: ">=8" }
 
-  shell-quote@1.9.0:
+  shell-quote@1.10.0:
     resolution:
       {
-        integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==,
+        integrity: sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==,
       }
     engines: { node: ">= 0.4" }
 
@@ -11255,13 +11253,6 @@ packages:
       {
         integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==,
       }
-
-  signal-exit@4.1.0:
-    resolution:
-      {
-        integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==,
-      }
-    engines: { node: ">=14" }
 
   simple-concat@1.0.1:
     resolution:
@@ -11316,20 +11307,6 @@ packages:
         integrity: sha512-3dOsAHXXUkQTpOYcoAxLIorMTp4gIQr5IW3iVb7A7lFIp0VHhnynm9izx6TssdrIcVIESAlVjtnO2K8bg+Coew==,
       }
     engines: { node: ">=12" }
-
-  slice-ansi@7.1.2:
-    resolution:
-      {
-        integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==,
-      }
-    engines: { node: ">=18" }
-
-  slice-ansi@8.0.0:
-    resolution:
-      {
-        integrity: sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==,
-      }
-    engines: { node: ">=20" }
 
   snake-case@3.0.4:
     resolution:
@@ -11441,6 +11418,12 @@ packages:
         integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==,
       }
 
+  strictdom@1.0.1:
+    resolution:
+      {
+        integrity: sha512-cEmp9QeXXRmjj/rVp9oyiqcvyocWab/HaoN4+bwFeZ7QzykJD6L3yD4v12K1x0tHpqRqVpJevN3gW7kyM39Bqg==,
+      }
+
   string-argv@0.3.2:
     resolution:
       {
@@ -11461,20 +11444,6 @@ packages:
         integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==,
       }
     engines: { node: ">=12" }
-
-  string-width@7.2.0:
-    resolution:
-      {
-        integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==,
-      }
-    engines: { node: ">=18" }
-
-  string-width@8.2.2:
-    resolution:
-      {
-        integrity: sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==,
-      }
-    engines: { node: ">=20" }
 
   string_decoder@1.1.1:
     resolution:
@@ -11591,16 +11560,17 @@ packages:
       }
     engines: { node: ">= 0.4" }
 
-  svg-parser@2.0.4:
+  svg-parser@2.0.5:
     resolution:
       {
-        integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==,
+        integrity: sha512-FuT74puvVMJQ8sgFxgOKPex5MbxPeltqCXJV3wR9Xq+vPHaF+tTdE1lhJcwspUxjtjvXy1NwqcSLZx9UNwHawg==,
       }
+    engines: { node: ">=8" }
 
-  svgo@3.3.3:
+  svgo@3.3.4:
     resolution:
       {
-        integrity: sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==,
+        integrity: sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==,
       }
     engines: { node: ">=14.0.0" }
     hasBin: true
@@ -11626,10 +11596,10 @@ packages:
         integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==,
       }
 
-  tailwindcss@4.3.2:
+  tailwindcss@4.3.3:
     resolution:
       {
-        integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==,
+        integrity: sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==,
       }
 
   tapable@2.3.3:
@@ -11698,18 +11668,18 @@ packages:
       uglify-js:
         optional: true
 
-  terser@5.49.0:
+  terser@5.50.0:
     resolution:
       {
-        integrity: sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==,
+        integrity: sha512-CN9BVxWhgS/hRxtUMjtC2uRWSTcSfQFHMDWma6sKKfIivCD91sM+FOPfvwoaRMqCSrUpe1nv3jDamd9eEQ4y+w==,
       }
     engines: { node: ">=10" }
     hasBin: true
 
-  thingies@2.6.0:
+  thingies@2.6.1:
     resolution:
       {
-        integrity: sha512-rMHRjmlFLM1R96UYPvpmnc3LYtdFrT33JIB7L9hetGue1qAPfn1N2LJeEjxUSidu1Iku+haLZXDuEXUHNGO/lg==,
+        integrity: sha512-cV/CMGTK3M4MlnJ/0At6ismOw/A0EEniDNScajjz/Br3c1sqE72YD01rGpPTKwd27wAxI5Pr+6+0w8yofzFRYw==,
       }
     engines: { node: ">=10.18" }
     peerDependencies:
@@ -11739,10 +11709,10 @@ packages:
         integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==,
       }
 
-  tinyexec@1.2.4:
+  tinyexec@1.3.0:
     resolution:
       {
-        integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==,
+        integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==,
       }
     engines: { node: ">=18" }
 
@@ -11760,23 +11730,23 @@ packages:
       }
     engines: { node: ^18.0.0 || >=20.0.0 }
 
-  tinyrainbow@3.1.0:
+  tinyrainbow@3.1.1:
     resolution:
       {
-        integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==,
+        integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==,
       }
     engines: { node: ">=14.0.0" }
 
-  tldts-core@7.4.7:
+  tldts-core@7.4.10:
     resolution:
       {
-        integrity: sha512-rNlAI8fKn/JckBMUSbNL/ES2kmDiurWaE49l+ikwEc9A6lFR7gMx9AhgQMQKBK4H5w4pKLH64JzZfB99uRsGNQ==,
+        integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==,
       }
 
-  tldts@7.4.7:
+  tldts@7.4.10:
     resolution:
       {
-        integrity: sha512-56L0/9HELHSsG1bFCzay8UoLxzRL7kpFf7Wl5q/kSYwiSJGACvro61xnKzPNM+SadxllzdtXsKDSXE7HPeqIAw==,
+        integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==,
       }
     hasBin: true
 
@@ -11944,10 +11914,10 @@ packages:
     peerDependencies:
       typescript: 5.0.x || 5.1.x || 5.2.x || 5.3.x || 5.4.x || 5.5.x || 5.6.x || 5.7.x || 5.8.x || 5.9.x || 6.0.x
 
-  typescript-eslint@8.63.0:
+  typescript-eslint@8.67.0:
     resolution:
       {
-        integrity: sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ==,
+        integrity: sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==,
       }
     engines: { node: ^18.18.0 || ^20.9.0 || >=21.1.0 }
     peerDependencies:
@@ -11988,10 +11958,10 @@ packages:
         integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==,
       }
 
-  undici@7.28.0:
+  undici@7.29.0:
     resolution:
       {
-        integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==,
+        integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==,
       }
     engines: { node: ">=20.18.1" }
 
@@ -12147,10 +12117,10 @@ packages:
       }
     engines: { node: ">=18" }
 
-  update-browserslist-db@1.2.3:
+  update-browserslist-db@1.3.1:
     resolution:
       {
-        integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==,
+        integrity: sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==,
       }
     hasBin: true
     peerDependencies:
@@ -12216,10 +12186,10 @@ packages:
       }
     engines: { node: ">= 0.4.0" }
 
-  uuid@14.0.1:
+  uuid@14.0.2:
     resolution:
       {
-        integrity: sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==,
+        integrity: sha512-xZe/16rV4aa+HGSOCiY2YeLT1OybRLrrkL/Rqaq7p7GMVXjFh+6wN4oMYgjFmnSnhY8t6Xpdl2l9qmnHYuMHwQ==,
       }
     hasBin: true
 
@@ -12281,16 +12251,16 @@ packages:
       rollup:
         optional: true
 
-  vite@8.1.4:
+  vite@8.2.2:
     resolution:
       {
-        integrity: sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==,
+        integrity: sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q==,
       }
     engines: { node: ^20.19.0 || >=22.12.0 }
     hasBin: true
     peerDependencies:
       "@types/node": ^20.19.0 || >=22.12.0
-      "@vitejs/devtools": ^0.3.0
+      "@vitejs/devtools": ^0.4.0 || ^0.5.0
       esbuild: ^0.27.0 || ^0.28.0
       jiti: ">=1.21.0"
       less: ^4.0.0
@@ -12327,10 +12297,10 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.10:
+  vitest@4.1.11:
     resolution:
       {
-        integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==,
+        integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==,
       }
     engines: { node: ^20.0.0 || ^22.0.0 || >=24.0.0 }
     hasBin: true
@@ -12338,12 +12308,12 @@ packages:
       "@edge-runtime/vm": "*"
       "@opentelemetry/api": ^1.9.0
       "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
-      "@vitest/browser-playwright": 4.1.10
-      "@vitest/browser-preview": 4.1.10
-      "@vitest/browser-webdriverio": 4.1.10
-      "@vitest/coverage-istanbul": 4.1.10
-      "@vitest/coverage-v8": 4.1.10
-      "@vitest/ui": 4.1.10
+      "@vitest/browser-playwright": 4.1.11
+      "@vitest/browser-preview": 4.1.11
+      "@vitest/browser-webdriverio": 4.1.11
+      "@vitest/coverage-istanbul": 4.1.11
+      "@vitest/coverage-v8": 4.1.11
+      "@vitest/ui": 4.1.11
       happy-dom: "*"
       jsdom: "*"
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -12473,10 +12443,10 @@ packages:
         integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==,
       }
 
-  webpack@5.108.4:
+  webpack@5.109.2:
     resolution:
       {
-        integrity: sha512-yur8LyJoeiWh47dErD+Ok7vlbmDsJ3UbbRPAoxbGJ54WpE2y5yVo5G/inUzujnYgw3tPmBRdn+G7PoxXaYC33w==,
+        integrity: sha512-U9/cvLzxObKNEZ9+TtdqrHM5/9z3lgl2c+c4BzbqGxFQvQvBAq87yql5A8pQ+rrMbS496MZJeF5enVBndIy2hw==,
       }
     engines: { node: ">=10.13.0" }
     hasBin: true
@@ -12565,26 +12535,12 @@ packages:
       }
     engines: { node: ">=0.10.0" }
 
-  wrap-ansi@10.0.0:
-    resolution:
-      {
-        integrity: sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==,
-      }
-    engines: { node: ">=20" }
-
   wrap-ansi@8.1.0:
     resolution:
       {
         integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==,
       }
     engines: { node: ">=12" }
-
-  wrap-ansi@9.0.2:
-    resolution:
-      {
-        integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==,
-      }
-    engines: { node: ">=18" }
 
   wrappy@1.0.2:
     resolution:
@@ -12598,10 +12554,10 @@ packages:
         integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==,
       }
 
-  ws@7.5.11:
+  ws@7.5.13:
     resolution:
       {
-        integrity: sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==,
+        integrity: sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==,
       }
     engines: { node: ">=8.3.0" }
     peerDependencies:
@@ -12613,10 +12569,10 @@ packages:
       utf-8-validate:
         optional: true
 
-  ws@8.21.0:
+  ws@8.21.3:
     resolution:
       {
-        integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==,
+        integrity: sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==,
       }
     engines: { node: ">=10.0.0" }
     peerDependencies:
@@ -12711,10 +12667,10 @@ packages:
         integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==,
       }
 
-  zustand@5.0.14:
+  zustand@5.0.15:
     resolution:
       {
-        integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==,
+        integrity: sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==,
       }
     engines: { node: ">=12.20.0" }
     peerDependencies:
@@ -12739,146 +12695,153 @@ packages:
       }
 
 snapshots:
-  "@algolia/abtesting@1.21.2":
+  "@11ty/gray-matter@1.0.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      js-yaml: 4.3.1
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
 
-  "@algolia/autocomplete-core@1.19.2(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)(search-insights@2.17.3)":
+  "@algolia/abtesting@1.23.0":
     dependencies:
-      "@algolia/autocomplete-plugin-algolia-insights": 1.19.2(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)(search-insights@2.17.3)
-      "@algolia/autocomplete-shared": 1.19.2(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
+
+  "@algolia/autocomplete-core@1.19.2(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)":
+    dependencies:
+      "@algolia/autocomplete-plugin-algolia-insights": 1.19.2(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)
+      "@algolia/autocomplete-shared": 1.19.2(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)
     transitivePeerDependencies:
       - "@algolia/client-search"
       - algoliasearch
       - search-insights
 
-  "@algolia/autocomplete-core@1.19.9(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)(search-insights@2.17.3)":
+  "@algolia/autocomplete-core@1.19.9(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)":
     dependencies:
-      "@algolia/autocomplete-plugin-algolia-insights": 1.19.9(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)(search-insights@2.17.3)
-      "@algolia/autocomplete-shared": 1.19.9(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)
+      "@algolia/autocomplete-plugin-algolia-insights": 1.19.9(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)
+      "@algolia/autocomplete-shared": 1.19.9(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)
     transitivePeerDependencies:
       - "@algolia/client-search"
       - algoliasearch
       - search-insights
 
-  "@algolia/autocomplete-plugin-algolia-insights@1.19.2(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)(search-insights@2.17.3)":
+  "@algolia/autocomplete-plugin-algolia-insights@1.19.2(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)":
     dependencies:
-      "@algolia/autocomplete-shared": 1.19.2(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)
+      "@algolia/autocomplete-shared": 1.19.2(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - "@algolia/client-search"
       - algoliasearch
 
-  "@algolia/autocomplete-plugin-algolia-insights@1.19.9(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)(search-insights@2.17.3)":
+  "@algolia/autocomplete-plugin-algolia-insights@1.19.9(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)":
     dependencies:
-      "@algolia/autocomplete-shared": 1.19.9(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)
+      "@algolia/autocomplete-shared": 1.19.9(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - "@algolia/client-search"
       - algoliasearch
 
-  "@algolia/autocomplete-shared@1.19.2(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)":
+  "@algolia/autocomplete-shared@1.19.2(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)":
     dependencies:
-      "@algolia/client-search": 5.55.2
-      algoliasearch: 5.55.2
+      "@algolia/client-search": 5.57.0
+      algoliasearch: 5.57.0
 
-  "@algolia/autocomplete-shared@1.19.9(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)":
+  "@algolia/autocomplete-shared@1.19.9(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)":
     dependencies:
-      "@algolia/client-search": 5.55.2
-      algoliasearch: 5.55.2
+      "@algolia/client-search": 5.57.0
+      algoliasearch: 5.57.0
 
-  "@algolia/client-abtesting@5.55.2":
+  "@algolia/client-abtesting@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
-  "@algolia/client-analytics@5.55.2":
+  "@algolia/client-analytics@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
-  "@algolia/client-common@5.55.2": {}
+  "@algolia/client-common@5.57.0": {}
 
-  "@algolia/client-insights@5.55.2":
+  "@algolia/client-insights@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
-  "@algolia/client-personalization@5.55.2":
+  "@algolia/client-personalization@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
-  "@algolia/client-query-suggestions@5.55.2":
+  "@algolia/client-query-suggestions@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
-  "@algolia/client-search@5.55.2":
+  "@algolia/client-search@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
   "@algolia/events@4.0.1": {}
 
-  "@algolia/ingestion@1.55.2":
+  "@algolia/ingestion@1.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
-  "@algolia/monitoring@1.55.2":
+  "@algolia/monitoring@1.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
-  "@algolia/recommend@5.55.2":
+  "@algolia/recommend@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/client-common": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
-  "@algolia/requester-browser-xhr@5.55.2":
+  "@algolia/requester-browser-xhr@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
+      "@algolia/client-common": 5.57.0
 
-  "@algolia/requester-fetch@5.55.2":
+  "@algolia/requester-fetch@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
+      "@algolia/client-common": 5.57.0
 
-  "@algolia/requester-node-http@5.55.2":
+  "@algolia/requester-node-http@5.57.0":
     dependencies:
-      "@algolia/client-common": 5.55.2
+      "@algolia/client-common": 5.57.0
 
   "@antfu/install-pkg@1.1.0":
     dependencies:
-      package-manager-detector: 1.7.0
-      tinyexec: 1.2.4
+      package-manager-detector: 1.8.0
+      tinyexec: 1.3.0
 
   "@asamuzakjp/css-color@5.1.11":
     dependencies:
       "@asamuzakjp/generational-cache": 1.0.1
-      "@csstools/css-calc": 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      "@csstools/css-color-parser": 4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-calc": 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      "@csstools/css-color-parser": 4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
       "@csstools/css-tokenizer": 4.0.0
 
@@ -12902,72 +12865,72 @@ snapshots:
 
   "@babel/compat-data@7.29.7": {}
 
-  "@babel/core@7.29.7":
+  "@babel/core@7.29.7(supports-color@8.1.1)":
     dependencies:
       "@babel/code-frame": 7.29.7
-      "@babel/generator": 7.29.7
+      "@babel/generator": 7.29.8
       "@babel/helper-compilation-targets": 7.29.7
-      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       "@babel/helpers": 7.29.7
-      "@babel/parser": 7.29.7
+      "@babel/parser": 7.29.8
       "@babel/template": 7.29.7
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
+      "@babel/types": 7.29.8
       "@jridgewell/remapping": 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/generator@7.29.7":
+  "@babel/generator@7.29.8":
     dependencies:
-      "@babel/parser": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/parser": 7.29.8
+      "@babel/types": 7.29.8
       "@jridgewell/gen-mapping": 0.3.13
       "@jridgewell/trace-mapping": 0.3.31
       jsesc: 3.1.0
 
   "@babel/helper-annotate-as-pure@7.29.7":
     dependencies:
-      "@babel/types": 7.29.7
+      "@babel/types": 7.29.8
 
   "@babel/helper-compilation-targets@7.29.7":
     dependencies:
       "@babel/compat-data": 7.29.7
       "@babel/helper-validator-option": 7.29.7
-      browserslist: 4.28.5
+      browserslist: 4.28.8
       lru-cache: 5.1.1
       semver: 6.3.1
 
-  "@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7)":
+  "@babel/helper-create-class-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-annotate-as-pure": 7.29.7
-      "@babel/helper-member-expression-to-functions": 7.29.7
+      "@babel/helper-member-expression-to-functions": 7.29.7(supports-color@8.1.1)
       "@babel/helper-optimise-call-expression": 7.29.7
-      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7)
-      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
-      "@babel/traverse": 7.29.7
+      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7(supports-color@8.1.1)
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7)":
+  "@babel/helper-create-regexp-features-plugin@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-annotate-as-pure": 7.29.7
       regexpu-core: 6.4.0
       semver: 6.3.1
 
-  "@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7)":
+  "@babel/helper-define-polyfill-provider@0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-compilation-targets": 7.29.7
       "@babel/helper-plugin-utils": 7.29.7
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       lodash.debounce: 4.0.8
       resolve: 1.22.12
     transitivePeerDependencies:
@@ -12975,57 +12938,57 @@ snapshots:
 
   "@babel/helper-globals@7.29.7": {}
 
-  "@babel/helper-member-expression-to-functions@7.29.7":
+  "@babel/helper-member-expression-to-functions@7.29.7(supports-color@8.1.1)":
     dependencies:
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
+      "@babel/types": 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-module-imports@7.29.7":
+  "@babel/helper-module-imports@7.29.7(supports-color@8.1.1)":
     dependencies:
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
+      "@babel/types": 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7)":
+  "@babel/helper-module-transforms@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-module-imports": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-module-imports": 7.29.7(supports-color@8.1.1)
       "@babel/helper-validator-identifier": 7.29.7
-      "@babel/traverse": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   "@babel/helper-optimise-call-expression@7.29.7":
     dependencies:
-      "@babel/types": 7.29.7
+      "@babel/types": 7.29.8
 
   "@babel/helper-plugin-utils@7.29.7": {}
 
-  "@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7)":
+  "@babel/helper-remap-async-to-generator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-annotate-as-pure": 7.29.7
-      "@babel/helper-wrap-function": 7.29.7
-      "@babel/traverse": 7.29.7
+      "@babel/helper-wrap-function": 7.29.7(supports-color@8.1.1)
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7)":
+  "@babel/helper-replace-supers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-member-expression-to-functions": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-member-expression-to-functions": 7.29.7(supports-color@8.1.1)
       "@babel/helper-optimise-call-expression": 7.29.7
-      "@babel/traverse": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/helper-skip-transparent-expression-wrappers@7.29.7":
+  "@babel/helper-skip-transparent-expression-wrappers@7.29.7(supports-color@8.1.1)":
     dependencies:
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
+      "@babel/types": 7.29.8
     transitivePeerDependencies:
       - supports-color
 
@@ -13035,595 +12998,595 @@ snapshots:
 
   "@babel/helper-validator-option@7.29.7": {}
 
-  "@babel/helper-wrap-function@7.29.7":
+  "@babel/helper-wrap-function@7.29.7(supports-color@8.1.1)":
     dependencies:
       "@babel/template": 7.29.7
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
+      "@babel/types": 7.29.8
     transitivePeerDependencies:
       - supports-color
 
   "@babel/helpers@7.29.7":
     dependencies:
       "@babel/template": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/types": 7.29.8
 
-  "@babel/parser@7.29.7":
+  "@babel/parser@7.29.8":
     dependencies:
-      "@babel/types": 7.29.7
+      "@babel/types": 7.29.8
 
-  "@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-bugfix-firefox-class-in-computed-class-key@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/traverse": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-bugfix-safari-class-field-initializer-scope@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
-      "@babel/plugin-transform-optional-chaining": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7(supports-color@8.1.1)
+      "@babel/plugin-transform-optional-chaining": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/traverse": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)":
+  "@babel/plugin-proposal-private-property-in-object@7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
 
-  "@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-dynamic-import@7.8.3(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-import-assertions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-import-attributes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7)":
+  "@babel/plugin-syntax-unicode-sets-regex@7.18.6(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-arrow-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-async-generator-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-remap-async-to-generator": 7.29.7(@babel/core@7.29.7)
-      "@babel/traverse": 7.29.7
+      "@babel/helper-remap-async-to-generator": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-async-to-generator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-module-imports": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-module-imports": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-remap-async-to-generator": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-remap-async-to-generator": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-block-scoped-functions@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-block-scoping@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-class-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
-      "@babel/helper-plugin-utils": 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  "@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7)":
-    dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-class-static-block@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-classes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
+    dependencies:
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-annotate-as-pure": 7.29.7
       "@babel/helper-compilation-targets": 7.29.7
       "@babel/helper-globals": 7.29.7
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7)
-      "@babel/traverse": 7.29.7
+      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-computed-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
       "@babel/template": 7.29.7
 
-  "@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-destructuring@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/traverse": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-dotall-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-duplicate-keys@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-duplicate-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-dynamic-import@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-explicit-resource-management@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-exponentiation-operator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-export-namespace-from@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-for-of@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-function-name@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-compilation-targets": 7.29.7
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/traverse": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-json-strings@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-logical-assignment-operators@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-member-expression-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-modules-amd@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
-      "@babel/helper-plugin-utils": 7.29.7
-    transitivePeerDependencies:
-      - supports-color
-
-  "@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7)":
-    dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-modules-systemjs@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-modules-commonjs@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/helper-plugin-utils": 7.29.7
+    transitivePeerDependencies:
+      - supports-color
+
+  "@babel/plugin-transform-modules-systemjs@7.29.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
+    dependencies:
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
       "@babel/helper-validator-identifier": 7.29.7
-      "@babel/traverse": 7.29.7
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-modules-umd@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-module-transforms": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-named-capturing-groups-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-new-target@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-nullish-coalescing-operator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-numeric-separator@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-object-rest-spread@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-compilation-targets": 7.29.7
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7)
-      "@babel/traverse": 7.29.7
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-object-super@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-replace-supers": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-optional-catch-binding@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-optional-chaining@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-parameters@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-private-methods@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-private-property-in-object@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-annotate-as-pure": 7.29.7
-      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-property-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-react-constant-elements@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-react-constant-elements@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-react-display-name@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-react-jsx-development@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-react-jsx-development@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/plugin-transform-react-jsx": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/plugin-transform-react-jsx": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-react-jsx@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-annotate-as-pure": 7.29.7
-      "@babel/helper-module-imports": 7.29.7
+      "@babel/helper-module-imports": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7)
-      "@babel/types": 7.29.7
+      "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/types": 7.29.8
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-react-pure-annotations@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-react-pure-annotations@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-annotate-as-pure": 7.29.7
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-regenerator@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-regenerator@7.29.8(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-regexp-modifiers@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-reserved-words@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-runtime@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-module-imports": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-module-imports": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
-      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-shorthand-properties@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-spread@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-spread@7.29.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-sticky-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-template-literals@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-typeof-symbol@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-annotate-as-pure": 7.29.7
-      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-create-class-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7
-      "@babel/plugin-syntax-typescript": 7.29.7(@babel/core@7.29.7)
+      "@babel/helper-skip-transparent-expression-wrappers": 7.29.7(supports-color@8.1.1)
+      "@babel/plugin-syntax-typescript": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-unicode-escapes@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-unicode-property-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-unicode-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7)":
+  "@babel/plugin-transform-unicode-sets-regex@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-create-regexp-features-plugin": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
       "@babel/helper-plugin-utils": 7.29.7
 
-  "@babel/preset-env@7.29.7(@babel/core@7.29.7)":
+  "@babel/preset-env@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
       "@babel/compat-data": 7.29.7
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-compilation-targets": 7.29.7
       "@babel/helper-plugin-utils": 7.29.7
       "@babel/helper-validator-option": 7.29.7
-      "@babel/plugin-bugfix-firefox-class-in-computed-class-key": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-bugfix-safari-class-field-initializer-scope": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-proposal-private-property-in-object": 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7)
-      "@babel/plugin-syntax-import-assertions": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-syntax-import-attributes": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-syntax-unicode-sets-regex": 7.18.6(@babel/core@7.29.7)
-      "@babel/plugin-transform-arrow-functions": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-async-generator-functions": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-async-to-generator": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-block-scoped-functions": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-block-scoping": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-class-properties": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-class-static-block": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-classes": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-computed-properties": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-dotall-regex": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-duplicate-keys": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-duplicate-named-capturing-groups-regex": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-dynamic-import": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-explicit-resource-management": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-exponentiation-operator": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-export-namespace-from": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-for-of": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-function-name": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-json-strings": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-literals": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-logical-assignment-operators": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-member-expression-literals": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-modules-amd": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-modules-systemjs": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-modules-umd": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-named-capturing-groups-regex": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-new-target": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-nullish-coalescing-operator": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-numeric-separator": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-object-rest-spread": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-object-super": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-optional-catch-binding": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-optional-chaining": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-private-methods": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-private-property-in-object": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-property-literals": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-regenerator": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-regexp-modifiers": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-reserved-words": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-shorthand-properties": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-spread": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-sticky-regex": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-template-literals": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-typeof-symbol": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-unicode-escapes": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-unicode-property-regex": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-unicode-regex": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-unicode-sets-regex": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-modules": 0.1.6-no-external-plugins(@babel/core@7.29.7)
-      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7)
-      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7)
-      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7)
-      core-js-compat: 3.49.0
+      "@babel/plugin-bugfix-firefox-class-in-computed-class-key": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-bugfix-safari-class-field-initializer-scope": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-bugfix-safari-rest-destructuring-rhs-array": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-proposal-private-property-in-object": 7.21.0-placeholder-for-preset-env.2(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-syntax-import-assertions": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-syntax-import-attributes": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-syntax-unicode-sets-regex": 7.18.6(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-arrow-functions": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-async-generator-functions": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-async-to-generator": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-block-scoped-functions": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-block-scoping": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-class-properties": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-class-static-block": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-classes": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-computed-properties": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-destructuring": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-dotall-regex": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-duplicate-keys": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-duplicate-named-capturing-groups-regex": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-dynamic-import": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-explicit-resource-management": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-exponentiation-operator": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-export-namespace-from": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-for-of": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-function-name": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-json-strings": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-literals": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-logical-assignment-operators": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-member-expression-literals": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-modules-amd": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-modules-systemjs": 7.29.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-modules-umd": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-named-capturing-groups-regex": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-new-target": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-nullish-coalescing-operator": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-numeric-separator": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-object-rest-spread": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-object-super": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-optional-catch-binding": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-optional-chaining": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-parameters": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-private-methods": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-private-property-in-object": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-property-literals": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-regenerator": 7.29.8(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-regexp-modifiers": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-reserved-words": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-shorthand-properties": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-spread": 7.29.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-sticky-regex": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-template-literals": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-typeof-symbol": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-unicode-escapes": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-unicode-property-regex": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-unicode-regex": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-unicode-sets-regex": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/preset-modules": 0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@8.1.1))
+      babel-plugin-polyfill-corejs2: 0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-corejs3: 0.14.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      babel-plugin-polyfill-regenerator: 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      core-js-compat: 3.50.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7)":
+  "@babel/preset-modules@0.1.6-no-external-plugins(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/types": 7.29.8
       esutils: 2.0.3
 
-  "@babel/preset-react@7.29.7(@babel/core@7.29.7)":
+  "@babel/preset-react@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
       "@babel/helper-validator-option": 7.29.7
-      "@babel/plugin-transform-react-display-name": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-react-jsx": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-react-jsx-development": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-react-pure-annotations": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-transform-react-display-name": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-react-jsx": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-react-jsx-development": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-react-pure-annotations": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/preset-typescript@7.29.7(@babel/core@7.29.7)":
+  "@babel/preset-typescript@7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       "@babel/helper-plugin-utils": 7.29.7
       "@babel/helper-validator-option": 7.29.7
-      "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7)
-      "@babel/plugin-transform-typescript": 7.29.7(@babel/core@7.29.7)
+      "@babel/plugin-syntax-jsx": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-modules-commonjs": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/plugin-transform-typescript": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -13632,48 +13595,48 @@ snapshots:
   "@babel/template@7.29.7":
     dependencies:
       "@babel/code-frame": 7.29.7
-      "@babel/parser": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/parser": 7.29.8
+      "@babel/types": 7.29.8
 
-  "@babel/traverse@7.29.7":
+  "@babel/traverse@7.29.8(supports-color@8.1.1)":
     dependencies:
       "@babel/code-frame": 7.29.7
-      "@babel/generator": 7.29.7
+      "@babel/generator": 7.29.8
       "@babel/helper-globals": 7.29.7
-      "@babel/parser": 7.29.7
+      "@babel/parser": 7.29.8
       "@babel/template": 7.29.7
-      "@babel/types": 7.29.7
-      debug: 4.4.3
+      "@babel/types": 7.29.8
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
-  "@babel/types@7.29.7":
+  "@babel/types@7.29.8":
     dependencies:
       "@babel/helper-string-parser": 7.29.7
       "@babel/helper-validator-identifier": 7.29.7
 
-  "@base-ui/react@1.6.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@base-ui/react@1.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@babel/runtime": 7.29.7
-      "@base-ui/utils": 0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@floating-ui/react-dom": 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@floating-ui/utils": 0.2.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      use-sync-external-store: 1.6.0(react@19.2.7)
+      "@base-ui/utils": 0.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@floating-ui/react-dom": 2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@floating-ui/utils": 0.2.12
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
     optionalDependencies:
-      "@types/react": 19.2.17
+      "@types/react": 19.2.18
 
-  "@base-ui/utils@0.3.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@base-ui/utils@0.3.2(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@babel/runtime": 7.29.7
-      "@floating-ui/utils": 0.2.11
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@floating-ui/utils": 0.2.12
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       reselect: 5.2.0
-      use-sync-external-store: 1.6.0(react@19.2.7)
+      use-sync-external-store: 1.6.0(react@19.2.8)
     optionalDependencies:
-      "@types/react": 19.2.17
+      "@types/react": 19.2.18
 
   "@bcoe/v8-coverage@1.0.2": {}
 
@@ -13695,14 +13658,14 @@ snapshots:
 
   "@csstools/color-helpers@5.1.0": {}
 
-  "@csstools/color-helpers@6.1.0": {}
+  "@csstools/color-helpers@6.1.1": {}
 
   "@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
 
-  "@csstools/css-calc@3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)":
+  "@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)":
     dependencies:
       "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
       "@csstools/css-tokenizer": 4.0.0
@@ -13714,10 +13677,10 @@ snapshots:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
 
-  "@csstools/css-color-parser@4.1.9(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)":
+  "@csstools/css-color-parser@4.2.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)":
     dependencies:
-      "@csstools/color-helpers": 6.1.0
-      "@csstools/css-calc": 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      "@csstools/color-helpers": 6.1.1
+      "@csstools/css-calc": 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       "@csstools/css-parser-algorithms": 4.0.0(@csstools/css-tokenizer@4.0.0)
       "@csstools/css-tokenizer": 4.0.0
 
@@ -13729,7 +13692,7 @@ snapshots:
     dependencies:
       "@csstools/css-tokenizer": 4.0.0
 
-  "@csstools/css-syntax-patches-for-csstree@1.1.6(css-tree@3.2.1)":
+  "@csstools/css-syntax-patches-for-csstree@1.1.8(css-tree@3.2.1)":
     optionalDependencies:
       css-tree: 3.2.1
 
@@ -13742,284 +13705,284 @@ snapshots:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
 
-  "@csstools/postcss-alpha-function@1.0.1(postcss@8.5.16)":
+  "@csstools/postcss-alpha-function@1.0.1(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.16)":
+  "@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.26)":
     dependencies:
-      "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.4)
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.5)
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  "@csstools/postcss-color-function-display-p3-linear@1.0.1(postcss@8.5.16)":
-    dependencies:
-      "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
-
-  "@csstools/postcss-color-function@4.0.12(postcss@8.5.16)":
+  "@csstools/postcss-color-function-display-p3-linear@1.0.1(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-color-mix-function@3.0.12(postcss@8.5.16)":
+  "@csstools/postcss-color-function@4.0.12(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-color-mix-variadic-function-arguments@1.0.2(postcss@8.5.16)":
+  "@csstools/postcss-color-mix-function@3.0.12(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-content-alt-text@2.0.8(postcss@8.5.16)":
-    dependencies:
-      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
-
-  "@csstools/postcss-contrast-color-function@2.0.12(postcss@8.5.16)":
+  "@csstools/postcss-color-mix-variadic-function-arguments@1.0.2(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-exponential-functions@2.0.9(postcss@8.5.16)":
+  "@csstools/postcss-content-alt-text@2.0.8(postcss@8.5.26)":
+    dependencies:
+      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-tokenizer": 3.0.4
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
+
+  "@csstools/postcss-contrast-color-function@2.0.12(postcss@8.5.26)":
+    dependencies:
+      "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-tokenizer": 3.0.4
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
+
+  "@csstools/postcss-exponential-functions@2.0.9(postcss@8.5.26)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.16)":
+  "@csstools/postcss-font-format-keywords@4.0.0(postcss@8.5.26)":
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-gamut-mapping@2.0.11(postcss@8.5.16)":
+  "@csstools/postcss-gamut-mapping@2.0.11(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-gradients-interpolation-method@5.0.12(postcss@8.5.16)":
+  "@csstools/postcss-gradients-interpolation-method@5.0.12(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-hwb-function@4.0.12(postcss@8.5.16)":
+  "@csstools/postcss-hwb-function@4.0.12(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-ic-unit@4.0.4(postcss@8.5.16)":
+  "@csstools/postcss-ic-unit@4.0.4(postcss@8.5.26)":
     dependencies:
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-initial@2.0.1(postcss@8.5.16)":
+  "@csstools/postcss-initial@2.0.1(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.16)":
+  "@csstools/postcss-is-pseudo-class@5.0.3(postcss@8.5.26)":
     dependencies:
-      "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.4)
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.5)
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  "@csstools/postcss-light-dark-function@2.0.11(postcss@8.5.16)":
+  "@csstools/postcss-light-dark-function@2.0.11(postcss@8.5.26)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.16)":
+  "@csstools/postcss-logical-float-and-clear@3.0.0(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.16)":
+  "@csstools/postcss-logical-overflow@2.0.0(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.16)":
+  "@csstools/postcss-logical-overscroll-behavior@2.0.0(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-logical-resize@3.0.0(postcss@8.5.16)":
+  "@csstools/postcss-logical-resize@3.0.0(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-logical-viewport-units@3.0.4(postcss@8.5.16)":
+  "@csstools/postcss-logical-viewport-units@3.0.4(postcss@8.5.26)":
     dependencies:
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-media-minmax@2.0.9(postcss@8.5.16)":
+  "@csstools/postcss-media-minmax@2.0.9(postcss@8.5.26)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
       "@csstools/media-query-list-parser": 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5(postcss@8.5.16)":
+  "@csstools/postcss-media-queries-aspect-ratio-number-values@3.0.5(postcss@8.5.26)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
       "@csstools/media-query-list-parser": 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-nested-calc@4.0.0(postcss@8.5.16)":
+  "@csstools/postcss-nested-calc@4.0.0(postcss@8.5.26)":
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-normalize-display-values@4.0.1(postcss@8.5.16)":
+  "@csstools/postcss-normalize-display-values@4.0.1(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-oklab-function@4.0.12(postcss@8.5.16)":
+  "@csstools/postcss-oklab-function@4.0.12(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-position-area-property@1.0.0(postcss@8.5.16)":
+  "@csstools/postcss-position-area-property@1.0.0(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-progressive-custom-properties@4.2.1(postcss@8.5.16)":
+  "@csstools/postcss-progressive-custom-properties@4.2.1(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-property-rule-prelude-list@1.0.0(postcss@8.5.16)":
+  "@csstools/postcss-property-rule-prelude-list@1.0.0(postcss@8.5.26)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-random-function@2.0.1(postcss@8.5.16)":
+  "@csstools/postcss-random-function@2.0.1(postcss@8.5.26)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-relative-color-syntax@3.0.12(postcss@8.5.16)":
+  "@csstools/postcss-relative-color-syntax@3.0.12(postcss@8.5.26)":
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  "@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.16)":
+  "@csstools/postcss-scope-pseudo-class@4.0.1(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  "@csstools/postcss-sign-functions@1.1.4(postcss@8.5.16)":
-    dependencies:
-      "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
-      "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
-
-  "@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.16)":
+  "@csstools/postcss-sign-functions@1.1.4(postcss@8.5.26)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-syntax-descriptor-syntax-production@1.0.1(postcss@8.5.16)":
+  "@csstools/postcss-stepped-value-functions@4.0.9(postcss@8.5.26)":
+    dependencies:
+      "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
+      "@csstools/css-tokenizer": 3.0.4
+      postcss: 8.5.26
+
+  "@csstools/postcss-syntax-descriptor-syntax-production@1.0.1(postcss@8.5.26)":
     dependencies:
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-system-ui-font-family@1.0.0(postcss@8.5.16)":
+  "@csstools/postcss-system-ui-font-family@1.0.0(postcss@8.5.26)":
     dependencies:
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.16)":
+  "@csstools/postcss-text-decoration-shorthand@4.0.3(postcss@8.5.26)":
     dependencies:
       "@csstools/color-helpers": 5.1.0
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  "@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.16)":
+  "@csstools/postcss-trigonometric-functions@4.0.9(postcss@8.5.26)":
     dependencies:
       "@csstools/css-calc": 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/postcss-unset-value@4.0.0(postcss@8.5.16)":
+  "@csstools/postcss-unset-value@4.0.0(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  "@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.4)":
+  "@csstools/selector-resolve-nested@3.1.0(postcss-selector-parser@7.1.5)":
     dependencies:
-      postcss-selector-parser: 7.1.4
+      postcss-selector-parser: 7.1.5
 
-  "@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.4)":
+  "@csstools/selector-specificity@5.0.0(postcss-selector-parser@7.1.5)":
     dependencies:
-      postcss-selector-parser: 7.1.4
+      postcss-selector-parser: 7.1.5
 
-  "@csstools/utilities@2.0.0(postcss@8.5.16)":
+  "@csstools/utilities@2.0.0(postcss@8.5.26)":
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
   "@discoveryjs/json-ext@0.5.7": {}
 
@@ -14048,13 +14011,13 @@ snapshots:
       "@dnd-kit/state": 0.5.0
       tslib: 2.8.1
 
-  "@dnd-kit/react@0.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@dnd-kit/react@0.5.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@dnd-kit/abstract": 0.5.0
       "@dnd-kit/dom": 0.5.0
       "@dnd-kit/state": 0.5.0
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
 
   "@dnd-kit/state@0.5.0":
@@ -14062,43 +14025,43 @@ snapshots:
       "@preact/signals-core": 1.14.4
       tslib: 2.8.1
 
-  "@docsearch/core@4.6.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docsearch/core@4.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     optionalDependencies:
-      "@types/react": 19.2.17
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@types/react": 19.2.18
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
-  "@docsearch/css@4.6.3": {}
+  "@docsearch/css@4.7.0": {}
 
-  "@docsearch/react@4.6.3(@algolia/client-search@5.55.2)(@types/react@19.2.17)(algoliasearch@5.55.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)":
+  "@docsearch/react@4.7.0(@algolia/client-search@5.57.0)(@types/react@19.2.18)(algoliasearch@5.57.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)":
     dependencies:
-      "@algolia/autocomplete-core": 1.19.2(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)(search-insights@2.17.3)
-      "@docsearch/core": 4.6.3(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docsearch/css": 4.6.3
+      "@algolia/autocomplete-core": 1.19.2(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)
+      "@docsearch/core": 4.7.0(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      "@docsearch/css": 4.7.0
     optionalDependencies:
-      "@types/react": 19.2.17
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@types/react": 19.2.18
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       search-insights: 2.17.3
     transitivePeerDependencies:
       - "@algolia/client-search"
       - algoliasearch
 
-  "@docusaurus/babel@3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docusaurus/babel@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/generator": 7.29.7
-      "@babel/plugin-syntax-dynamic-import": 7.8.3(@babel/core@7.29.7)
-      "@babel/plugin-transform-runtime": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-env": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-react": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/generator": 7.29.8
+      "@babel/plugin-syntax-dynamic-import": 7.8.3(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/plugin-transform-runtime": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/preset-env": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/preset-react": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       "@babel/runtime": 7.29.7
-      "@babel/traverse": 7.29.7
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       babel-plugin-dynamic-import-node: 2.3.3
-      fs-extra: 11.3.6
+      fs-extra: 11.4.0
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@minify-html/node"
@@ -14118,68 +14081,34 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/babel@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docusaurus/bundler@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(csso@5.0.5)(lightningcss@1.33.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/generator": 7.29.7
-      "@babel/plugin-syntax-dynamic-import": 7.8.3(@babel/core@7.29.7)
-      "@babel/plugin-transform-runtime": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-env": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-react": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7)
-      "@babel/runtime": 7.29.7
-      "@babel/traverse": 7.29.7
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      babel-plugin-dynamic-import-node: 2.3.3
-      fs-extra: 11.3.6
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - "@minify-html/node"
-      - "@swc/core"
-      - "@swc/css"
-      - "@swc/html"
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - react
-      - react-dom
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  "@docusaurus/bundler@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@rspack/core@1.7.12)(@swc/core@1.15.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
-    dependencies:
-      "@babel/core": 7.29.7
-      "@docusaurus/babel": 3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/cssnano-preset": 3.10.1
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      babel-loader: 9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@docusaurus/babel": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/cssnano-preset": 3.10.2
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      babel-loader: 9.2.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       clean-css: 5.3.3
-      copy-webpack-plugin: 11.0.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      css-loader: 6.11.0(@rspack/core@1.7.12)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      cssnano: 6.1.2(postcss@8.5.16)
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      copy-webpack-plugin: 11.0.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      css-loader: 6.11.0(@rspack/core@1.7.12)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      css-minimizer-webpack-plugin: 5.0.1(clean-css@5.3.3)(csso@5.0.5)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      cssnano: 6.1.2(postcss@8.5.26)
+      file-loader: 6.2.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       html-minifier-terser: 7.2.0
-      mini-css-extract-plugin: 2.10.2(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      null-loader: 4.0.1(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      postcss: 8.5.16
-      postcss-loader: 7.3.4(postcss@8.5.16)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      postcss-preset-env: 10.6.1(postcss@8.5.16)
-      terser-webpack-plugin: 5.6.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      mini-css-extract-plugin: 2.10.2(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      null-loader: 4.0.1(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      postcss: 8.5.26
+      postcss-loader: 7.3.4(postcss@8.5.26)(typescript@6.0.3)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      postcss-preset-env: 10.6.1(postcss@8.5.26)
+      terser-webpack-plugin: 5.6.1(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)))(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      webpack: 5.108.4(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)
-      webpackbar: 7.0.0(@rspack/core@1.7.12)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
+      webpackbar: 7.0.0(@rspack/core@1.7.12)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
     optionalDependencies:
-      "@docusaurus/faster": 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16)
+      "@docusaurus/faster": 3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - "@minify-html/node"
       - "@parcel/css"
@@ -14197,55 +14126,55 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/core@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/core@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/babel": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/bundler": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@rspack/core@1.7.12)(@swc/core@1.15.43)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/mdx-loader": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-common": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@mdx-js/react": 3.1.1(@types/react@19.2.17)(react@19.2.7)
+      "@docusaurus/babel": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/bundler": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(csso@5.0.5)(lightningcss@1.33.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/mdx-loader": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-common": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@mdx-js/react": 3.1.1(@types/react@19.2.18)(react@19.2.8)
       boxen: 6.2.1
       chalk: 4.1.2
       chokidar: 3.6.0
       cli-table3: 0.6.5
       combine-promises: 1.2.0
       commander: 5.1.0
-      core-js: 3.49.0
-      detect-port: 1.6.1
+      core-js: 3.50.0
+      detect-port: 2.1.0
       escape-html: 1.0.3
       eta: 2.2.0
       eval: 0.1.8
       execa: 5.1.1
-      fs-extra: 11.3.6
+      fs-extra: 11.4.0
       html-tags: 3.3.1
-      html-webpack-plugin: 5.6.7(@rspack/core@1.7.12)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      html-webpack-plugin: 5.6.8(@rspack/core@1.7.12)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       leven: 3.1.0
       lodash: 4.18.1
       open: 8.4.2
       p-map: 4.0.0
       prompts: 2.4.2
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)"
-      react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.2.7)"
-      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.7))(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      react-router: 5.3.4(react@19.2.7)
-      react-router-config: 5.1.1(react-router@5.3.4(react@19.2.7))(react@19.2.7)
-      react-router-dom: 5.3.4(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)"
+      react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.2.8)"
+      react-loadable-ssr-addon-v5-slorber: 1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.8))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      react-router: 5.3.4(react@19.2.8)
+      react-router-config: 5.1.1(react-router@5.3.4(react@19.2.8))(react@19.2.8)
+      react-router-dom: 5.3.4(react@19.2.8)
       semver: 7.8.5
       serve-handler: 6.1.7
       tinypool: 1.1.1
       tslib: 2.8.1
       update-notifier: 6.0.2
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
       webpack-bundle-analyzer: 4.10.2
-      webpack-dev-server: 5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      webpack-dev-server: 5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       webpack-merge: 6.0.1
     optionalDependencies:
-      "@docusaurus/faster": 3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16)
+      "@docusaurus/faster": 3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - "@minify-html/node"
       - "@parcel/css"
@@ -14268,25 +14197,25 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/cssnano-preset@3.10.1":
+  "@docusaurus/cssnano-preset@3.10.2":
     dependencies:
-      cssnano-preset-advanced: 6.1.2(postcss@8.5.16)
-      postcss: 8.5.16
-      postcss-sort-media-queries: 5.2.0(postcss@8.5.16)
+      cssnano-preset-advanced: 6.1.2(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-sort-media-queries: 5.2.0(postcss@8.5.26)
       tslib: 2.8.1
 
-  "@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16)":
+  "@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26)":
     dependencies:
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       "@rspack/core": 1.7.12
-      "@swc/core": 1.15.43
-      "@swc/html": 1.15.43
-      browserslist: 4.28.5
-      lightningcss: 1.32.0
+      "@swc/core": 1.16.1
+      "@swc/html": 1.16.1
+      browserslist: 4.28.8
+      lightningcss: 1.33.0
       semver: 7.8.5
-      swc-loader: 0.2.7(@swc/core@1.15.43)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      swc-loader: 0.2.7(@swc/core@1.16.1)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.43)(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - "@minify-html/node"
       - "@swc/css"
@@ -14300,39 +14229,39 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/logger@3.10.1":
+  "@docusaurus/logger@3.10.2":
     dependencies:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  "@docusaurus/mdx-loader@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docusaurus/mdx-loader@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)":
     dependencies:
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@mdx-js/mdx": 3.1.1
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@mdx-js/mdx": 3.1.1(supports-color@8.1.1)
       "@slorber/remark-comment": 1.0.0
       escape-html: 1.0.3
       estree-util-value-to-estree: 3.5.0
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      fs-extra: 11.3.6
+      file-loader: 6.2.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      fs-extra: 11.4.0
       image-size: 2.0.2
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@8.1.1)
       mdast-util-to-string: 4.0.0
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       rehype-raw: 7.0.0
-      remark-directive: 3.0.1
+      remark-directive: 3.0.1(supports-color@8.1.1)
       remark-emoji: 4.0.1
-      remark-frontmatter: 5.0.0
-      remark-gfm: 4.0.1
+      remark-frontmatter: 5.0.0(supports-color@8.1.1)
+      remark-gfm: 4.0.1(supports-color@8.1.1)
       stringify-object: 3.3.0
       tslib: 2.8.1
       unified: 11.0.5
       unist-util-visit: 5.1.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)))(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       vfile: 6.0.3
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - "@minify-html/node"
       - "@swc/core"
@@ -14349,17 +14278,17 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/module-type-aliases@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docusaurus/module-type-aliases@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)":
     dependencies:
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       "@types/history": 4.7.11
-      "@types/react": 19.2.17
+      "@types/react": 19.2.18
       "@types/react-router-config": 5.0.11
       "@types/react-router-dom": 5.3.3
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)"
-      react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.2.7)"
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)"
+      react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.2.8)"
     transitivePeerDependencies:
       - "@minify-html/node"
       - "@swc/core"
@@ -14376,30 +14305,30 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/plugin-content-blog@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-content-blog@3.10.2(2490df0a9605874396a568ec3788caa5)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/mdx-loader": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/plugin-content-docs": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/theme-common": 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-common": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/mdx-loader": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/plugin-content-docs": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/theme-common": 3.10.2(d03570d07bef42454ded4d347253a2eb)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-common": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       cheerio: 1.0.0-rc.12
       combine-promises: 1.2.0
       feed: 4.2.2
-      fs-extra: 11.3.6
+      fs-extra: 11.4.0
       lodash: 4.18.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       schema-dts: 1.1.5
       srcset: 4.0.0
       tslib: 2.8.1
       unist-util-visit: 5.1.0
       utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -14424,28 +14353,28 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-content-docs@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/mdx-loader": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/module-type-aliases": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/theme-common": 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-common": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/mdx-loader": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/module-type-aliases": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/theme-common": 3.10.2(d03570d07bef42454ded4d347253a2eb)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-common": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       "@types/react-router-config": 5.0.11
       combine-promises: 1.2.0
-      fs-extra: 11.3.6
-      js-yaml: 4.3.0
+      fs-extra: 11.4.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       schema-dts: 1.1.5
       tslib: 2.8.1
       utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -14470,18 +14399,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-content-pages@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-content-pages@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/mdx-loader": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      fs-extra: 11.3.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/mdx-loader": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      fs-extra: 11.4.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -14506,12 +14435,12 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-css-cascade-layers@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-css-cascade-layers@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -14539,15 +14468,15 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-debug@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-debug@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      fs-extra: 11.3.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-json-view-lite: 2.5.0(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      fs-extra: 11.4.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-json-view-lite: 2.5.0(react@19.2.8)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -14573,13 +14502,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-google-analytics@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-google-analytics@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -14605,14 +14534,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-google-gtag@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-google-gtag@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@types/gtag.js": 0.0.20
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -14638,13 +14566,13 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-google-tag-manager@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-google-tag-manager@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -14670,17 +14598,17 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-sitemap@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-sitemap@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-common": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      fs-extra: 11.3.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-common": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      fs-extra: 11.4.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       sitemap: 7.1.3
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -14707,18 +14635,18 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/plugin-svgr@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/plugin-svgr@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@svgr/core": 8.1.0(typescript@6.0.3)
-      "@svgr/webpack": 8.1.0(typescript@6.0.3)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@svgr/core": 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
+      "@svgr/webpack": 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - "@docusaurus/faster"
       - "@mdx-js/react"
@@ -14743,25 +14671,25 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/preset-classic@3.10.1(@algolia/client-search@5.55.2)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(@types/react@19.2.17)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@6.0.3)":
+  "@docusaurus/preset-classic@3.10.2(@algolia/client-search@5.57.0)(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(@types/react@19.2.18)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-content-blog": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-content-docs": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-content-pages": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-css-cascade-layers": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-debug": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-google-analytics": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-google-gtag": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-google-tag-manager": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-sitemap": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-svgr": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/theme-classic": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@rspack/core@1.7.12)(@swc/core@1.15.43)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/theme-common": 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/theme-search-algolia": 3.10.1(@algolia/client-search@5.55.2)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(@types/react@19.2.17)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@6.0.3)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-content-blog": 3.10.2(2490df0a9605874396a568ec3788caa5)
+      "@docusaurus/plugin-content-docs": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-content-pages": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-css-cascade-layers": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-debug": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-google-analytics": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-google-gtag": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-google-tag-manager": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-sitemap": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-svgr": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/theme-classic": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(@types/react@19.2.18)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/theme-common": 3.10.2(d03570d07bef42454ded4d347253a2eb)
+      "@docusaurus/theme-search-algolia": 3.10.2(@algolia/client-search@5.57.0)(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(@types/react@19.2.18)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
     transitivePeerDependencies:
       - "@algolia/client-search"
       - "@docusaurus/faster"
@@ -14789,38 +14717,38 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/react-loadable@6.0.0(react@19.2.7)":
+  "@docusaurus/react-loadable@6.0.0(react@19.2.8)":
     dependencies:
-      "@types/react": 19.2.17
-      react: 19.2.7
+      "@types/react": 19.2.18
+      react: 19.2.8
 
-  "@docusaurus/theme-classic@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@rspack/core@1.7.12)(@swc/core@1.15.43)(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/theme-classic@3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(@types/react@19.2.18)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/mdx-loader": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/module-type-aliases": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/plugin-content-blog": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-content-docs": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/plugin-content-pages": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/theme-common": 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/theme-translations": 3.10.1
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-common": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@mdx-js/react": 3.1.1(@types/react@19.2.17)(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/mdx-loader": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/module-type-aliases": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/plugin-content-blog": 3.10.2(2490df0a9605874396a568ec3788caa5)
+      "@docusaurus/plugin-content-docs": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/plugin-content-pages": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/theme-common": 3.10.2(d03570d07bef42454ded4d347253a2eb)
+      "@docusaurus/theme-translations": 3.10.2
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-common": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@mdx-js/react": 3.1.1(@types/react@19.2.18)(react@19.2.8)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
       infima: 0.2.0-alpha.45
       lodash: 4.18.1
       nprogress: 0.2.0
-      postcss: 8.5.16
-      prism-react-renderer: 2.4.1(react@19.2.7)
+      postcss: 8.5.26
+      prism-react-renderer: 2.4.1(react@19.2.8)
       prismjs: 1.30.0
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-router-dom: 5.3.4(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-router-dom: 5.3.4(react@19.2.8)
       rtlcss: 4.3.0
       tslib: 2.8.1
       utility-types: 3.11.0
@@ -14847,21 +14775,21 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/theme-common@3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docusaurus/theme-common@3.10.2(d03570d07bef42454ded4d347253a2eb)":
     dependencies:
-      "@docusaurus/mdx-loader": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/module-type-aliases": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/plugin-content-docs": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-common": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@docusaurus/mdx-loader": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/module-type-aliases": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/plugin-content-docs": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-common": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       "@types/history": 4.7.11
-      "@types/react": 19.2.17
+      "@types/react": 19.2.18
       "@types/react-router-config": 5.0.11
       clsx: 2.1.1
       parse-numeric-range: 1.3.0
-      prism-react-renderer: 2.4.1(react@19.2.7)
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      prism-react-renderer: 2.4.1(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
       utility-types: 3.11.0
     transitivePeerDependencies:
@@ -14880,16 +14808,16 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/theme-mermaid@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)":
+  "@docusaurus/theme-mermaid@3.10.2(2490df0a9605874396a568ec3788caa5)":
     dependencies:
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/module-type-aliases": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/theme-common": 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      mermaid: 11.16.0
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/module-type-aliases": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/theme-common": 3.10.2(d03570d07bef42454ded4d347253a2eb)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      mermaid: 11.17.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@docusaurus/faster"
@@ -14916,25 +14844,25 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/theme-search-algolia@3.10.1(@algolia/client-search@5.55.2)(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(@types/react@19.2.17)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)(typescript@6.0.3)":
+  "@docusaurus/theme-search-algolia@3.10.2(@algolia/client-search@5.57.0)(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(@types/react@19.2.18)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@algolia/autocomplete-core": 1.19.9(@algolia/client-search@5.55.2)(algoliasearch@5.55.2)(search-insights@2.17.3)
-      "@docsearch/react": 4.6.3(@algolia/client-search@5.55.2)(@types/react@19.2.17)(algoliasearch@5.55.2)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(search-insights@2.17.3)
-      "@docusaurus/core": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/plugin-content-docs": 3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
-      "@docusaurus/theme-common": 3.10.1(@docusaurus/plugin-content-docs@3.10.1(@docusaurus/faster@3.10.1(@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(postcss@8.5.16))(@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7))(@rspack/core@1.7.12)(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3))(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/theme-translations": 3.10.1
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-validation": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      algoliasearch: 5.55.2
-      algoliasearch-helper: 3.29.2(algoliasearch@5.55.2)
+      "@algolia/autocomplete-core": 1.19.9(@algolia/client-search@5.57.0)(algoliasearch@5.57.0)(search-insights@2.17.3)
+      "@docsearch/react": 4.7.0(@algolia/client-search@5.57.0)(@types/react@19.2.18)(algoliasearch@5.57.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(search-insights@2.17.3)
+      "@docusaurus/core": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/plugin-content-docs": 3.10.2(@docusaurus/faster@3.10.2(@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1))(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(postcss@8.5.26))(@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8))(@rspack/core@1.7.12)(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(debug@4.4.3(supports-color@8.1.1))(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)(typescript@6.0.3)
+      "@docusaurus/theme-common": 3.10.2(d03570d07bef42454ded4d347253a2eb)
+      "@docusaurus/theme-translations": 3.10.2
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-validation": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      algoliasearch: 5.57.0
+      algoliasearch-helper: 3.29.3(algoliasearch@5.57.0)
       clsx: 2.1.1
       eta: 2.2.0
-      fs-extra: 11.3.6
+      fs-extra: 11.4.0
       lodash: 4.18.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       tslib: 2.8.1
       utility-types: 3.11.0
     transitivePeerDependencies:
@@ -14964,26 +14892,26 @@ snapshots:
       - utf-8-validate
       - webpack-cli
 
-  "@docusaurus/theme-translations@3.10.1":
+  "@docusaurus/theme-translations@3.10.2":
     dependencies:
-      fs-extra: 11.3.6
+      fs-extra: 11.4.0
       tslib: 2.8.1
 
-  "@docusaurus/tsconfig@3.10.1": {}
+  "@docusaurus/tsconfig@3.10.2": {}
 
-  "@docusaurus/types@3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docusaurus/types@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)":
     dependencies:
-      "@mdx-js/mdx": 3.1.1
+      "@mdx-js/mdx": 3.1.1(supports-color@8.1.1)
       "@types/history": 4.7.11
       "@types/mdast": 4.0.4
-      "@types/react": 19.2.17
+      "@types/react": 19.2.18
       commander: 5.1.0
-      joi: 17.13.4
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)"
+      joi: 17.13.6
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)"
       utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
       webpack-merge: 5.10.0
     transitivePeerDependencies:
       - "@minify-html/node"
@@ -15001,39 +14929,9 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/types@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docusaurus/utils-common@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)":
     dependencies:
-      "@mdx-js/mdx": 3.1.1
-      "@types/history": 4.7.11
-      "@types/mdast": 4.0.4
-      "@types/react": 19.2.17
-      commander: 5.1.0
-      joi: 17.13.4
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      react-helmet-async: "@slorber/react-helmet-async@1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)"
-      utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
-      webpack-merge: 5.10.0
-    transitivePeerDependencies:
-      - "@minify-html/node"
-      - "@swc/core"
-      - "@swc/css"
-      - "@swc/html"
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  "@docusaurus/utils-common@3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
-    dependencies:
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       tslib: 2.8.1
     transitivePeerDependencies:
       - "@minify-html/node"
@@ -15053,36 +14951,14 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils-common@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docusaurus/utils-validation@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)":
     dependencies:
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      tslib: 2.8.1
-    transitivePeerDependencies:
-      - "@minify-html/node"
-      - "@swc/core"
-      - "@swc/css"
-      - "@swc/html"
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - react
-      - react-dom
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  "@docusaurus/utils-validation@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
-    dependencies:
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/utils": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-common": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      fs-extra: 11.3.6
-      joi: 17.13.4
-      js-yaml: 4.3.0
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/utils": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-common": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      fs-extra: 11.4.0
+      joi: 17.13.6
+      js-yaml: 4.3.1
       lodash: 4.18.1
       tslib: 2.8.1
     transitivePeerDependencies:
@@ -15103,29 +14979,29 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils@3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@docusaurus/utils@3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)":
     dependencies:
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-common": 3.10.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      "@11ty/gray-matter": 1.0.0
+      "@docusaurus/logger": 3.10.2
+      "@docusaurus/types": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
+      "@docusaurus/utils-common": 3.10.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      fs-extra: 11.3.6
+      file-loader: 6.2.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      fs-extra: 11.4.0
       github-slugger: 1.5.0
       globby: 11.1.0
-      gray-matter: 4.0.3
       jiti: 1.21.7
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       lodash: 4.18.1
       micromatch: 4.0.8
       p-queue: 6.6.2
       prompts: 2.4.2
       resolve-pathname: 3.0.0
       tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)))(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - "@minify-html/node"
       - "@swc/core"
@@ -15144,79 +15020,38 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  "@docusaurus/utils@3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@emnapi/core@1.11.3":
     dependencies:
-      "@docusaurus/logger": 3.10.1
-      "@docusaurus/types": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      "@docusaurus/utils-common": 3.10.1(@swc/core@1.15.43)(postcss@8.5.16)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      escape-string-regexp: 4.0.0
-      execa: 5.1.1
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      fs-extra: 11.3.6
-      github-slugger: 1.5.0
-      globby: 11.1.0
-      gray-matter: 4.0.3
-      jiti: 1.21.7
-      js-yaml: 4.3.0
-      lodash: 4.18.1
-      micromatch: 4.0.8
-      p-queue: 6.6.2
-      prompts: 2.4.2
-      resolve-pathname: 3.0.0
-      tslib: 2.8.1
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)))(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      utility-types: 3.11.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
-    transitivePeerDependencies:
-      - "@minify-html/node"
-      - "@swc/core"
-      - "@swc/css"
-      - "@swc/html"
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - react
-      - react-dom
-      - supports-color
-      - uglify-js
-      - webpack-cli
-
-  "@emnapi/core@1.11.1":
-    dependencies:
-      "@emnapi/wasi-threads": 1.2.2
+      "@emnapi/wasi-threads": 1.2.3
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/runtime@1.11.1":
+  "@emnapi/runtime@1.11.3":
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  "@emnapi/wasi-threads@1.2.2":
+  "@emnapi/wasi-threads@1.2.3":
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  "@eslint-community/eslint-utils@4.9.1(eslint@10.6.0(jiti@2.7.0))":
+  "@eslint-community/eslint-utils@4.10.1(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))":
     dependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   "@eslint-community/regexpp@4.12.2": {}
 
-  "@eslint/config-array@0.23.5":
+  "@eslint/config-array@0.23.5(supports-color@8.1.1)":
     dependencies:
       "@eslint/object-schema": 3.0.5
-      debug: 4.4.3
-      minimatch: 10.2.5
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.6
     transitivePeerDependencies:
       - supports-color
 
-  "@eslint/config-helpers@0.6.0":
+  "@eslint/config-helpers@0.7.0":
     dependencies:
       "@eslint/core": 1.2.1
 
@@ -15224,9 +15059,9 @@ snapshots:
     dependencies:
       "@types/json-schema": 7.0.15
 
-  "@eslint/js@10.0.1(eslint@10.6.0(jiti@2.7.0))":
+  "@eslint/js@10.0.1(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))":
     optionalDependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
 
   "@eslint/object-schema@3.0.5": {}
 
@@ -15237,22 +15072,22 @@ snapshots:
 
   "@exodus/bytes@1.15.1": {}
 
-  "@floating-ui/core@1.7.5":
+  "@floating-ui/core@1.8.0":
     dependencies:
-      "@floating-ui/utils": 0.2.11
+      "@floating-ui/utils": 0.2.12
 
-  "@floating-ui/dom@1.7.6":
+  "@floating-ui/dom@1.8.0":
     dependencies:
-      "@floating-ui/core": 1.7.5
-      "@floating-ui/utils": 0.2.11
+      "@floating-ui/core": 1.8.0
+      "@floating-ui/utils": 0.2.12
 
-  "@floating-ui/react-dom@2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@floating-ui/react-dom@2.1.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
-      "@floating-ui/dom": 1.7.6
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@floating-ui/dom": 1.8.0
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
-  "@floating-ui/utils@0.2.11": {}
+  "@floating-ui/utils@0.2.12": {}
 
   "@gerrit0/mini-shiki@3.23.0":
     dependencies:
@@ -15294,14 +15129,14 @@ snapshots:
 
   "@jest/schemas@29.6.3":
     dependencies:
-      "@sinclair/typebox": 0.27.10
+      "@sinclair/typebox": 0.27.12
 
   "@jest/types@29.6.3":
     dependencies:
       "@jest/schemas": 29.6.3
       "@types/istanbul-lib-coverage": 2.0.6
       "@types/istanbul-reports": 3.0.4
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
       "@types/yargs": 17.0.35
       chalk: 4.1.2
 
@@ -15336,11 +15171,11 @@ snapshots:
       ajv-formats: 2.1.1(ajv@8.20.0)
       lodash: 4.18.1
 
-  "@jsonforms/react@3.8.0(@jsonforms/core@3.8.0)(react@19.2.7)":
+  "@jsonforms/react@3.8.0(@jsonforms/core@3.8.0)(react@19.2.8)":
     dependencies:
       "@jsonforms/core": 3.8.0
       lodash: 4.18.1
-      react: 19.2.7
+      react: 19.2.8
 
   "@jsonjoy.com/base64@1.1.2(tslib@2.8.1)":
     dependencies:
@@ -15366,59 +15201,59 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  "@jsonjoy.com/fs-core@4.64.0(tslib@2.8.1)":
+  "@jsonjoy.com/fs-core@4.68.1(tslib@2.8.1)":
     dependencies:
-      "@jsonjoy.com/fs-node-builtins": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-utils": 4.64.0(tslib@2.8.1)
-      thingies: 2.6.0(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-builtins": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-utils": 4.68.1(tslib@2.8.1)
+      thingies: 2.6.1(tslib@2.8.1)
       tslib: 2.8.1
 
-  "@jsonjoy.com/fs-fsa@4.64.0(tslib@2.8.1)":
+  "@jsonjoy.com/fs-fsa@4.68.1(tslib@2.8.1)":
     dependencies:
-      "@jsonjoy.com/fs-core": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-builtins": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-utils": 4.64.0(tslib@2.8.1)
-      thingies: 2.6.0(tslib@2.8.1)
+      "@jsonjoy.com/fs-core": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-builtins": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-utils": 4.68.1(tslib@2.8.1)
+      thingies: 2.6.1(tslib@2.8.1)
       tslib: 2.8.1
 
-  "@jsonjoy.com/fs-node-builtins@4.64.0(tslib@2.8.1)":
+  "@jsonjoy.com/fs-node-builtins@4.68.1(tslib@2.8.1)":
     dependencies:
       tslib: 2.8.1
 
-  "@jsonjoy.com/fs-node-to-fsa@4.64.0(tslib@2.8.1)":
+  "@jsonjoy.com/fs-node-to-fsa@4.68.1(tslib@2.8.1)":
     dependencies:
-      "@jsonjoy.com/fs-fsa": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-builtins": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-utils": 4.64.0(tslib@2.8.1)
+      "@jsonjoy.com/fs-fsa": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-builtins": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-utils": 4.68.1(tslib@2.8.1)
       tslib: 2.8.1
 
-  "@jsonjoy.com/fs-node-utils@4.64.0(tslib@2.8.1)":
+  "@jsonjoy.com/fs-node-utils@4.68.1(tslib@2.8.1)":
     dependencies:
-      "@jsonjoy.com/fs-node-builtins": 4.64.0(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-builtins": 4.68.1(tslib@2.8.1)
       glob-to-regex.js: 1.2.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  "@jsonjoy.com/fs-node@4.64.0(tslib@2.8.1)":
+  "@jsonjoy.com/fs-node@4.68.1(tslib@2.8.1)":
     dependencies:
-      "@jsonjoy.com/fs-core": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-builtins": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-utils": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-print": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-snapshot": 4.64.0(tslib@2.8.1)
+      "@jsonjoy.com/fs-core": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-builtins": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-utils": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-print": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-snapshot": 4.68.1(tslib@2.8.1)
       glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      thingies: 2.6.0(tslib@2.8.1)
+      thingies: 2.6.1(tslib@2.8.1)
       tslib: 2.8.1
 
-  "@jsonjoy.com/fs-print@4.64.0(tslib@2.8.1)":
+  "@jsonjoy.com/fs-print@4.68.1(tslib@2.8.1)":
     dependencies:
-      "@jsonjoy.com/fs-node-utils": 4.64.0(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-utils": 4.68.1(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
-  "@jsonjoy.com/fs-snapshot@4.64.0(tslib@2.8.1)":
+  "@jsonjoy.com/fs-snapshot@4.68.1(tslib@2.8.1)":
     dependencies:
       "@jsonjoy.com/buffers": 17.67.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-utils": 4.64.0(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-utils": 4.68.1(tslib@2.8.1)
       "@jsonjoy.com/json-pack": 17.67.0(tslib@2.8.1)
       "@jsonjoy.com/util": 17.67.0(tslib@2.8.1)
       tslib: 2.8.1
@@ -15431,7 +15266,7 @@ snapshots:
       "@jsonjoy.com/json-pointer": 1.0.2(tslib@2.8.1)
       "@jsonjoy.com/util": 1.9.0(tslib@2.8.1)
       hyperdyperid: 1.2.0
-      thingies: 2.6.0(tslib@2.8.1)
+      thingies: 2.6.1(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -15443,7 +15278,7 @@ snapshots:
       "@jsonjoy.com/json-pointer": 17.67.0(tslib@2.8.1)
       "@jsonjoy.com/util": 17.67.0(tslib@2.8.1)
       hyperdyperid: 1.2.0
-      thingies: 2.6.0(tslib@2.8.1)
+      thingies: 2.6.1(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -15472,26 +15307,26 @@ snapshots:
 
   "@leichtgewicht/ip-codec@2.0.5": {}
 
-  "@mdx-js/mdx@3.1.1":
+  "@mdx-js/mdx@3.1.1(supports-color@8.1.1)":
     dependencies:
       "@types/estree": 1.0.9
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.5
       "@types/mdx": 2.0.14
-      acorn: 8.17.0
+      acorn: 8.18.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       estree-util-scope: 1.0.0
       estree-walker: 3.0.3
-      hast-util-to-jsx-runtime: 2.3.6
+      hast-util-to-jsx-runtime: 2.3.6(supports-color@8.1.1)
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.17.0)
+      recma-jsx: 1.0.1(acorn@8.18.0)
       recma-stringify: 1.0.0
-      rehype-recma: 1.0.0
-      remark-mdx: 3.1.1
-      remark-parse: 11.0.0
+      rehype-recma: 1.0.0(supports-color@8.1.1)
+      remark-mdx: 3.1.1(supports-color@8.1.1)
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-rehype: 11.1.2
       source-map: 0.7.6
       unified: 11.0.5
@@ -15502,33 +15337,33 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7)":
+  "@mdx-js/react@3.1.1(@types/react@19.2.18)(react@19.2.8)":
     dependencies:
       "@types/mdx": 2.0.14
-      "@types/react": 19.2.17
-      react: 19.2.7
+      "@types/react": 19.2.18
+      react: 19.2.8
 
-  "@mermaid-js/parser@1.2.0":
+  "@mermaid-js/parser@1.2.1":
     dependencies:
       "@chevrotain/types": 11.1.2
 
-  "@microsoft/api-extractor-model@7.33.8(@types/node@26.1.1)":
+  "@microsoft/api-extractor-model@7.33.11(@types/node@26.2.0)":
     dependencies:
       "@microsoft/tsdoc": 0.16.0
       "@microsoft/tsdoc-config": 0.18.1
-      "@rushstack/node-core-library": 5.23.1(@types/node@26.1.1)
+      "@rushstack/node-core-library": 5.24.0(@types/node@26.2.0)
     transitivePeerDependencies:
       - "@types/node"
 
-  "@microsoft/api-extractor@7.58.9(@types/node@26.1.1)":
+  "@microsoft/api-extractor@7.59.0(@types/node@26.2.0)":
     dependencies:
-      "@microsoft/api-extractor-model": 7.33.8(@types/node@26.1.1)
+      "@microsoft/api-extractor-model": 7.33.11(@types/node@26.2.0)
       "@microsoft/tsdoc": 0.16.0
       "@microsoft/tsdoc-config": 0.18.1
-      "@rushstack/node-core-library": 5.23.1(@types/node@26.1.1)
+      "@rushstack/node-core-library": 5.24.0(@types/node@26.2.0)
       "@rushstack/rig-package": 0.7.3
-      "@rushstack/terminal": 0.24.0(@types/node@26.1.1)
-      "@rushstack/ts-command-line": 5.3.10(@types/node@26.1.1)
+      "@rushstack/terminal": 0.24.3(@types/node@26.2.0)
+      "@rushstack/ts-command-line": 5.3.13(@types/node@26.2.0)
       diff: 8.0.4
       minimatch: 10.2.3
       resolve: 1.22.12
@@ -15574,15 +15409,8 @@ snapshots:
 
   "@napi-rs/wasm-runtime@1.0.7":
     dependencies:
-      "@emnapi/core": 1.11.1
-      "@emnapi/runtime": 1.11.1
-      "@tybys/wasm-util": 0.10.3
-    optional: true
-
-  "@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)":
-    dependencies:
-      "@emnapi/core": 1.11.1
-      "@emnapi/runtime": 1.11.1
+      "@emnapi/core": 1.11.3
+      "@emnapi/runtime": 1.11.3
       "@tybys/wasm-util": 0.10.3
     optional: true
 
@@ -15600,80 +15428,80 @@ snapshots:
       "@nodelib/fs.scandir": 2.1.5
       fastq: 1.20.1
 
-  "@oxc-project/types@0.139.0": {}
+  "@oxc-project/types@0.146.0": {}
 
-  "@peculiar/asn1-cms@2.8.0":
+  "@peculiar/asn1-cms@2.9.4":
     dependencies:
-      "@peculiar/asn1-schema": 2.8.0
-      "@peculiar/asn1-x509": 2.8.0
-      "@peculiar/asn1-x509-attr": 2.8.0
+      "@peculiar/asn1-schema": 2.9.4
+      "@peculiar/asn1-x509": 2.9.4
+      "@peculiar/asn1-x509-attr": 2.9.4
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  "@peculiar/asn1-csr@2.8.0":
+  "@peculiar/asn1-csr@2.9.4":
     dependencies:
-      "@peculiar/asn1-schema": 2.8.0
-      "@peculiar/asn1-x509": 2.8.0
+      "@peculiar/asn1-schema": 2.9.4
+      "@peculiar/asn1-x509": 2.9.4
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  "@peculiar/asn1-ecc@2.8.0":
+  "@peculiar/asn1-ecc@2.9.4":
     dependencies:
-      "@peculiar/asn1-schema": 2.8.0
-      "@peculiar/asn1-x509": 2.8.0
+      "@peculiar/asn1-schema": 2.9.4
+      "@peculiar/asn1-x509": 2.9.4
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  "@peculiar/asn1-pfx@2.8.0":
+  "@peculiar/asn1-pfx@2.9.4":
     dependencies:
-      "@peculiar/asn1-cms": 2.8.0
-      "@peculiar/asn1-pkcs8": 2.8.0
-      "@peculiar/asn1-rsa": 2.8.0
-      "@peculiar/asn1-schema": 2.8.0
+      "@peculiar/asn1-cms": 2.9.4
+      "@peculiar/asn1-pkcs8": 2.9.4
+      "@peculiar/asn1-rsa": 2.9.4
+      "@peculiar/asn1-schema": 2.9.4
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  "@peculiar/asn1-pkcs8@2.8.0":
+  "@peculiar/asn1-pkcs8@2.9.4":
     dependencies:
-      "@peculiar/asn1-schema": 2.8.0
-      "@peculiar/asn1-x509": 2.8.0
+      "@peculiar/asn1-schema": 2.9.4
+      "@peculiar/asn1-x509": 2.9.4
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  "@peculiar/asn1-pkcs9@2.8.0":
+  "@peculiar/asn1-pkcs9@2.9.4":
     dependencies:
-      "@peculiar/asn1-cms": 2.8.0
-      "@peculiar/asn1-pfx": 2.8.0
-      "@peculiar/asn1-pkcs8": 2.8.0
-      "@peculiar/asn1-schema": 2.8.0
-      "@peculiar/asn1-x509": 2.8.0
-      "@peculiar/asn1-x509-attr": 2.8.0
+      "@peculiar/asn1-cms": 2.9.4
+      "@peculiar/asn1-pfx": 2.9.4
+      "@peculiar/asn1-pkcs8": 2.9.4
+      "@peculiar/asn1-schema": 2.9.4
+      "@peculiar/asn1-x509": 2.9.4
+      "@peculiar/asn1-x509-attr": 2.9.4
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  "@peculiar/asn1-rsa@2.8.0":
+  "@peculiar/asn1-rsa@2.9.4":
     dependencies:
-      "@peculiar/asn1-schema": 2.8.0
-      "@peculiar/asn1-x509": 2.8.0
+      "@peculiar/asn1-schema": 2.9.4
+      "@peculiar/asn1-x509": 2.9.4
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  "@peculiar/asn1-schema@2.8.0":
+  "@peculiar/asn1-schema@2.9.4":
     dependencies:
       "@peculiar/utils": 2.0.3
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  "@peculiar/asn1-x509-attr@2.8.0":
+  "@peculiar/asn1-x509-attr@2.9.4":
     dependencies:
-      "@peculiar/asn1-schema": 2.8.0
-      "@peculiar/asn1-x509": 2.8.0
+      "@peculiar/asn1-schema": 2.9.4
+      "@peculiar/asn1-x509": 2.9.4
       asn1js: 3.0.10
       tslib: 2.8.1
 
-  "@peculiar/asn1-x509@2.8.0":
+  "@peculiar/asn1-x509@2.9.4":
     dependencies:
-      "@peculiar/asn1-schema": 2.8.0
+      "@peculiar/asn1-schema": 2.9.4
       "@peculiar/utils": 2.0.3
       asn1js: 3.0.10
       tslib: 2.8.1
@@ -15684,13 +15512,13 @@ snapshots:
 
   "@peculiar/x509@1.14.3":
     dependencies:
-      "@peculiar/asn1-cms": 2.8.0
-      "@peculiar/asn1-csr": 2.8.0
-      "@peculiar/asn1-ecc": 2.8.0
-      "@peculiar/asn1-pkcs9": 2.8.0
-      "@peculiar/asn1-rsa": 2.8.0
-      "@peculiar/asn1-schema": 2.8.0
-      "@peculiar/asn1-x509": 2.8.0
+      "@peculiar/asn1-cms": 2.9.4
+      "@peculiar/asn1-csr": 2.9.4
+      "@peculiar/asn1-ecc": 2.9.4
+      "@peculiar/asn1-pkcs9": 2.9.4
+      "@peculiar/asn1-rsa": 2.9.4
+      "@peculiar/asn1-schema": 2.9.4
+      "@peculiar/asn1-x509": 2.9.4
       pvtsutils: 1.3.6
       reflect-metadata: 0.2.2
       tslib: 2.8.1
@@ -15712,53 +15540,49 @@ snapshots:
 
   "@preact/signals-core@1.14.4": {}
 
-  "@rolldown/binding-android-arm64@1.1.5":
+  "@rolldown/binding-android-arm-eabi@1.2.5":
     optional: true
 
-  "@rolldown/binding-darwin-arm64@1.1.5":
+  "@rolldown/binding-android-arm64@1.2.5":
     optional: true
 
-  "@rolldown/binding-darwin-x64@1.1.5":
+  "@rolldown/binding-darwin-arm64@1.2.5":
     optional: true
 
-  "@rolldown/binding-freebsd-x64@1.1.5":
+  "@rolldown/binding-darwin-x64@1.2.5":
     optional: true
 
-  "@rolldown/binding-linux-arm-gnueabihf@1.1.5":
+  "@rolldown/binding-freebsd-x64@1.2.5":
     optional: true
 
-  "@rolldown/binding-linux-arm64-gnu@1.1.5":
+  "@rolldown/binding-linux-arm-gnueabihf@1.2.5":
     optional: true
 
-  "@rolldown/binding-linux-arm64-musl@1.1.5":
+  "@rolldown/binding-linux-arm64-gnu@1.2.5":
     optional: true
 
-  "@rolldown/binding-linux-ppc64-gnu@1.1.5":
+  "@rolldown/binding-linux-arm64-musl@1.2.5":
     optional: true
 
-  "@rolldown/binding-linux-s390x-gnu@1.1.5":
+  "@rolldown/binding-linux-ppc64-gnu@1.2.5":
     optional: true
 
-  "@rolldown/binding-linux-x64-gnu@1.1.5":
+  "@rolldown/binding-linux-s390x-gnu@1.2.5":
     optional: true
 
-  "@rolldown/binding-linux-x64-musl@1.1.5":
+  "@rolldown/binding-linux-x64-gnu@1.2.5":
     optional: true
 
-  "@rolldown/binding-openharmony-arm64@1.1.5":
+  "@rolldown/binding-linux-x64-musl@1.2.5":
     optional: true
 
-  "@rolldown/binding-wasm32-wasi@1.1.5":
-    dependencies:
-      "@emnapi/core": 1.11.1
-      "@emnapi/runtime": 1.11.1
-      "@napi-rs/wasm-runtime": 1.1.6(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)
+  "@rolldown/binding-openharmony-arm64@1.2.5":
     optional: true
 
-  "@rolldown/binding-win32-arm64-msvc@1.1.5":
+  "@rolldown/binding-win32-arm64-msvc@1.2.5":
     optional: true
 
-  "@rolldown/binding-win32-x64-msvc@1.1.5":
+  "@rolldown/binding-win32-x64-msvc@1.2.5":
     optional: true
 
   "@rolldown/pluginutils@1.0.1": {}
@@ -15822,39 +15646,39 @@ snapshots:
 
   "@rspack/lite-tapable@1.1.0": {}
 
-  "@rushstack/node-core-library@5.23.1(@types/node@26.1.1)":
+  "@rushstack/node-core-library@5.24.0(@types/node@26.2.0)":
     dependencies:
-      ajv: 8.18.0
-      ajv-draft-04: 1.0.0(ajv@8.18.0)
-      ajv-formats: 3.0.1(ajv@8.18.0)
+      ajv: 8.20.0
+      ajv-draft-04: 1.0.0(ajv@8.20.0)
+      ajv-formats: 3.0.1(ajv@8.20.0)
       fs-extra: 11.3.6
       import-lazy: 4.0.0
       jju: 1.4.0
       resolve: 1.22.12
       semver: 7.7.4
     optionalDependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
-  "@rushstack/problem-matcher@0.2.1(@types/node@26.1.1)":
+  "@rushstack/problem-matcher@0.2.1(@types/node@26.2.0)":
     optionalDependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@rushstack/rig-package@0.7.3":
     dependencies:
       jju: 1.4.0
       resolve: 1.22.12
 
-  "@rushstack/terminal@0.24.0(@types/node@26.1.1)":
+  "@rushstack/terminal@0.24.3(@types/node@26.2.0)":
     dependencies:
-      "@rushstack/node-core-library": 5.23.1(@types/node@26.1.1)
-      "@rushstack/problem-matcher": 0.2.1(@types/node@26.1.1)
+      "@rushstack/node-core-library": 5.24.0(@types/node@26.2.0)
+      "@rushstack/problem-matcher": 0.2.1(@types/node@26.2.0)
       supports-color: 8.1.1
     optionalDependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
-  "@rushstack/ts-command-line@5.3.10(@types/node@26.1.1)":
+  "@rushstack/ts-command-line@5.3.13(@types/node@26.2.0)":
     dependencies:
-      "@rushstack/terminal": 0.24.0(@types/node@26.1.1)
+      "@rushstack/terminal": 0.24.3(@types/node@26.2.0)
       "@types/argparse": 1.0.38
       argparse: 1.0.10
       string-argv: 0.3.2
@@ -15889,19 +15713,19 @@ snapshots:
 
   "@sideway/pinpoint@2.0.0": {}
 
-  "@sinclair/typebox@0.27.10": {}
+  "@sinclair/typebox@0.27.12": {}
 
   "@sindresorhus/is@4.6.0": {}
 
   "@sindresorhus/is@5.6.0": {}
 
-  "@slorber/react-helmet-async@1.3.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@slorber/react-helmet-async@1.3.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@babel/runtime": 7.29.7
       invariant: 2.2.4
       prop-types: 15.8.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
       react-fast-compare: 3.2.2
       shallowequal: 1.1.0
 
@@ -15913,54 +15737,54 @@ snapshots:
 
   "@standard-schema/spec@1.1.0": {}
 
-  "@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7)":
+  "@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
 
-  "@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7)":
+  "@svgr/babel-plugin-remove-jsx-attribute@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
 
-  "@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7)":
+  "@svgr/babel-plugin-remove-jsx-empty-expression@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
 
-  "@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7)":
+  "@svgr/babel-plugin-replace-jsx-attribute-value@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
 
-  "@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7)":
+  "@svgr/babel-plugin-svg-dynamic-title@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
 
-  "@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7)":
+  "@svgr/babel-plugin-svg-em-dimensions@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
 
-  "@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7)":
+  "@svgr/babel-plugin-transform-react-native-svg@8.1.0(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
 
-  "@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7)":
+  "@svgr/babel-plugin-transform-svg-component@8.0.0(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
 
-  "@svgr/babel-preset@8.1.0(@babel/core@7.29.7)":
+  "@svgr/babel-preset@8.1.0(@babel/core@7.29.7(supports-color@8.1.1))":
     dependencies:
-      "@babel/core": 7.29.7
-      "@svgr/babel-plugin-add-jsx-attribute": 8.0.0(@babel/core@7.29.7)
-      "@svgr/babel-plugin-remove-jsx-attribute": 8.0.0(@babel/core@7.29.7)
-      "@svgr/babel-plugin-remove-jsx-empty-expression": 8.0.0(@babel/core@7.29.7)
-      "@svgr/babel-plugin-replace-jsx-attribute-value": 8.0.0(@babel/core@7.29.7)
-      "@svgr/babel-plugin-svg-dynamic-title": 8.0.0(@babel/core@7.29.7)
-      "@svgr/babel-plugin-svg-em-dimensions": 8.0.0(@babel/core@7.29.7)
-      "@svgr/babel-plugin-transform-react-native-svg": 8.1.0(@babel/core@7.29.7)
-      "@svgr/babel-plugin-transform-svg-component": 8.0.0(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@svgr/babel-plugin-add-jsx-attribute": 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      "@svgr/babel-plugin-remove-jsx-attribute": 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      "@svgr/babel-plugin-remove-jsx-empty-expression": 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      "@svgr/babel-plugin-replace-jsx-attribute-value": 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      "@svgr/babel-plugin-svg-dynamic-title": 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      "@svgr/babel-plugin-svg-em-dimensions": 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
+      "@svgr/babel-plugin-transform-react-native-svg": 8.1.0(@babel/core@7.29.7(supports-color@8.1.1))
+      "@svgr/babel-plugin-transform-svg-component": 8.0.0(@babel/core@7.29.7(supports-color@8.1.1))
 
-  "@svgr/core@8.1.0(typescript@6.0.3)":
+  "@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@svgr/babel-preset": 8.1.0(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@svgr/babel-preset": 8.1.0(@babel/core@7.29.7(supports-color@8.1.1))
       camelcase: 6.3.0
       cosmiconfig: 8.3.6(typescript@6.0.3)
       snake-case: 3.0.4
@@ -15970,152 +15794,152 @@ snapshots:
 
   "@svgr/hast-util-to-babel-ast@8.0.0":
     dependencies:
-      "@babel/types": 7.29.7
+      "@babel/types": 7.29.8
       entities: 4.5.0
 
-  "@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))":
+  "@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(supports-color@8.1.1)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@svgr/babel-preset": 8.1.0(@babel/core@7.29.7)
-      "@svgr/core": 8.1.0(typescript@6.0.3)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@svgr/babel-preset": 8.1.0(@babel/core@7.29.7(supports-color@8.1.1))
+      "@svgr/core": 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
       "@svgr/hast-util-to-babel-ast": 8.0.0
-      svg-parser: 2.0.4
+      svg-parser: 2.0.5
     transitivePeerDependencies:
       - supports-color
 
-  "@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)":
+  "@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(typescript@6.0.3)":
     dependencies:
-      "@svgr/core": 8.1.0(typescript@6.0.3)
+      "@svgr/core": 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
       cosmiconfig: 8.3.6(typescript@6.0.3)
       deepmerge: 4.3.1
-      svgo: 3.3.3
+      svgo: 3.3.4
     transitivePeerDependencies:
       - typescript
 
-  "@svgr/webpack@8.1.0(typescript@6.0.3)":
+  "@svgr/webpack@8.1.0(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/plugin-transform-react-constant-elements": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-env": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-react": 7.29.7(@babel/core@7.29.7)
-      "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7)
-      "@svgr/core": 8.1.0(typescript@6.0.3)
-      "@svgr/plugin-jsx": 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))
-      "@svgr/plugin-svgo": 8.1.0(@svgr/core@8.1.0(typescript@6.0.3))(typescript@6.0.3)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/plugin-transform-react-constant-elements": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))
+      "@babel/preset-env": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/preset-react": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@babel/preset-typescript": 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      "@svgr/core": 8.1.0(supports-color@8.1.1)(typescript@6.0.3)
+      "@svgr/plugin-jsx": 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(supports-color@8.1.1)
+      "@svgr/plugin-svgo": 8.1.0(@svgr/core@8.1.0(supports-color@8.1.1)(typescript@6.0.3))(typescript@6.0.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  "@swc/core-darwin-arm64@1.15.43":
+  "@swc/core-darwin-arm64@1.16.1":
     optional: true
 
-  "@swc/core-darwin-x64@1.15.43":
+  "@swc/core-darwin-x64@1.16.1":
     optional: true
 
-  "@swc/core-linux-arm-gnueabihf@1.15.43":
+  "@swc/core-linux-arm-gnueabihf@1.16.1":
     optional: true
 
-  "@swc/core-linux-arm64-gnu@1.15.43":
+  "@swc/core-linux-arm64-gnu@1.16.1":
     optional: true
 
-  "@swc/core-linux-arm64-musl@1.15.43":
+  "@swc/core-linux-arm64-musl@1.16.1":
     optional: true
 
-  "@swc/core-linux-ppc64-gnu@1.15.43":
+  "@swc/core-linux-ppc64-gnu@1.16.1":
     optional: true
 
-  "@swc/core-linux-s390x-gnu@1.15.43":
+  "@swc/core-linux-s390x-gnu@1.16.1":
     optional: true
 
-  "@swc/core-linux-x64-gnu@1.15.43":
+  "@swc/core-linux-x64-gnu@1.16.1":
     optional: true
 
-  "@swc/core-linux-x64-musl@1.15.43":
+  "@swc/core-linux-x64-musl@1.16.1":
     optional: true
 
-  "@swc/core-win32-arm64-msvc@1.15.43":
+  "@swc/core-win32-arm64-msvc@1.16.1":
     optional: true
 
-  "@swc/core-win32-ia32-msvc@1.15.43":
+  "@swc/core-win32-ia32-msvc@1.16.1":
     optional: true
 
-  "@swc/core-win32-x64-msvc@1.15.43":
+  "@swc/core-win32-x64-msvc@1.16.1":
     optional: true
 
-  "@swc/core@1.15.43":
+  "@swc/core@1.16.1":
     dependencies:
       "@swc/counter": 0.1.3
-      "@swc/types": 0.1.27
+      "@swc/types": 0.1.28
     optionalDependencies:
-      "@swc/core-darwin-arm64": 1.15.43
-      "@swc/core-darwin-x64": 1.15.43
-      "@swc/core-linux-arm-gnueabihf": 1.15.43
-      "@swc/core-linux-arm64-gnu": 1.15.43
-      "@swc/core-linux-arm64-musl": 1.15.43
-      "@swc/core-linux-ppc64-gnu": 1.15.43
-      "@swc/core-linux-s390x-gnu": 1.15.43
-      "@swc/core-linux-x64-gnu": 1.15.43
-      "@swc/core-linux-x64-musl": 1.15.43
-      "@swc/core-win32-arm64-msvc": 1.15.43
-      "@swc/core-win32-ia32-msvc": 1.15.43
-      "@swc/core-win32-x64-msvc": 1.15.43
+      "@swc/core-darwin-arm64": 1.16.1
+      "@swc/core-darwin-x64": 1.16.1
+      "@swc/core-linux-arm-gnueabihf": 1.16.1
+      "@swc/core-linux-arm64-gnu": 1.16.1
+      "@swc/core-linux-arm64-musl": 1.16.1
+      "@swc/core-linux-ppc64-gnu": 1.16.1
+      "@swc/core-linux-s390x-gnu": 1.16.1
+      "@swc/core-linux-x64-gnu": 1.16.1
+      "@swc/core-linux-x64-musl": 1.16.1
+      "@swc/core-win32-arm64-msvc": 1.16.1
+      "@swc/core-win32-ia32-msvc": 1.16.1
+      "@swc/core-win32-x64-msvc": 1.16.1
 
   "@swc/counter@0.1.3": {}
 
-  "@swc/html-darwin-arm64@1.15.43":
+  "@swc/html-darwin-arm64@1.16.1":
     optional: true
 
-  "@swc/html-darwin-x64@1.15.43":
+  "@swc/html-darwin-x64@1.16.1":
     optional: true
 
-  "@swc/html-linux-arm-gnueabihf@1.15.43":
+  "@swc/html-linux-arm-gnueabihf@1.16.1":
     optional: true
 
-  "@swc/html-linux-arm64-gnu@1.15.43":
+  "@swc/html-linux-arm64-gnu@1.16.1":
     optional: true
 
-  "@swc/html-linux-arm64-musl@1.15.43":
+  "@swc/html-linux-arm64-musl@1.16.1":
     optional: true
 
-  "@swc/html-linux-ppc64-gnu@1.15.43":
+  "@swc/html-linux-ppc64-gnu@1.16.1":
     optional: true
 
-  "@swc/html-linux-s390x-gnu@1.15.43":
+  "@swc/html-linux-s390x-gnu@1.16.1":
     optional: true
 
-  "@swc/html-linux-x64-gnu@1.15.43":
+  "@swc/html-linux-x64-gnu@1.16.1":
     optional: true
 
-  "@swc/html-linux-x64-musl@1.15.43":
+  "@swc/html-linux-x64-musl@1.16.1":
     optional: true
 
-  "@swc/html-win32-arm64-msvc@1.15.43":
+  "@swc/html-win32-arm64-msvc@1.16.1":
     optional: true
 
-  "@swc/html-win32-ia32-msvc@1.15.43":
+  "@swc/html-win32-ia32-msvc@1.16.1":
     optional: true
 
-  "@swc/html-win32-x64-msvc@1.15.43":
+  "@swc/html-win32-x64-msvc@1.16.1":
     optional: true
 
-  "@swc/html@1.15.43":
+  "@swc/html@1.16.1":
     dependencies:
       "@swc/counter": 0.1.3
     optionalDependencies:
-      "@swc/html-darwin-arm64": 1.15.43
-      "@swc/html-darwin-x64": 1.15.43
-      "@swc/html-linux-arm-gnueabihf": 1.15.43
-      "@swc/html-linux-arm64-gnu": 1.15.43
-      "@swc/html-linux-arm64-musl": 1.15.43
-      "@swc/html-linux-ppc64-gnu": 1.15.43
-      "@swc/html-linux-s390x-gnu": 1.15.43
-      "@swc/html-linux-x64-gnu": 1.15.43
-      "@swc/html-linux-x64-musl": 1.15.43
-      "@swc/html-win32-arm64-msvc": 1.15.43
-      "@swc/html-win32-ia32-msvc": 1.15.43
-      "@swc/html-win32-x64-msvc": 1.15.43
+      "@swc/html-darwin-arm64": 1.16.1
+      "@swc/html-darwin-x64": 1.16.1
+      "@swc/html-linux-arm-gnueabihf": 1.16.1
+      "@swc/html-linux-arm64-gnu": 1.16.1
+      "@swc/html-linux-arm64-musl": 1.16.1
+      "@swc/html-linux-ppc64-gnu": 1.16.1
+      "@swc/html-linux-s390x-gnu": 1.16.1
+      "@swc/html-linux-x64-gnu": 1.16.1
+      "@swc/html-linux-x64-musl": 1.16.1
+      "@swc/html-win32-arm64-msvc": 1.16.1
+      "@swc/html-win32-ia32-msvc": 1.16.1
+      "@swc/html-win32-x64-msvc": 1.16.1
 
-  "@swc/types@0.1.27":
+  "@swc/types@0.1.28":
     dependencies:
       "@swc/counter": 0.1.3
 
@@ -16123,101 +15947,101 @@ snapshots:
     dependencies:
       defer-to-connect: 2.0.1
 
-  "@tailwindcss/node@4.3.2":
+  "@tailwindcss/node@4.3.3":
     dependencies:
       "@jridgewell/remapping": 2.3.5
-      enhanced-resolve: 5.21.6
+      enhanced-resolve: 5.24.5
       jiti: 2.7.0
       lightningcss: 1.32.0
       magic-string: 0.30.21
       source-map-js: 1.2.1
-      tailwindcss: 4.3.2
+      tailwindcss: 4.3.3
 
-  "@tailwindcss/oxide-android-arm64@4.3.2":
+  "@tailwindcss/oxide-android-arm64@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-darwin-arm64@4.3.2":
+  "@tailwindcss/oxide-darwin-arm64@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-darwin-x64@4.3.2":
+  "@tailwindcss/oxide-darwin-x64@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-freebsd-x64@4.3.2":
+  "@tailwindcss/oxide-freebsd-x64@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-linux-arm-gnueabihf@4.3.2":
+  "@tailwindcss/oxide-linux-arm-gnueabihf@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-linux-arm64-gnu@4.3.2":
+  "@tailwindcss/oxide-linux-arm64-gnu@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-linux-arm64-musl@4.3.2":
+  "@tailwindcss/oxide-linux-arm64-musl@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-linux-x64-gnu@4.3.2":
+  "@tailwindcss/oxide-linux-x64-gnu@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-linux-x64-musl@4.3.2":
+  "@tailwindcss/oxide-linux-x64-musl@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-wasm32-wasi@4.3.2":
+  "@tailwindcss/oxide-wasm32-wasi@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-win32-arm64-msvc@4.3.2":
+  "@tailwindcss/oxide-win32-arm64-msvc@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide-win32-x64-msvc@4.3.2":
+  "@tailwindcss/oxide-win32-x64-msvc@4.3.3":
     optional: true
 
-  "@tailwindcss/oxide@4.3.2":
+  "@tailwindcss/oxide@4.3.3":
     optionalDependencies:
-      "@tailwindcss/oxide-android-arm64": 4.3.2
-      "@tailwindcss/oxide-darwin-arm64": 4.3.2
-      "@tailwindcss/oxide-darwin-x64": 4.3.2
-      "@tailwindcss/oxide-freebsd-x64": 4.3.2
-      "@tailwindcss/oxide-linux-arm-gnueabihf": 4.3.2
-      "@tailwindcss/oxide-linux-arm64-gnu": 4.3.2
-      "@tailwindcss/oxide-linux-arm64-musl": 4.3.2
-      "@tailwindcss/oxide-linux-x64-gnu": 4.3.2
-      "@tailwindcss/oxide-linux-x64-musl": 4.3.2
-      "@tailwindcss/oxide-wasm32-wasi": 4.3.2
-      "@tailwindcss/oxide-win32-arm64-msvc": 4.3.2
-      "@tailwindcss/oxide-win32-x64-msvc": 4.3.2
+      "@tailwindcss/oxide-android-arm64": 4.3.3
+      "@tailwindcss/oxide-darwin-arm64": 4.3.3
+      "@tailwindcss/oxide-darwin-x64": 4.3.3
+      "@tailwindcss/oxide-freebsd-x64": 4.3.3
+      "@tailwindcss/oxide-linux-arm-gnueabihf": 4.3.3
+      "@tailwindcss/oxide-linux-arm64-gnu": 4.3.3
+      "@tailwindcss/oxide-linux-arm64-musl": 4.3.3
+      "@tailwindcss/oxide-linux-x64-gnu": 4.3.3
+      "@tailwindcss/oxide-linux-x64-musl": 4.3.3
+      "@tailwindcss/oxide-wasm32-wasi": 4.3.3
+      "@tailwindcss/oxide-win32-arm64-msvc": 4.3.3
+      "@tailwindcss/oxide-win32-x64-msvc": 4.3.3
 
-  "@tailwindcss/vite@4.3.2(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))":
+  "@tailwindcss/vite@4.3.3(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))":
     dependencies:
-      "@tailwindcss/node": 4.3.2
-      "@tailwindcss/oxide": 4.3.2
-      tailwindcss: 4.3.2
-      vite: 8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
+      "@tailwindcss/node": 4.3.3
+      "@tailwindcss/oxide": 4.3.3
+      tailwindcss: 4.3.3
+      vite: 8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
 
-  "@tanstack/react-table@8.21.3(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
       "@tanstack/table-core": 8.21.3
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
-  "@tanstack/react-virtual@3.14.5(react-dom@19.2.7(react@19.2.7))(react@19.2.7)":
+  "@tanstack/react-virtual@3.14.10(react-dom@19.2.8(react@19.2.8))(react@19.2.8)":
     dependencies:
-      "@tanstack/virtual-core": 3.17.3
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      "@tanstack/virtual-core": 3.17.8
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
   "@tanstack/table-core@8.21.3": {}
 
-  "@tanstack/virtual-core@3.17.3": {}
+  "@tanstack/virtual-core@3.17.8": {}
 
-  "@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.9.4)":
+  "@trivago/prettier-plugin-sort-imports@6.0.2(prettier@3.9.6)(supports-color@8.1.1)":
     dependencies:
-      "@babel/generator": 7.29.7
-      "@babel/parser": 7.29.7
-      "@babel/traverse": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/generator": 7.29.8
+      "@babel/parser": 7.29.8
+      "@babel/traverse": 7.29.8(supports-color@8.1.1)
+      "@babel/types": 7.29.8
       javascript-natural-sort: 0.7.1
       lodash-es: 4.18.1
       minimatch: 9.0.9
       parse-imports-exports: 0.2.4
-      prettier: 3.9.4
+      prettier: 3.9.6
     transitivePeerDependencies:
       - supports-color
 
@@ -16231,11 +16055,11 @@ snapshots:
   "@types/body-parser@1.19.6":
     dependencies:
       "@types/connect": 3.4.38
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/bonjour@3.5.13":
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/chai@5.2.3":
     dependencies:
@@ -16245,11 +16069,11 @@ snapshots:
   "@types/connect-history-api-fallback@1.5.4":
     dependencies:
       "@types/express-serve-static-core": 4.19.9
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/connect@3.4.38":
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/d3-array@3.2.2": {}
 
@@ -16290,7 +16114,7 @@ snapshots:
 
   "@types/d3-format@3.0.4": {}
 
-  "@types/d3-geo@3.1.0":
+  "@types/d3-geo@3.1.1":
     dependencies:
       "@types/geojson": 7946.0.16
 
@@ -16316,7 +16140,7 @@ snapshots:
 
   "@types/d3-selection@3.0.11": {}
 
-  "@types/d3-shape@3.1.8":
+  "@types/d3-shape@3.2.0":
     dependencies:
       "@types/d3-path": 3.1.1
 
@@ -16351,7 +16175,7 @@ snapshots:
       "@types/d3-fetch": 3.0.7
       "@types/d3-force": 3.0.10
       "@types/d3-format": 3.0.4
-      "@types/d3-geo": 3.1.0
+      "@types/d3-geo": 3.1.1
       "@types/d3-hierarchy": 3.1.7
       "@types/d3-interpolate": 3.0.4
       "@types/d3-path": 3.1.1
@@ -16361,7 +16185,7 @@ snapshots:
       "@types/d3-scale": 4.0.9
       "@types/d3-scale-chromatic": 3.1.0
       "@types/d3-selection": 3.0.11
-      "@types/d3-shape": 3.1.8
+      "@types/d3-shape": 3.2.0
       "@types/d3-time": 3.0.4
       "@types/d3-time-format": 4.0.3
       "@types/d3-timer": 3.0.2
@@ -16384,7 +16208,7 @@ snapshots:
 
   "@types/express-serve-static-core@4.19.9":
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
       "@types/qs": 6.15.1
       "@types/range-parser": 1.2.7
       "@types/send": 1.2.1
@@ -16397,8 +16221,6 @@ snapshots:
       "@types/serve-static": 1.15.10
 
   "@types/geojson@7946.0.16": {}
-
-  "@types/gtag.js@0.0.20": {}
 
   "@types/hast@3.0.5":
     dependencies:
@@ -16414,7 +16236,7 @@ snapshots:
 
   "@types/http-proxy@1.17.17":
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/istanbul-lib-coverage@2.0.6": {}
 
@@ -16440,13 +16262,13 @@ snapshots:
 
   "@types/node@17.0.45": {}
 
-  "@types/node@26.1.1":
+  "@types/node@26.2.0":
     dependencies:
       undici-types: 8.3.0
 
   "@types/papaparse@5.5.2":
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/prismjs@1.26.6": {}
 
@@ -16454,28 +16276,28 @@ snapshots:
 
   "@types/range-parser@1.2.7": {}
 
-  "@types/react-dom@19.2.3(@types/react@19.2.17)":
+  "@types/react-dom@19.2.4(@types/react@19.2.18)":
     dependencies:
-      "@types/react": 19.2.17
+      "@types/react": 19.2.18
 
   "@types/react-router-config@5.0.11":
     dependencies:
       "@types/history": 4.7.11
-      "@types/react": 19.2.17
+      "@types/react": 19.2.18
       "@types/react-router": 5.1.20
 
   "@types/react-router-dom@5.3.3":
     dependencies:
       "@types/history": 4.7.11
-      "@types/react": 19.2.17
+      "@types/react": 19.2.18
       "@types/react-router": 5.1.20
 
   "@types/react-router@5.1.20":
     dependencies:
       "@types/history": 4.7.11
-      "@types/react": 19.2.17
+      "@types/react": 19.2.18
 
-  "@types/react@19.2.17":
+  "@types/react@19.2.18":
     dependencies:
       csstype: 3.2.3
 
@@ -16483,16 +16305,16 @@ snapshots:
 
   "@types/sax@1.2.7":
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/send@0.17.6":
     dependencies:
       "@types/mime": 1.3.5
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/send@1.2.1":
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/serve-index@1.9.4":
     dependencies:
@@ -16501,12 +16323,12 @@ snapshots:
   "@types/serve-static@1.15.10":
     dependencies:
       "@types/http-errors": 2.0.5
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
       "@types/send": 0.17.6
 
   "@types/sockjs@0.3.36":
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/trusted-types@2.0.7":
     optional: true
@@ -16517,7 +16339,7 @@ snapshots:
 
   "@types/ws@8.18.1":
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
 
   "@types/yargs-parser@21.0.3": {}
 
@@ -16525,74 +16347,74 @@ snapshots:
     dependencies:
       "@types/yargs-parser": 21.0.3
 
-  "@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)":
+  "@typescript-eslint/eslint-plugin@8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
       "@eslint-community/regexpp": 4.12.2
-      "@typescript-eslint/parser": 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      "@typescript-eslint/scope-manager": 8.63.0
-      "@typescript-eslint/type-utils": 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      "@typescript-eslint/visitor-keys": 8.63.0
-      eslint: 10.6.0(jiti@2.7.0)
-      ignore: 7.0.5
+      "@typescript-eslint/parser": 8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      "@typescript-eslint/scope-manager": 8.67.0
+      "@typescript-eslint/type-utils": 8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      "@typescript-eslint/visitor-keys": 8.67.0
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
+      ignore: 7.0.6
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/parser@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)":
+  "@typescript-eslint/parser@8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/scope-manager": 8.63.0
-      "@typescript-eslint/types": 8.63.0
-      "@typescript-eslint/typescript-estree": 8.63.0(typescript@6.0.3)
-      "@typescript-eslint/visitor-keys": 8.63.0
-      debug: 4.4.3
-      eslint: 10.6.0(jiti@2.7.0)
+      "@typescript-eslint/scope-manager": 8.67.0
+      "@typescript-eslint/types": 8.67.0
+      "@typescript-eslint/typescript-estree": 8.67.0(supports-color@8.1.1)(typescript@6.0.3)
+      "@typescript-eslint/visitor-keys": 8.67.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/project-service@8.63.0(typescript@6.0.3)":
+  "@typescript-eslint/project-service@8.67.0(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/tsconfig-utils": 8.63.0(typescript@6.0.3)
-      "@typescript-eslint/types": 8.63.0
-      debug: 4.4.3
+      "@typescript-eslint/tsconfig-utils": 8.67.0(typescript@6.0.3)
+      "@typescript-eslint/types": 8.67.0
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/scope-manager@8.63.0":
+  "@typescript-eslint/scope-manager@8.67.0":
     dependencies:
-      "@typescript-eslint/types": 8.63.0
-      "@typescript-eslint/visitor-keys": 8.63.0
+      "@typescript-eslint/types": 8.67.0
+      "@typescript-eslint/visitor-keys": 8.67.0
 
-  "@typescript-eslint/tsconfig-utils@8.63.0(typescript@6.0.3)":
+  "@typescript-eslint/tsconfig-utils@8.67.0(typescript@6.0.3)":
     dependencies:
       typescript: 6.0.3
 
-  "@typescript-eslint/type-utils@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)":
+  "@typescript-eslint/type-utils@8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/types": 8.63.0
-      "@typescript-eslint/typescript-estree": 8.63.0(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      debug: 4.4.3
-      eslint: 10.6.0(jiti@2.7.0)
+      "@typescript-eslint/types": 8.67.0
+      "@typescript-eslint/typescript-estree": 8.67.0(supports-color@8.1.1)(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/types@8.63.0": {}
+  "@typescript-eslint/types@8.67.0": {}
 
-  "@typescript-eslint/typescript-estree@8.63.0(typescript@6.0.3)":
+  "@typescript-eslint/typescript-estree@8.67.0(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@typescript-eslint/project-service": 8.63.0(typescript@6.0.3)
-      "@typescript-eslint/tsconfig-utils": 8.63.0(typescript@6.0.3)
-      "@typescript-eslint/types": 8.63.0
-      "@typescript-eslint/visitor-keys": 8.63.0
-      debug: 4.4.3
-      minimatch: 10.2.5
+      "@typescript-eslint/project-service": 8.67.0(supports-color@8.1.1)(typescript@6.0.3)
+      "@typescript-eslint/tsconfig-utils": 8.67.0(typescript@6.0.3)
+      "@typescript-eslint/types": 8.67.0
+      "@typescript-eslint/visitor-keys": 8.67.0
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.6
       semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -16600,88 +16422,88 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/utils@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)":
+  "@typescript-eslint/utils@8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)":
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.6.0(jiti@2.7.0))
-      "@typescript-eslint/scope-manager": 8.63.0
-      "@typescript-eslint/types": 8.63.0
-      "@typescript-eslint/typescript-estree": 8.63.0(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      "@eslint-community/eslint-utils": 4.10.1(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))
+      "@typescript-eslint/scope-manager": 8.67.0
+      "@typescript-eslint/types": 8.67.0
+      "@typescript-eslint/typescript-estree": 8.67.0(supports-color@8.1.1)(typescript@6.0.3)
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  "@typescript-eslint/visitor-keys@8.63.0":
+  "@typescript-eslint/visitor-keys@8.67.0":
     dependencies:
-      "@typescript-eslint/types": 8.63.0
+      "@typescript-eslint/types": 8.67.0
       eslint-visitor-keys: 5.0.1
 
-  "@ungap/structured-clone@1.3.2": {}
+  "@ungap/structured-clone@1.3.3": {}
 
   "@upsetjs/venn.js@2.0.0":
     optionalDependencies:
       d3-selection: 3.0.0
       d3-transition: 3.0.1(d3-selection@3.0.0)
 
-  "@vitejs/plugin-react@6.0.3(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))":
+  "@vitejs/plugin-react@6.1.0(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))":
     dependencies:
       "@rolldown/pluginutils": 1.0.1
-      vite: 8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
 
-  "@vitest/coverage-v8@4.1.10(vitest@4.1.10)":
+  "@vitest/coverage-v8@4.1.11(vitest@4.1.11)":
     dependencies:
       "@bcoe/v8-coverage": 1.0.2
-      "@vitest/utils": 4.1.10
-      ast-v8-to-istanbul: 1.0.4
+      "@vitest/utils": 4.1.11
+      ast-v8-to-istanbul: 1.0.5
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
       istanbul-reports: 3.2.0
-      magicast: 0.5.3
-      obug: 2.1.3
+      magicast: 0.5.4
+      obug: 2.1.4
       std-env: 4.2.0
-      tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(canvas@3.2.3))(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
+      tinyrainbow: 3.1.1
+      vitest: 4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(canvas@3.2.3))(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
 
-  "@vitest/expect@4.1.10":
+  "@vitest/expect@4.1.11":
     dependencies:
       "@standard-schema/spec": 1.1.0
       "@types/chai": 5.2.3
-      "@vitest/spy": 4.1.10
-      "@vitest/utils": 4.1.10
+      "@vitest/spy": 4.1.11
+      "@vitest/utils": 4.1.11
       chai: 6.2.2
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
-  "@vitest/mocker@4.1.10(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))":
+  "@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))":
     dependencies:
-      "@vitest/spy": 4.1.10
+      "@vitest/spy": 4.1.11
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
 
-  "@vitest/pretty-format@4.1.10":
+  "@vitest/pretty-format@4.1.11":
     dependencies:
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
-  "@vitest/runner@4.1.10":
+  "@vitest/runner@4.1.11":
     dependencies:
-      "@vitest/utils": 4.1.10
+      "@vitest/utils": 4.1.11
       pathe: 2.0.3
 
-  "@vitest/snapshot@4.1.10":
+  "@vitest/snapshot@4.1.11":
     dependencies:
-      "@vitest/pretty-format": 4.1.10
-      "@vitest/utils": 4.1.10
+      "@vitest/pretty-format": 4.1.11
+      "@vitest/utils": 4.1.11
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  "@vitest/spy@4.1.10": {}
+  "@vitest/spy@4.1.11": {}
 
-  "@vitest/utils@4.1.10":
+  "@vitest/utils@4.1.11":
     dependencies:
-      "@vitest/pretty-format": 4.1.10
+      "@vitest/pretty-format": 4.1.11
       convert-source-map: 2.0.0
-      tinyrainbow: 3.1.0
+      tinyrainbow: 3.1.1
 
   "@volar/language-core@2.4.28":
     dependencies:
@@ -16790,38 +16612,34 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-import-phases@1.0.4(acorn@8.17.0):
+  acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:
-      acorn: 8.17.0
-
-  acorn-jsx@5.3.2(acorn@8.17.0):
-    dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
 
   acorn-walk@8.3.5:
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
 
-  acorn@8.17.0: {}
+  acorn@8.18.0: {}
 
-  address@1.2.2: {}
+  address@2.0.3: {}
 
   aggregate-error@3.1.0:
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
 
-  ajv-draft-04@1.0.0(ajv@8.18.0):
+  ajv-draft-04@1.0.0(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-formats@2.1.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
 
-  ajv-formats@3.0.1(ajv@8.18.0):
+  ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
-      ajv: 8.18.0
+      ajv: 8.20.0
 
   ajv-keywords@3.5.2(ajv@6.15.0):
     dependencies:
@@ -16842,52 +16660,48 @@ snapshots:
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.3
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
-  algoliasearch-helper@3.29.2(algoliasearch@5.55.2):
+  algoliasearch-helper@3.29.3(algoliasearch@5.57.0):
     dependencies:
       "@algolia/events": 4.0.1
-      algoliasearch: 5.55.2
+      algoliasearch: 5.57.0
 
-  algoliasearch@5.55.2:
+  algoliasearch@5.57.0:
     dependencies:
-      "@algolia/abtesting": 1.21.2
-      "@algolia/client-abtesting": 5.55.2
-      "@algolia/client-analytics": 5.55.2
-      "@algolia/client-common": 5.55.2
-      "@algolia/client-insights": 5.55.2
-      "@algolia/client-personalization": 5.55.2
-      "@algolia/client-query-suggestions": 5.55.2
-      "@algolia/client-search": 5.55.2
-      "@algolia/ingestion": 1.55.2
-      "@algolia/monitoring": 1.55.2
-      "@algolia/recommend": 5.55.2
-      "@algolia/requester-browser-xhr": 5.55.2
-      "@algolia/requester-fetch": 5.55.2
-      "@algolia/requester-node-http": 5.55.2
+      "@algolia/abtesting": 1.23.0
+      "@algolia/client-abtesting": 5.57.0
+      "@algolia/client-analytics": 5.57.0
+      "@algolia/client-common": 5.57.0
+      "@algolia/client-insights": 5.57.0
+      "@algolia/client-personalization": 5.57.0
+      "@algolia/client-query-suggestions": 5.57.0
+      "@algolia/client-search": 5.57.0
+      "@algolia/ingestion": 1.57.0
+      "@algolia/monitoring": 1.57.0
+      "@algolia/recommend": 5.57.0
+      "@algolia/requester-browser-xhr": 5.57.0
+      "@algolia/requester-fetch": 5.57.0
+      "@algolia/requester-node-http": 5.57.0
 
   ansi-align@3.0.1:
     dependencies:
       string-width: 4.2.3
 
-  ansi-escapes@7.3.0:
-    dependencies:
-      environment: 1.1.0
-
   ansi-html-community@0.0.8: {}
 
   ansi-regex@5.0.1: {}
 
-  ansi-regex@6.2.2: {}
+  ansi-regex@6.3.0: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -16917,12 +16731,12 @@ snapshots:
   asn1js@3.0.10:
     dependencies:
       pvtsutils: 1.3.6
-      pvutils: 1.1.5
+      pvutils: 1.2.0
       tslib: 2.8.1
 
   assertion-error@2.0.1: {}
 
-  ast-v8-to-istanbul@1.0.4:
+  ast-v8-to-istanbul@1.0.5:
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       estree-walker: 3.0.3
@@ -16930,55 +16744,55 @@ snapshots:
 
   astring@1.9.0: {}
 
-  autoprefixer@10.5.2(postcss@8.5.16):
+  autoprefixer@10.5.4(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.5
-      caniuse-lite: 1.0.30001803
+      browserslist: 4.28.8
+      caniuse-lite: 1.0.30001809
       fraction.js: 5.3.4
       picocolors: 1.1.1
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  babel-loader@9.2.1(@babel/core@7.29.7)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  babel-loader@9.2.1(@babel/core@7.29.7(supports-color@8.1.1))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
-      "@babel/core": 7.29.7
+      "@babel/core": 7.29.7(supports-color@8.1.1)
       find-cache-dir: 4.0.0
       schema-utils: 4.3.3
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
   babel-plugin-dynamic-import-node@2.3.3:
     dependencies:
       object.assign: 4.1.7
 
-  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7):
+  babel-plugin-polyfill-corejs2@0.4.17(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       "@babel/compat-data": 7.29.7
-      "@babel/core": 7.29.7
-      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7):
+  babel-plugin-polyfill-corejs3@0.13.0(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7)
-      core-js-compat: 3.49.0
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      core-js-compat: 3.50.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7):
+  babel-plugin-polyfill-corejs3@0.14.2(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7)
-      core-js-compat: 3.49.0
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
+      core-js-compat: 3.50.0
     transitivePeerDependencies:
       - supports-color
 
-  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7):
+  babel-plugin-polyfill-regenerator@0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/helper-define-polyfill-provider": 0.6.8(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16990,7 +16804,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.42: {}
+  baseline-browser-mapping@2.11.17: {}
 
   batch@0.6.1: {}
 
@@ -17008,11 +16822,11 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  body-parser@1.20.6:
+  body-parser@1.20.6(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.1
@@ -17025,7 +16839,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  bonjour-service@1.4.3:
+  bonjour-service@1.4.4:
     dependencies:
       fast-deep-equal: 3.1.3
       multicast-dns: 7.2.5
@@ -17054,16 +16868,16 @@ snapshots:
       widest-line: 4.0.1
       wrap-ansi: 8.1.0
 
-  brace-expansion@1.1.16:
+  brace-expansion@1.1.18:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -17071,13 +16885,13 @@ snapshots:
     dependencies:
       fill-range: 7.1.1
 
-  browserslist@4.28.5:
+  browserslist@4.28.8:
     dependencies:
-      baseline-browser-mapping: 2.10.42
-      caniuse-lite: 1.0.30001803
-      electron-to-chromium: 1.5.389
-      node-releases: 2.0.51
-      update-browserslist-db: 1.2.3(browserslist@4.28.5)
+      baseline-browser-mapping: 2.11.17
+      caniuse-lite: 1.0.30001809
+      electron-to-chromium: 1.5.412
+      node-releases: 2.0.53
+      update-browserslist-db: 1.3.1(browserslist@4.28.8)
 
   buffer-from@1.1.2: {}
 
@@ -17138,12 +16952,12 @@ snapshots:
 
   caniuse-api@3.0.0:
     dependencies:
-      browserslist: 4.28.5
-      caniuse-lite: 1.0.30001803
+      browserslist: 4.28.8
+      caniuse-lite: 1.0.30001809
       lodash.memoize: 4.1.2
       lodash.uniq: 4.5.0
 
-  caniuse-lite@1.0.30001803: {}
+  caniuse-lite@1.0.30001809: {}
 
   canvas@3.2.3:
     dependencies:
@@ -17220,20 +17034,11 @@ snapshots:
 
   cli-boxes@3.0.0: {}
 
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
   cli-table3@0.6.5:
     dependencies:
       string-width: 4.2.3
     optionalDependencies:
       "@colors/colors": 1.5.0
-
-  cli-truncate@5.2.0:
-    dependencies:
-      slice-ansi: 8.0.0
-      string-width: 8.2.2
 
   clone-deep@4.0.1:
     dependencies:
@@ -17251,7 +17056,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  colord@2.9.3: {}
+  colord@2.10.0: {}
 
   colorette@2.0.20: {}
 
@@ -17277,11 +17082,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1:
+  compression@1.8.1(supports-color@8.1.1):
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -17328,7 +17133,7 @@ snapshots:
 
   copy-text-to-clipboard@3.2.2: {}
 
-  copy-webpack-plugin@11.0.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  copy-webpack-plugin@11.0.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       fast-glob: 3.3.3
       glob-parent: 6.0.2
@@ -17336,13 +17141,13 @@ snapshots:
       normalize-path: 3.0.0
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
-  core-js-compat@3.49.0:
+  core-js-compat@3.50.0:
     dependencies:
-      browserslist: 4.28.5
+      browserslist: 4.28.8
 
-  core-js@3.49.0: {}
+  core-js@3.50.0: {}
 
   core-util-is@1.0.3: {}
 
@@ -17357,7 +17162,7 @@ snapshots:
   cosmiconfig@8.3.6(typescript@6.0.3):
     dependencies:
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
     optionalDependencies:
@@ -17373,51 +17178,53 @@ snapshots:
     dependencies:
       type-fest: 1.4.0
 
-  css-blank-pseudo@7.0.1(postcss@8.5.16):
+  css-blank-pseudo@7.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  css-declaration-sorter@7.4.0(postcss@8.5.16):
+  css-declaration-sorter@7.4.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  css-has-pseudo@7.0.3(postcss@8.5.16):
+  css-has-pseudo@7.0.3(postcss@8.5.26):
     dependencies:
-      "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.4)
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.5)
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
       postcss-value-parser: 4.2.0
 
-  css-loader@6.11.0(@rspack/core@1.7.12)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  css-loader@6.11.0(@rspack/core@1.7.12)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.16)
-      postcss: 8.5.16
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.16)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.16)
-      postcss-modules-scope: 3.2.1(postcss@8.5.16)
-      postcss-modules-values: 4.0.0(postcss@8.5.16)
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.26)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.26)
+      postcss-modules-scope: 3.2.1(postcss@8.5.26)
+      postcss-modules-values: 4.0.0(postcss@8.5.26)
       postcss-value-parser: 4.2.0
       semver: 7.8.5
     optionalDependencies:
       "@rspack/core": 1.7.12
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
-  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  css-minimizer-webpack-plugin@5.0.1(clean-css@5.3.3)(csso@5.0.5)(lightningcss@1.33.0)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
-      cssnano: 6.1.2(postcss@8.5.16)
+      cssnano: 6.1.2(postcss@8.5.26)
       jest-worker: 29.7.0
-      postcss: 8.5.16
+      postcss: 8.5.26
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     optionalDependencies:
       clean-css: 5.3.3
+      csso: 5.0.5
+      lightningcss: 1.33.0
 
-  css-prefers-color-scheme@10.0.0(postcss@8.5.16):
+  css-prefers-color-scheme@10.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
   css-select@4.3.0:
     dependencies:
@@ -17452,64 +17259,64 @@ snapshots:
 
   css-what@6.2.2: {}
 
-  cssdb@8.9.0: {}
+  cssdb@8.10.0: {}
 
   cssesc@3.0.0: {}
 
-  cssnano-preset-advanced@6.1.2(postcss@8.5.16):
+  cssnano-preset-advanced@6.1.2(postcss@8.5.26):
     dependencies:
-      autoprefixer: 10.5.2(postcss@8.5.16)
-      browserslist: 4.28.5
-      cssnano-preset-default: 6.1.2(postcss@8.5.16)
-      postcss: 8.5.16
-      postcss-discard-unused: 6.0.5(postcss@8.5.16)
-      postcss-merge-idents: 6.0.3(postcss@8.5.16)
-      postcss-reduce-idents: 6.0.3(postcss@8.5.16)
-      postcss-zindex: 6.0.2(postcss@8.5.16)
+      autoprefixer: 10.5.4(postcss@8.5.26)
+      browserslist: 4.28.8
+      cssnano-preset-default: 6.1.2(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-discard-unused: 6.0.5(postcss@8.5.26)
+      postcss-merge-idents: 6.0.3(postcss@8.5.26)
+      postcss-reduce-idents: 6.0.3(postcss@8.5.26)
+      postcss-zindex: 6.0.2(postcss@8.5.26)
 
-  cssnano-preset-default@6.1.2(postcss@8.5.16):
+  cssnano-preset-default@6.1.2(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.5
-      css-declaration-sorter: 7.4.0(postcss@8.5.16)
-      cssnano-utils: 4.0.2(postcss@8.5.16)
-      postcss: 8.5.16
-      postcss-calc: 9.0.1(postcss@8.5.16)
-      postcss-colormin: 6.1.0(postcss@8.5.16)
-      postcss-convert-values: 6.1.0(postcss@8.5.16)
-      postcss-discard-comments: 6.0.2(postcss@8.5.16)
-      postcss-discard-duplicates: 6.0.3(postcss@8.5.16)
-      postcss-discard-empty: 6.0.3(postcss@8.5.16)
-      postcss-discard-overridden: 6.0.2(postcss@8.5.16)
-      postcss-merge-longhand: 6.0.5(postcss@8.5.16)
-      postcss-merge-rules: 6.1.1(postcss@8.5.16)
-      postcss-minify-font-values: 6.1.0(postcss@8.5.16)
-      postcss-minify-gradients: 6.0.3(postcss@8.5.16)
-      postcss-minify-params: 6.1.0(postcss@8.5.16)
-      postcss-minify-selectors: 6.0.4(postcss@8.5.16)
-      postcss-normalize-charset: 6.0.2(postcss@8.5.16)
-      postcss-normalize-display-values: 6.0.2(postcss@8.5.16)
-      postcss-normalize-positions: 6.0.2(postcss@8.5.16)
-      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.16)
-      postcss-normalize-string: 6.0.2(postcss@8.5.16)
-      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.16)
-      postcss-normalize-unicode: 6.1.0(postcss@8.5.16)
-      postcss-normalize-url: 6.0.2(postcss@8.5.16)
-      postcss-normalize-whitespace: 6.0.2(postcss@8.5.16)
-      postcss-ordered-values: 6.0.2(postcss@8.5.16)
-      postcss-reduce-initial: 6.1.0(postcss@8.5.16)
-      postcss-reduce-transforms: 6.0.2(postcss@8.5.16)
-      postcss-svgo: 6.0.3(postcss@8.5.16)
-      postcss-unique-selectors: 6.0.4(postcss@8.5.16)
+      browserslist: 4.28.8
+      css-declaration-sorter: 7.4.0(postcss@8.5.26)
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-calc: 9.0.1(postcss@8.5.26)
+      postcss-colormin: 6.1.0(postcss@8.5.26)
+      postcss-convert-values: 6.1.0(postcss@8.5.26)
+      postcss-discard-comments: 6.0.2(postcss@8.5.26)
+      postcss-discard-duplicates: 6.0.3(postcss@8.5.26)
+      postcss-discard-empty: 6.0.3(postcss@8.5.26)
+      postcss-discard-overridden: 6.0.2(postcss@8.5.26)
+      postcss-merge-longhand: 6.0.5(postcss@8.5.26)
+      postcss-merge-rules: 6.1.1(postcss@8.5.26)
+      postcss-minify-font-values: 6.1.0(postcss@8.5.26)
+      postcss-minify-gradients: 6.0.3(postcss@8.5.26)
+      postcss-minify-params: 6.1.0(postcss@8.5.26)
+      postcss-minify-selectors: 6.0.4(postcss@8.5.26)
+      postcss-normalize-charset: 6.0.2(postcss@8.5.26)
+      postcss-normalize-display-values: 6.0.2(postcss@8.5.26)
+      postcss-normalize-positions: 6.0.2(postcss@8.5.26)
+      postcss-normalize-repeat-style: 6.0.2(postcss@8.5.26)
+      postcss-normalize-string: 6.0.2(postcss@8.5.26)
+      postcss-normalize-timing-functions: 6.0.2(postcss@8.5.26)
+      postcss-normalize-unicode: 6.1.0(postcss@8.5.26)
+      postcss-normalize-url: 6.0.2(postcss@8.5.26)
+      postcss-normalize-whitespace: 6.0.2(postcss@8.5.26)
+      postcss-ordered-values: 6.0.2(postcss@8.5.26)
+      postcss-reduce-initial: 6.1.0(postcss@8.5.26)
+      postcss-reduce-transforms: 6.0.2(postcss@8.5.26)
+      postcss-svgo: 6.0.3(postcss@8.5.26)
+      postcss-unique-selectors: 6.0.4(postcss@8.5.26)
 
-  cssnano-utils@4.0.2(postcss@8.5.16):
+  cssnano-utils@4.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  cssnano@6.1.2(postcss@8.5.16):
+  cssnano@6.1.2(postcss@8.5.26):
     dependencies:
-      cssnano-preset-default: 6.1.2(postcss@8.5.16)
+      cssnano-preset-default: 6.1.2(postcss@8.5.26)
       lilconfig: 3.1.3
-      postcss: 8.5.16
+      postcss: 8.5.26
 
   csso@5.0.5:
     dependencies:
@@ -17517,17 +17324,17 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.1):
     dependencies:
       cose-base: 1.0.3
-      cytoscape: 3.34.0
+      cytoscape: 3.34.1
 
-  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+  cytoscape-fcose@2.2.0(cytoscape@3.34.1):
     dependencies:
       cose-base: 2.2.0
-      cytoscape: 3.34.0
+      cytoscape: 3.34.1
 
-  cytoscape@3.34.0: {}
+  cytoscape@3.34.1: {}
 
   d3-array@2.12.1:
     dependencies:
@@ -17708,17 +17515,21 @@ snapshots:
     transitivePeerDependencies:
       - "@noble/hashes"
 
-  dayjs@1.11.21: {}
+  dayjs@1.11.23: {}
 
   debounce@1.2.1: {}
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@8.1.1):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 8.1.1
 
-  debug@4.4.3:
+  debug@4.4.3(supports-color@8.1.1):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 8.1.1
 
   decimal.js@10.6.0: {}
 
@@ -17738,7 +17549,7 @@ snapshots:
 
   default-browser-id@5.0.1: {}
 
-  default-browser@5.5.0:
+  default-browser@5.5.1:
     dependencies:
       bundle-name: 4.1.0
       default-browser-id: 5.0.1
@@ -17777,12 +17588,9 @@ snapshots:
 
   detect-node@2.1.0: {}
 
-  detect-port@1.6.1:
+  detect-port@2.1.0:
     dependencies:
-      address: 1.2.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
+      address: 2.0.3
 
   devlop@1.1.0:
     dependencies:
@@ -17798,17 +17606,17 @@ snapshots:
     dependencies:
       "@leichtgewicht/ip-codec": 2.0.5
 
-  dockview-core@7.0.2: {}
+  dockview-core@7.0.4: {}
 
-  dockview-react@7.0.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  dockview-react@7.0.4(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      dockview: 7.0.2
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      dockview: 7.0.4
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
-  dockview@7.0.2:
+  dockview@7.0.4:
     dependencies:
-      dockview-core: 7.0.2
+      dockview-core: 7.0.4
 
   docusaurus-plugin-typedoc@1.4.2(typedoc-plugin-markdown@4.12.0(typedoc@0.28.20(typescript@6.0.3))):
     dependencies:
@@ -17841,7 +17649,7 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
-  dompurify@3.4.11:
+  dompurify@3.4.14:
     optionalDependencies:
       "@types/trusted-types": 2.0.7
 
@@ -17878,9 +17686,7 @@ snapshots:
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.389: {}
-
-  emoji-regex@10.6.0: {}
+  electron-to-chromium@1.5.412: {}
 
   emoji-regex@8.0.0: {}
 
@@ -17898,12 +17704,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enhanced-resolve@5.21.6:
-    dependencies:
-      graceful-fs: 4.2.11
-      tapable: 2.3.3
-
-  enhanced-resolve@5.24.2:
+  enhanced-resolve@5.24.5:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.3.3
@@ -17916,8 +17717,6 @@ snapshots:
 
   entities@8.0.0: {}
 
-  environment@1.1.0: {}
-
   error-ex@1.3.4:
     dependencies:
       is-arrayish: 0.2.1
@@ -17926,13 +17725,13 @@ snapshots:
 
   es-errors@1.3.0: {}
 
-  es-module-lexer@2.3.0: {}
+  es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.2:
     dependencies:
       es-errors: 1.3.0
 
-  es-toolkit@1.49.0: {}
+  es-toolkit@1.51.0: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -17944,7 +17743,7 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       "@types/estree-jsx": 1.0.5
-      acorn: 8.17.0
+      acorn: 8.18.0
       esast-util-from-estree: 2.0.0
       vfile-message: 4.0.3
 
@@ -17958,24 +17757,24 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.6.0(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
 
-  eslint-plugin-react-hooks@7.1.1(eslint@10.6.0(jiti@2.7.0)):
+  eslint-plugin-react-hooks@7.1.1(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      "@babel/core": 7.29.7
-      "@babel/parser": 7.29.7
-      eslint: 10.6.0(jiti@2.7.0)
+      "@babel/core": 7.29.7(supports-color@8.1.1)
+      "@babel/parser": 7.29.8
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
       hermes-parser: 0.25.1
       zod: 4.4.3
       zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react-refresh@0.5.3(eslint@10.6.0(jiti@2.7.0)):
+  eslint-plugin-react-refresh@0.5.4(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.6.0(jiti@2.7.0)
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
 
   eslint-scope@5.1.1:
     dependencies:
@@ -17993,12 +17792,12 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.6.0(jiti@2.7.0):
+  eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1):
     dependencies:
-      "@eslint-community/eslint-utils": 4.9.1(eslint@10.6.0(jiti@2.7.0))
+      "@eslint-community/eslint-utils": 4.10.1(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))
       "@eslint-community/regexpp": 4.12.2
-      "@eslint/config-array": 0.23.5
-      "@eslint/config-helpers": 0.6.0
+      "@eslint/config-array": 0.23.5(supports-color@8.1.1)
+      "@eslint/config-helpers": 0.7.0
       "@eslint/core": 1.2.1
       "@eslint/plugin-kit": 0.7.2
       "@humanfs/node": 0.16.8
@@ -18007,7 +17806,7 @@ snapshots:
       "@types/estree": 1.0.9
       ajv: 6.15.0
       cross-spawn: 7.0.6
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
@@ -18022,7 +17821,7 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -18032,11 +17831,9 @@ snapshots:
 
   espree@11.2.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       eslint-visitor-keys: 5.0.1
-
-  esprima@4.0.1: {}
 
   esquery@1.7.0:
     dependencies:
@@ -18097,12 +17894,10 @@ snapshots:
 
   eval@0.1.8:
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
       require-like: 0.1.2
 
   eventemitter3@4.0.7: {}
-
-  eventemitter3@5.0.4: {}
 
   events@3.3.0: {}
 
@@ -18122,21 +17917,21 @@ snapshots:
 
   expect-type@1.4.0: {}
 
-  express@4.22.2:
+  express@4.22.2(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.6
+      body-parser: 1.20.6(supports-color@8.1.1)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.0.7
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.2
+      finalhandler: 1.3.2(supports-color@8.1.1)
       fresh: 0.5.2
       http-errors: 2.0.1
       merge-descriptors: 1.0.3
@@ -18148,8 +17943,8 @@ snapshots:
       qs: 6.15.3
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.2
-      serve-static: 1.16.3
+      send: 0.19.2(supports-color@8.1.1)
+      serve-static: 1.16.3(supports-color@8.1.1)
       setprototypeof: 1.2.0
       statuses: 2.0.2
       type-is: 1.6.18
@@ -18158,7 +17953,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  exsolve@1.1.0: {}
+  exsolve@1.1.1: {}
 
   extend-shallow@2.0.1:
     dependencies:
@@ -18182,7 +17977,11 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
-  fast-uri@3.1.3: {}
+  fast-uri@3.1.5: {}
+
+  fastdom@1.0.12:
+    dependencies:
+      strictdom: 1.0.1
 
   fastq@1.20.1:
     dependencies:
@@ -18210,19 +18009,19 @@ snapshots:
     dependencies:
       flat-cache: 4.0.1
 
-  file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.2:
+  finalhandler@1.3.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -18249,14 +18048,16 @@ snapshots:
 
   flat-cache@4.0.1:
     dependencies:
-      flatted: 3.4.2
+      flatted: 3.4.4
       keyv: 4.5.4
 
   flat@5.0.2: {}
 
-  flatted@3.4.2: {}
+  flatted@3.4.4: {}
 
-  follow-redirects@1.16.0: {}
+  follow-redirects@1.16.0(debug@4.4.3(supports-color@8.1.1)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@8.1.1)
 
   form-data-encoder@2.1.4: {}
 
@@ -18276,6 +18077,12 @@ snapshots:
       jsonfile: 6.2.1
       universalify: 2.0.1
 
+  fs-extra@11.4.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fsevents@2.3.3:
     optional: true
 
@@ -18284,10 +18091,6 @@ snapshots:
   fzstd@0.1.1: {}
 
   gensync@1.0.0-beta.2: {}
-
-  geojson@0.5.0: {}
-
-  get-east-asian-width@1.6.0: {}
 
   get-intrinsic@1.3.0:
     dependencies:
@@ -18333,7 +18136,7 @@ snapshots:
     dependencies:
       ini: 2.0.0
 
-  globals@17.7.0: {}
+  globals@17.11.0: {}
 
   globby@11.1.0:
     dependencies:
@@ -18371,13 +18174,6 @@ snapshots:
   graceful-fs@4.2.10: {}
 
   graceful-fs@4.2.11: {}
-
-  gray-matter@4.0.3:
-    dependencies:
-      js-yaml: 3.15.0
-      kind-of: 6.0.3
-      section-matter: 1.0.0
-      strip-bom-string: 1.0.0
 
   gzip-size@6.0.0:
     dependencies:
@@ -18420,7 +18216,7 @@ snapshots:
     dependencies:
       "@types/hast": 3.0.5
       "@types/unist": 3.0.3
-      "@ungap/structured-clone": 1.3.2
+      "@ungap/structured-clone": 1.3.3
       hast-util-from-parse5: 8.0.3
       hast-util-to-parse5: 8.0.1
       html-void-elements: 3.0.0
@@ -18432,7 +18228,7 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
-  hast-util-to-estree@3.1.3:
+  hast-util-to-estree@3.1.3(supports-color@8.1.1):
     dependencies:
       "@types/estree": 1.0.9
       "@types/estree-jsx": 1.0.5
@@ -18442,9 +18238,9 @@ snapshots:
       estree-util-attach-comments: 3.0.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -18453,7 +18249,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-jsx-runtime@2.3.6:
+  hast-util-to-jsx-runtime@2.3.6(supports-color@8.1.1):
     dependencies:
       "@types/estree": 1.0.9
       "@types/hast": 3.0.5
@@ -18462,9 +18258,9 @@ snapshots:
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
       hast-util-whitespace: 3.0.0
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       property-information: 7.2.0
       space-separated-tokens: 2.0.2
       style-to-js: 1.1.21
@@ -18539,7 +18335,7 @@ snapshots:
       he: 1.2.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.49.0
+      terser: 5.50.0
 
   html-minifier-terser@7.2.0:
     dependencies:
@@ -18549,13 +18345,13 @@ snapshots:
       entities: 4.5.0
       param-case: 3.0.4
       relateurl: 0.2.7
-      terser: 5.49.0
+      terser: 5.50.0
 
   html-tags@3.3.1: {}
 
   html-void-elements@3.0.0: {}
 
-  html-webpack-plugin@5.6.7(@rspack/core@1.7.12)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  html-webpack-plugin@5.6.8(@rspack/core@1.7.12)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       "@types/html-minifier-terser": 6.1.0
       html-minifier-terser: 6.1.0
@@ -18564,7 +18360,7 @@ snapshots:
       tapable: 2.3.3
     optionalDependencies:
       "@rspack/core": 1.7.12
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
   htmlparser2@6.1.0:
     dependencies:
@@ -18602,10 +18398,10 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-middleware@2.0.10(@types/express@4.17.25):
+  http-proxy-middleware@2.0.10(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       "@types/http-proxy": 1.17.17
-      http-proxy: 1.18.1
+      http-proxy: 1.18.1(debug@4.4.3(supports-color@8.1.1))
       is-glob: 4.0.3
       is-plain-obj: 3.0.0
       micromatch: 4.0.8
@@ -18614,10 +18410,10 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  http-proxy@1.18.1:
+  http-proxy@1.18.1(debug@4.4.3(supports-color@8.1.1)):
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.4.3(supports-color@8.1.1))
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -18636,7 +18432,7 @@ snapshots:
       fzstd: 0.1.1
       hysnappy: 1.0.0
 
-  hyparquet@1.26.2: {}
+  hyparquet@1.29.1: {}
 
   hyperdyperid@1.2.0: {}
 
@@ -18650,19 +18446,19 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
-  icss-utils@5.1.0(postcss@8.5.16):
+  icss-utils@5.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
 
-  ignore@7.0.5: {}
+  ignore@7.0.6: {}
 
   image-size@2.0.2: {}
 
-  immer@11.1.11: {}
+  immer@11.1.18: {}
 
   import-fresh@3.3.1:
     dependencies:
@@ -18697,7 +18493,7 @@ snapshots:
 
   ipaddr.js@1.9.1: {}
 
-  ipaddr.js@2.4.0: {}
+  ipaddr.js@2.5.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -18731,10 +18527,6 @@ snapshots:
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
-
-  is-fullwidth-code-point@5.1.0:
-    dependencies:
-      get-east-asian-width: 1.6.0
 
   is-glob@4.0.3:
     dependencies:
@@ -18815,7 +18607,7 @@ snapshots:
   jest-util@29.7.0:
     dependencies:
       "@jest/types": 29.6.3
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
       chalk: 4.1.2
       ci-info: 3.9.0
       graceful-fs: 4.2.11
@@ -18823,13 +18615,13 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
   jest-worker@29.7.0:
     dependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -18840,7 +18632,7 @@ snapshots:
 
   jju@1.4.0: {}
 
-  joi@17.13.4:
+  joi@17.13.6:
     dependencies:
       "@hapi/hoek": 9.3.0
       "@hapi/topo": 5.1.0
@@ -18852,12 +18644,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
-    dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
-
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -18866,7 +18653,7 @@ snapshots:
       "@asamuzakjp/css-color": 5.1.11
       "@asamuzakjp/dom-selector": 7.1.1
       "@bramus/specificity": 2.4.2
-      "@csstools/css-syntax-patches-for-csstree": 1.1.6(css-tree@3.2.1)
+      "@csstools/css-syntax-patches-for-csstree": 1.1.8(css-tree@3.2.1)
       "@exodus/bytes": 1.15.1
       css-tree: 3.2.1
       data-urls: 7.0.0
@@ -18878,7 +18665,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.2
-      undici: 7.28.0
+      undici: 7.29.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -18932,7 +18719,7 @@ snapshots:
   launch-editor@2.14.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.9.0
+      shell-quote: 1.10.0
 
   layout-base@1.0.2: {}
 
@@ -18948,34 +18735,67 @@ snapshots:
   lightningcss-android-arm64@1.32.0:
     optional: true
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
     optional: true
 
   lightningcss-darwin-x64@1.32.0:
     optional: true
 
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.32.0:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.32.0:
     optional: true
 
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.32.0:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
     optional: true
 
   lightningcss@1.32.0:
@@ -18994,6 +18814,22 @@ snapshots:
       lightningcss-win32-arm64-msvc: 1.32.0
       lightningcss-win32-x64-msvc: 1.32.0
 
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lilconfig@3.1.3: {}
 
   lines-and-columns@1.2.4: {}
@@ -19002,24 +18838,13 @@ snapshots:
     dependencies:
       uc.micro: 2.1.0
 
-  lint-staged@17.0.8:
+  lint-staged@17.3.0:
     dependencies:
-      listr2: 10.2.2
       picomatch: 4.0.5
       string-argv: 0.3.2
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
     optionalDependencies:
       yaml: 2.9.0
-
-  listr2@10.2.2:
-    dependencies:
-      cli-truncate: 5.2.0
-      eventemitter3: 5.0.4
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 10.0.0
-
-  loader-runner@4.3.2: {}
 
   loader-utils@2.0.4:
     dependencies:
@@ -19051,14 +18876,6 @@ snapshots:
 
   lodash@4.18.1: {}
 
-  log-update@6.1.0:
-    dependencies:
-      ansi-escapes: 7.3.0
-      cli-cursor: 5.0.0
-      slice-ansi: 7.1.2
-      strip-ansi: 7.2.0
-      wrap-ansi: 9.0.2
-
   longest-streak@3.1.0: {}
 
   loose-envify@1.4.0:
@@ -19077,9 +18894,9 @@ snapshots:
     dependencies:
       yallist: 3.1.1
 
-  lucide-react@1.24.0(react@19.2.7):
+  lucide-react@1.33.0(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
   lunr@2.3.9: {}
 
@@ -19087,10 +18904,10 @@ snapshots:
     dependencies:
       "@jridgewell/sourcemap-codec": 1.5.5
 
-  magicast@0.5.3:
+  magicast@0.5.4:
     dependencies:
-      "@babel/parser": 7.29.7
-      "@babel/types": 7.29.7
+      "@babel/parser": 7.29.8
+      "@babel/types": 7.29.8
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -19104,7 +18921,7 @@ snapshots:
       argparse: 2.0.1
       entities: 4.5.0
       linkify-it: 5.0.2
-      mdurl: 2.0.0
+      mdurl: 2.1.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
@@ -19114,13 +18931,13 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
-  mdast-util-directive@3.1.0:
+  mdast-util-directive@3.1.0(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
       "@types/unist": 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -19135,14 +18952,14 @@ snapshots:
       unist-util-is: 6.0.1
       unist-util-visit-parents: 6.0.2
 
-  mdast-util-from-markdown@2.0.3:
+  mdast-util-from-markdown@2.0.3(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
       "@types/unist": 3.0.3
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       mdast-util-to-string: 4.0.0
-      micromark: 4.0.2
+      micromark: 4.0.2(supports-color@8.1.1)
       micromark-util-decode-numeric-character-reference: 2.0.2
       micromark-util-decode-string: 2.0.1
       micromark-util-normalize-identifier: 2.0.1
@@ -19152,12 +18969,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-frontmatter@2.0.1:
+  mdast-util-frontmatter@2.0.1(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
       devlop: 1.1.0
       escape-string-regexp: 5.0.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       micromark-extension-frontmatter: 2.0.0
     transitivePeerDependencies:
@@ -19171,67 +18988,67 @@ snapshots:
       mdast-util-find-and-replace: 3.0.2
       micromark-util-character: 2.1.1
 
-  mdast-util-gfm-footnote@2.1.0:
+  mdast-util-gfm-footnote@2.1.0(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       micromark-util-normalize-identifier: 2.0.1
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-strikethrough@2.0.0:
+  mdast-util-gfm-strikethrough@2.0.0(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-table@2.0.0:
+  mdast-util-gfm-table@2.0.0(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
       devlop: 1.1.0
       markdown-table: 3.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm-task-list-item@2.0.0:
+  mdast-util-gfm-task-list-item@2.0.0(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-gfm@3.1.0:
+  mdast-util-gfm@3.1.0(supports-color@8.1.1):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-gfm-autolink-literal: 2.0.1
-      mdast-util-gfm-footnote: 2.1.0
-      mdast-util-gfm-strikethrough: 2.0.0
-      mdast-util-gfm-table: 2.0.0
-      mdast-util-gfm-task-list-item: 2.0.0
+      mdast-util-gfm-footnote: 2.1.0(supports-color@8.1.1)
+      mdast-util-gfm-strikethrough: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-table: 2.0.0(supports-color@8.1.1)
+      mdast-util-gfm-task-list-item: 2.0.0(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-expression@2.0.1:
+  mdast-util-mdx-expression@2.0.1(supports-color@8.1.1):
     dependencies:
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx-jsx@3.2.0:
+  mdast-util-mdx-jsx@3.2.0(supports-color@8.1.1):
     dependencies:
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.5
@@ -19239,7 +19056,7 @@ snapshots:
       "@types/unist": 3.0.3
       ccount: 2.0.1
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
       parse-entities: 4.0.2
       stringify-entities: 4.0.4
@@ -19248,23 +19065,23 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdx@3.0.0:
+  mdast-util-mdx@3.0.0(supports-color@8.1.1):
     dependencies:
-      mdast-util-from-markdown: 2.0.3
-      mdast-util-mdx-expression: 2.0.1
-      mdast-util-mdx-jsx: 3.2.0
-      mdast-util-mdxjs-esm: 2.0.1
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
+      mdast-util-mdx-expression: 2.0.1(supports-color@8.1.1)
+      mdast-util-mdx-jsx: 3.2.0(supports-color@8.1.1)
+      mdast-util-mdxjs-esm: 2.0.1(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
 
-  mdast-util-mdxjs-esm@2.0.1:
+  mdast-util-mdxjs-esm@2.0.1(supports-color@8.1.1):
     dependencies:
       "@types/estree-jsx": 1.0.5
       "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
       devlop: 1.1.0
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       mdast-util-to-markdown: 2.1.2
     transitivePeerDependencies:
       - supports-color
@@ -19278,7 +19095,7 @@ snapshots:
     dependencies:
       "@types/hast": 3.0.5
       "@types/mdast": 4.0.4
-      "@ungap/structured-clone": 1.3.2
+      "@ungap/structured-clone": 1.3.3
       devlop: 1.1.0
       micromark-util-sanitize-uri: 2.0.1
       trim-lines: 3.0.1
@@ -19308,24 +19125,24 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
-  mdurl@2.0.0: {}
+  mdurl@2.1.0: {}
 
   media-typer@0.3.0: {}
 
-  memfs@4.64.0(tslib@2.8.1):
+  memfs@4.68.1:
     dependencies:
-      "@jsonjoy.com/fs-core": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-fsa": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-builtins": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-to-fsa": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-node-utils": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-print": 4.64.0(tslib@2.8.1)
-      "@jsonjoy.com/fs-snapshot": 4.64.0(tslib@2.8.1)
+      "@jsonjoy.com/fs-core": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-fsa": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-builtins": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-to-fsa": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-node-utils": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-print": 4.68.1(tslib@2.8.1)
+      "@jsonjoy.com/fs-snapshot": 4.68.1(tslib@2.8.1)
       "@jsonjoy.com/json-pack": 1.21.0(tslib@2.8.1)
       "@jsonjoy.com/util": 1.9.0(tslib@2.8.1)
       glob-to-regex.js: 1.2.0(tslib@2.8.1)
-      thingies: 2.6.0(tslib@2.8.1)
+      thingies: 2.6.1(tslib@2.8.1)
       tree-dump: 1.1.0(tslib@2.8.1)
       tslib: 2.8.1
 
@@ -19335,29 +19152,30 @@ snapshots:
 
   merge2@1.4.1: {}
 
-  mermaid@11.16.0:
+  mermaid@11.17.0:
     dependencies:
       "@braintree/sanitize-url": 7.1.2
       "@iconify/utils": 3.1.4
-      "@mermaid-js/parser": 1.2.0
+      "@mermaid-js/parser": 1.2.1
       "@types/d3": 7.4.3
       "@upsetjs/venn.js": 2.0.0
-      cytoscape: 3.34.0
-      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
-      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      cytoscape: 3.34.1
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.1)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.1)
       d3: 7.9.0
       d3-sankey: 0.12.3
       dagre-d3-es: 7.0.14
-      dayjs: 1.11.21
-      dompurify: 3.4.11
-      es-toolkit: 1.49.0
+      dayjs: 1.11.23
+      dompurify: 3.4.14
+      es-toolkit: 1.51.0
+      fastdom: 1.0.12
       katex: 0.16.47
       khroma: 2.1.0
       marked: 16.4.2
       roughjs: 4.6.6
       stylis: 4.4.0
       ts-dedent: 2.3.0
-      uuid: 14.0.1
+      uuid: 14.0.2
 
   methods@1.1.2: {}
 
@@ -19497,8 +19315,8 @@ snapshots:
 
   micromark-extension-mdxjs@3.0.0:
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       micromark-extension-mdx-expression: 3.0.1
       micromark-extension-mdx-jsx: 3.0.2
       micromark-extension-mdx-md: 2.0.0
@@ -19634,10 +19452,10 @@ snapshots:
 
   micromark-util-types@2.0.2: {}
 
-  micromark@4.0.2:
+  micromark@4.0.2(supports-color@8.1.1):
     dependencies:
       "@types/debug": 4.1.13
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -19683,90 +19501,58 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-function@5.0.1: {}
-
   mimic-response@3.1.0: {}
 
   mimic-response@4.0.0: {}
 
-  mini-css-extract-plugin@2.10.2(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  mini-css-extract-plugin@2.10.2(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.3
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
   minimalistic-assert@1.0.1: {}
 
   minimatch@10.2.3:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
-  minimatch@10.2.5:
+  minimatch@10.2.6:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 1.1.18
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43)(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.16)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  minimizer-webpack-plugin@5.6.1(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.49.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      terser: 5.50.0
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     optionalDependencies:
-      "@swc/core": 1.15.43
-      "@swc/html": 1.15.43
-      lightningcss: 1.32.0
-      postcss: 8.5.16
-
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
-    dependencies:
-      "@jridgewell/trace-mapping": 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.49.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
-    optionalDependencies:
-      "@swc/core": 1.15.43
+      "@swc/core": 1.16.1
+      "@swc/html": 1.16.1
       clean-css: 5.3.3
-      cssnano: 6.1.2(postcss@8.5.16)
+      cssnano: 6.1.2(postcss@8.5.26)
+      csso: 5.0.5
       html-minifier-terser: 7.2.0
-      postcss: 8.5.16
-
-  minimizer-webpack-plugin@5.6.1(@swc/core@1.15.43)(postcss@8.5.16)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
-    dependencies:
-      "@jridgewell/trace-mapping": 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.49.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
-    optionalDependencies:
-      "@swc/core": 1.15.43
-      postcss: 8.5.16
-
-  minimizer-webpack-plugin@5.6.1(webpack@5.108.4):
-    dependencies:
-      "@jridgewell/trace-mapping": 0.3.31
-      jest-worker: 27.5.1
-      schema-utils: 4.3.3
-      terser: 5.49.0
-      webpack: 5.108.4
-    optional: true
+      lightningcss: 1.33.0
+      postcss: 8.5.26
 
   mkdirp-classic@0.5.3: {}
 
   mlly@1.8.2:
     dependencies:
-      acorn: 8.17.0
+      acorn: 8.18.0
       pathe: 2.0.3
       pkg-types: 1.3.1
       ufo: 1.6.4
@@ -19782,7 +19568,7 @@ snapshots:
       dns-packet: 5.6.1
       thunky: 1.1.0
 
-  nanoid@3.3.15: {}
+  nanoid@3.3.18: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -19812,7 +19598,7 @@ snapshots:
       emojilib: 2.4.0
       skin-tone: 2.0.0
 
-  node-releases@2.0.51: {}
+  node-releases@2.0.53: {}
 
   normalize-path@3.0.0: {}
 
@@ -19828,11 +19614,11 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  null-loader@4.0.1(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  null-loader@4.0.1(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
   numcodecs@0.3.2:
     dependencies:
@@ -19855,17 +19641,17 @@ snapshots:
 
   obuf@1.1.2: {}
 
-  obug@2.1.3: {}
+  obug@2.1.4: {}
 
   ome-zarr.js@0.0.19:
     dependencies:
       zarrita: 0.5.4
 
-  omezarr-tilesource@0.2.0(openseadragon@6.0.2):
+  omezarr-tilesource@0.2.0(openseadragon@6.1.0):
     dependencies:
       "@zarrita/storage": 0.2.0
       ome-zarr.js: 0.0.19
-      openseadragon: 6.0.2
+      openseadragon: 6.1.0
       zarrita: 0.5.4
 
   on-finished@2.4.1:
@@ -19882,13 +19668,9 @@ snapshots:
     dependencies:
       mimic-fn: 2.1.0
 
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
-
   open@10.2.0:
     dependencies:
-      default-browser: 5.5.0
+      default-browser: 5.5.1
       define-lazy-prop: 3.0.0
       is-inside-container: 1.0.0
       wsl-utils: 0.1.0
@@ -19901,7 +19683,7 @@ snapshots:
 
   opener@1.5.2: {}
 
-  openseadragon@6.0.2: {}
+  openseadragon@6.1.0: {}
 
   optionator@0.9.4:
     dependencies:
@@ -19958,9 +19740,9 @@ snapshots:
       registry-url: 6.0.1
       semver: 7.8.5
 
-  package-manager-detector@1.7.0: {}
+  package-manager-detector@1.8.0: {}
 
-  papaparse@5.5.4: {}
+  papaparse@5.6.0: {}
 
   param-case@3.0.4:
     dependencies:
@@ -20061,7 +19843,7 @@ snapshots:
   pkg-types@2.3.1:
     dependencies:
       confbox: 0.2.4
-      exsolve: 1.1.0
+      exsolve: 1.1.1
       pathe: 2.0.3
 
   pkijs@3.4.0:
@@ -20070,7 +19852,7 @@ snapshots:
       asn1js: 3.0.10
       bytestreamjs: 2.0.1
       pvtsutils: 1.3.6
-      pvutils: 1.1.5
+      pvutils: 1.2.0
       tslib: 2.8.1
 
   points-on-curve@0.2.0: {}
@@ -20080,444 +19862,444 @@ snapshots:
       path-data-parser: 0.1.0
       points-on-curve: 0.2.0
 
-  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.16):
+  postcss-attribute-case-insensitive@7.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  postcss-calc@9.0.1(postcss@8.5.16):
+  postcss-calc@9.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
       postcss-value-parser: 4.2.0
 
-  postcss-clamp@4.1.0(postcss@8.5.16):
+  postcss-clamp@4.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-color-functional-notation@7.0.12(postcss@8.5.16):
+  postcss-color-functional-notation@7.0.12(postcss@8.5.26):
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  postcss-color-hex-alpha@10.0.0(postcss@8.5.16):
+  postcss-color-hex-alpha@10.0.0(postcss@8.5.26):
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-color-rebeccapurple@10.0.0(postcss@8.5.16):
+  postcss-color-rebeccapurple@10.0.0(postcss@8.5.26):
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-colormin@6.1.0(postcss@8.5.16):
+  postcss-colormin@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.5
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
-      colord: 2.9.3
-      postcss: 8.5.16
+      colord: 2.10.0
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-convert-values@6.1.0(postcss@8.5.16):
+  postcss-convert-values@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.5
-      postcss: 8.5.16
+      browserslist: 4.28.8
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-custom-media@11.0.6(postcss@8.5.16):
+  postcss-custom-media@11.0.6(postcss@8.5.26):
     dependencies:
       "@csstools/cascade-layer-name-parser": 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
       "@csstools/media-query-list-parser": 4.0.3(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-custom-properties@14.0.6(postcss@8.5.16):
+  postcss-custom-properties@14.0.6(postcss@8.5.26):
     dependencies:
       "@csstools/cascade-layer-name-parser": 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-custom-selectors@8.0.5(postcss@8.5.16):
+  postcss-custom-selectors@8.0.5(postcss@8.5.26):
     dependencies:
       "@csstools/cascade-layer-name-parser": 2.0.5(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  postcss-dir-pseudo-class@9.0.1(postcss@8.5.16):
+  postcss-dir-pseudo-class@9.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  postcss-discard-comments@6.0.2(postcss@8.5.16):
+  postcss-discard-comments@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-discard-duplicates@6.0.3(postcss@8.5.16):
+  postcss-discard-duplicates@6.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-discard-empty@6.0.3(postcss@8.5.16):
+  postcss-discard-empty@6.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-discard-overridden@6.0.2(postcss@8.5.16):
+  postcss-discard-overridden@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-discard-unused@6.0.5(postcss@8.5.16):
+  postcss-discard-unused@6.0.5(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-double-position-gradients@6.0.4(postcss@8.5.16):
+  postcss-double-position-gradients@6.0.4(postcss@8.5.26):
     dependencies:
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-focus-visible@10.0.1(postcss@8.5.16):
+  postcss-focus-visible@10.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  postcss-focus-within@9.0.1(postcss@8.5.16):
+  postcss-focus-within@9.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  postcss-font-variant@5.0.0(postcss@8.5.16):
+  postcss-font-variant@5.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-gap-properties@6.0.0(postcss@8.5.16):
+  postcss-gap-properties@6.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-image-set-function@7.0.0(postcss@8.5.16):
+  postcss-image-set-function@7.0.0(postcss@8.5.26):
     dependencies:
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-lab-function@7.0.12(postcss@8.5.16):
+  postcss-lab-function@7.0.12(postcss@8.5.26):
     dependencies:
       "@csstools/css-color-parser": 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-parser-algorithms": 3.0.5(@csstools/css-tokenizer@3.0.4)
       "@csstools/css-tokenizer": 3.0.4
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/utilities": 2.0.0(postcss@8.5.16)
-      postcss: 8.5.16
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/utilities": 2.0.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  postcss-loader@7.3.4(postcss@8.5.16)(typescript@6.0.3)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  postcss-loader@7.3.4(postcss@8.5.26)(typescript@6.0.3)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       cosmiconfig: 8.3.6(typescript@6.0.3)
       jiti: 1.21.7
-      postcss: 8.5.16
+      postcss: 8.5.26
       semver: 7.8.5
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - typescript
 
-  postcss-logical@8.1.0(postcss@8.5.16):
+  postcss-logical@8.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-merge-idents@6.0.3(postcss@8.5.16):
+  postcss-merge-idents@6.0.3(postcss@8.5.26):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.16)
-      postcss: 8.5.16
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-merge-longhand@6.0.5(postcss@8.5.16):
+  postcss-merge-longhand@6.0.5(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
-      stylehacks: 6.1.1(postcss@8.5.16)
+      stylehacks: 6.1.1(postcss@8.5.26)
 
-  postcss-merge-rules@6.1.1(postcss@8.5.16):
+  postcss-merge-rules@6.1.1(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.5
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
-      cssnano-utils: 4.0.2(postcss@8.5.16)
-      postcss: 8.5.16
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-minify-font-values@6.1.0(postcss@8.5.16):
+  postcss-minify-font-values@6.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-minify-gradients@6.0.3(postcss@8.5.16):
+  postcss-minify-gradients@6.0.3(postcss@8.5.26):
     dependencies:
-      colord: 2.9.3
-      cssnano-utils: 4.0.2(postcss@8.5.16)
-      postcss: 8.5.16
+      colord: 2.10.0
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-minify-params@6.1.0(postcss@8.5.16):
+  postcss-minify-params@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.5
-      cssnano-utils: 4.0.2(postcss@8.5.16)
-      postcss: 8.5.16
+      browserslist: 4.28.8
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-minify-selectors@6.0.4(postcss@8.5.16):
+  postcss-minify-selectors@6.0.4(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
-  postcss-modules-extract-imports@3.1.0(postcss@8.5.16):
+  postcss-modules-extract-imports@3.1.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-modules-local-by-default@4.2.0(postcss@8.5.16):
+  postcss-modules-local-by-default@4.2.0(postcss@8.5.26):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.16)
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
       postcss-value-parser: 4.2.0
 
-  postcss-modules-scope@3.2.1(postcss@8.5.16):
+  postcss-modules-scope@3.2.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  postcss-modules-values@4.0.0(postcss@8.5.16):
+  postcss-modules-values@4.0.0(postcss@8.5.26):
     dependencies:
-      icss-utils: 5.1.0(postcss@8.5.16)
-      postcss: 8.5.16
+      icss-utils: 5.1.0(postcss@8.5.26)
+      postcss: 8.5.26
 
-  postcss-nesting@13.0.2(postcss@8.5.16):
+  postcss-nesting@13.0.2(postcss@8.5.26):
     dependencies:
-      "@csstools/selector-resolve-nested": 3.1.0(postcss-selector-parser@7.1.4)
-      "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.4)
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      "@csstools/selector-resolve-nested": 3.1.0(postcss-selector-parser@7.1.5)
+      "@csstools/selector-specificity": 5.0.0(postcss-selector-parser@7.1.5)
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  postcss-normalize-charset@6.0.2(postcss@8.5.16):
+  postcss-normalize-charset@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-normalize-display-values@6.0.2(postcss@8.5.16):
+  postcss-normalize-display-values@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-positions@6.0.2(postcss@8.5.16):
+  postcss-normalize-positions@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-repeat-style@6.0.2(postcss@8.5.16):
+  postcss-normalize-repeat-style@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-string@6.0.2(postcss@8.5.16):
+  postcss-normalize-string@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-timing-functions@6.0.2(postcss@8.5.16):
+  postcss-normalize-timing-functions@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-unicode@6.1.0(postcss@8.5.16):
+  postcss-normalize-unicode@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.5
-      postcss: 8.5.16
+      browserslist: 4.28.8
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-url@6.0.2(postcss@8.5.16):
+  postcss-normalize-url@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-normalize-whitespace@6.0.2(postcss@8.5.16):
+  postcss-normalize-whitespace@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-opacity-percentage@3.0.0(postcss@8.5.16):
+  postcss-opacity-percentage@3.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-ordered-values@6.0.2(postcss@8.5.16):
+  postcss-ordered-values@6.0.2(postcss@8.5.26):
     dependencies:
-      cssnano-utils: 4.0.2(postcss@8.5.16)
-      postcss: 8.5.16
+      cssnano-utils: 4.0.2(postcss@8.5.26)
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-overflow-shorthand@6.0.0(postcss@8.5.16):
+  postcss-overflow-shorthand@6.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-page-break@3.0.4(postcss@8.5.16):
+  postcss-page-break@3.0.4(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-place@10.0.0(postcss@8.5.16):
+  postcss-place@10.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-preset-env@10.6.1(postcss@8.5.16):
+  postcss-preset-env@10.6.1(postcss@8.5.26):
     dependencies:
-      "@csstools/postcss-alpha-function": 1.0.1(postcss@8.5.16)
-      "@csstools/postcss-cascade-layers": 5.0.2(postcss@8.5.16)
-      "@csstools/postcss-color-function": 4.0.12(postcss@8.5.16)
-      "@csstools/postcss-color-function-display-p3-linear": 1.0.1(postcss@8.5.16)
-      "@csstools/postcss-color-mix-function": 3.0.12(postcss@8.5.16)
-      "@csstools/postcss-color-mix-variadic-function-arguments": 1.0.2(postcss@8.5.16)
-      "@csstools/postcss-content-alt-text": 2.0.8(postcss@8.5.16)
-      "@csstools/postcss-contrast-color-function": 2.0.12(postcss@8.5.16)
-      "@csstools/postcss-exponential-functions": 2.0.9(postcss@8.5.16)
-      "@csstools/postcss-font-format-keywords": 4.0.0(postcss@8.5.16)
-      "@csstools/postcss-gamut-mapping": 2.0.11(postcss@8.5.16)
-      "@csstools/postcss-gradients-interpolation-method": 5.0.12(postcss@8.5.16)
-      "@csstools/postcss-hwb-function": 4.0.12(postcss@8.5.16)
-      "@csstools/postcss-ic-unit": 4.0.4(postcss@8.5.16)
-      "@csstools/postcss-initial": 2.0.1(postcss@8.5.16)
-      "@csstools/postcss-is-pseudo-class": 5.0.3(postcss@8.5.16)
-      "@csstools/postcss-light-dark-function": 2.0.11(postcss@8.5.16)
-      "@csstools/postcss-logical-float-and-clear": 3.0.0(postcss@8.5.16)
-      "@csstools/postcss-logical-overflow": 2.0.0(postcss@8.5.16)
-      "@csstools/postcss-logical-overscroll-behavior": 2.0.0(postcss@8.5.16)
-      "@csstools/postcss-logical-resize": 3.0.0(postcss@8.5.16)
-      "@csstools/postcss-logical-viewport-units": 3.0.4(postcss@8.5.16)
-      "@csstools/postcss-media-minmax": 2.0.9(postcss@8.5.16)
-      "@csstools/postcss-media-queries-aspect-ratio-number-values": 3.0.5(postcss@8.5.16)
-      "@csstools/postcss-nested-calc": 4.0.0(postcss@8.5.16)
-      "@csstools/postcss-normalize-display-values": 4.0.1(postcss@8.5.16)
-      "@csstools/postcss-oklab-function": 4.0.12(postcss@8.5.16)
-      "@csstools/postcss-position-area-property": 1.0.0(postcss@8.5.16)
-      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.16)
-      "@csstools/postcss-property-rule-prelude-list": 1.0.0(postcss@8.5.16)
-      "@csstools/postcss-random-function": 2.0.1(postcss@8.5.16)
-      "@csstools/postcss-relative-color-syntax": 3.0.12(postcss@8.5.16)
-      "@csstools/postcss-scope-pseudo-class": 4.0.1(postcss@8.5.16)
-      "@csstools/postcss-sign-functions": 1.1.4(postcss@8.5.16)
-      "@csstools/postcss-stepped-value-functions": 4.0.9(postcss@8.5.16)
-      "@csstools/postcss-syntax-descriptor-syntax-production": 1.0.1(postcss@8.5.16)
-      "@csstools/postcss-system-ui-font-family": 1.0.0(postcss@8.5.16)
-      "@csstools/postcss-text-decoration-shorthand": 4.0.3(postcss@8.5.16)
-      "@csstools/postcss-trigonometric-functions": 4.0.9(postcss@8.5.16)
-      "@csstools/postcss-unset-value": 4.0.0(postcss@8.5.16)
-      autoprefixer: 10.5.2(postcss@8.5.16)
-      browserslist: 4.28.5
-      css-blank-pseudo: 7.0.1(postcss@8.5.16)
-      css-has-pseudo: 7.0.3(postcss@8.5.16)
-      css-prefers-color-scheme: 10.0.0(postcss@8.5.16)
-      cssdb: 8.9.0
-      postcss: 8.5.16
-      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.16)
-      postcss-clamp: 4.1.0(postcss@8.5.16)
-      postcss-color-functional-notation: 7.0.12(postcss@8.5.16)
-      postcss-color-hex-alpha: 10.0.0(postcss@8.5.16)
-      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.16)
-      postcss-custom-media: 11.0.6(postcss@8.5.16)
-      postcss-custom-properties: 14.0.6(postcss@8.5.16)
-      postcss-custom-selectors: 8.0.5(postcss@8.5.16)
-      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.16)
-      postcss-double-position-gradients: 6.0.4(postcss@8.5.16)
-      postcss-focus-visible: 10.0.1(postcss@8.5.16)
-      postcss-focus-within: 9.0.1(postcss@8.5.16)
-      postcss-font-variant: 5.0.0(postcss@8.5.16)
-      postcss-gap-properties: 6.0.0(postcss@8.5.16)
-      postcss-image-set-function: 7.0.0(postcss@8.5.16)
-      postcss-lab-function: 7.0.12(postcss@8.5.16)
-      postcss-logical: 8.1.0(postcss@8.5.16)
-      postcss-nesting: 13.0.2(postcss@8.5.16)
-      postcss-opacity-percentage: 3.0.0(postcss@8.5.16)
-      postcss-overflow-shorthand: 6.0.0(postcss@8.5.16)
-      postcss-page-break: 3.0.4(postcss@8.5.16)
-      postcss-place: 10.0.0(postcss@8.5.16)
-      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.16)
-      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.16)
-      postcss-selector-not: 8.0.1(postcss@8.5.16)
+      "@csstools/postcss-alpha-function": 1.0.1(postcss@8.5.26)
+      "@csstools/postcss-cascade-layers": 5.0.2(postcss@8.5.26)
+      "@csstools/postcss-color-function": 4.0.12(postcss@8.5.26)
+      "@csstools/postcss-color-function-display-p3-linear": 1.0.1(postcss@8.5.26)
+      "@csstools/postcss-color-mix-function": 3.0.12(postcss@8.5.26)
+      "@csstools/postcss-color-mix-variadic-function-arguments": 1.0.2(postcss@8.5.26)
+      "@csstools/postcss-content-alt-text": 2.0.8(postcss@8.5.26)
+      "@csstools/postcss-contrast-color-function": 2.0.12(postcss@8.5.26)
+      "@csstools/postcss-exponential-functions": 2.0.9(postcss@8.5.26)
+      "@csstools/postcss-font-format-keywords": 4.0.0(postcss@8.5.26)
+      "@csstools/postcss-gamut-mapping": 2.0.11(postcss@8.5.26)
+      "@csstools/postcss-gradients-interpolation-method": 5.0.12(postcss@8.5.26)
+      "@csstools/postcss-hwb-function": 4.0.12(postcss@8.5.26)
+      "@csstools/postcss-ic-unit": 4.0.4(postcss@8.5.26)
+      "@csstools/postcss-initial": 2.0.1(postcss@8.5.26)
+      "@csstools/postcss-is-pseudo-class": 5.0.3(postcss@8.5.26)
+      "@csstools/postcss-light-dark-function": 2.0.11(postcss@8.5.26)
+      "@csstools/postcss-logical-float-and-clear": 3.0.0(postcss@8.5.26)
+      "@csstools/postcss-logical-overflow": 2.0.0(postcss@8.5.26)
+      "@csstools/postcss-logical-overscroll-behavior": 2.0.0(postcss@8.5.26)
+      "@csstools/postcss-logical-resize": 3.0.0(postcss@8.5.26)
+      "@csstools/postcss-logical-viewport-units": 3.0.4(postcss@8.5.26)
+      "@csstools/postcss-media-minmax": 2.0.9(postcss@8.5.26)
+      "@csstools/postcss-media-queries-aspect-ratio-number-values": 3.0.5(postcss@8.5.26)
+      "@csstools/postcss-nested-calc": 4.0.0(postcss@8.5.26)
+      "@csstools/postcss-normalize-display-values": 4.0.1(postcss@8.5.26)
+      "@csstools/postcss-oklab-function": 4.0.12(postcss@8.5.26)
+      "@csstools/postcss-position-area-property": 1.0.0(postcss@8.5.26)
+      "@csstools/postcss-progressive-custom-properties": 4.2.1(postcss@8.5.26)
+      "@csstools/postcss-property-rule-prelude-list": 1.0.0(postcss@8.5.26)
+      "@csstools/postcss-random-function": 2.0.1(postcss@8.5.26)
+      "@csstools/postcss-relative-color-syntax": 3.0.12(postcss@8.5.26)
+      "@csstools/postcss-scope-pseudo-class": 4.0.1(postcss@8.5.26)
+      "@csstools/postcss-sign-functions": 1.1.4(postcss@8.5.26)
+      "@csstools/postcss-stepped-value-functions": 4.0.9(postcss@8.5.26)
+      "@csstools/postcss-syntax-descriptor-syntax-production": 1.0.1(postcss@8.5.26)
+      "@csstools/postcss-system-ui-font-family": 1.0.0(postcss@8.5.26)
+      "@csstools/postcss-text-decoration-shorthand": 4.0.3(postcss@8.5.26)
+      "@csstools/postcss-trigonometric-functions": 4.0.9(postcss@8.5.26)
+      "@csstools/postcss-unset-value": 4.0.0(postcss@8.5.26)
+      autoprefixer: 10.5.4(postcss@8.5.26)
+      browserslist: 4.28.8
+      css-blank-pseudo: 7.0.1(postcss@8.5.26)
+      css-has-pseudo: 7.0.3(postcss@8.5.26)
+      css-prefers-color-scheme: 10.0.0(postcss@8.5.26)
+      cssdb: 8.10.0
+      postcss: 8.5.26
+      postcss-attribute-case-insensitive: 7.0.1(postcss@8.5.26)
+      postcss-clamp: 4.1.0(postcss@8.5.26)
+      postcss-color-functional-notation: 7.0.12(postcss@8.5.26)
+      postcss-color-hex-alpha: 10.0.0(postcss@8.5.26)
+      postcss-color-rebeccapurple: 10.0.0(postcss@8.5.26)
+      postcss-custom-media: 11.0.6(postcss@8.5.26)
+      postcss-custom-properties: 14.0.6(postcss@8.5.26)
+      postcss-custom-selectors: 8.0.5(postcss@8.5.26)
+      postcss-dir-pseudo-class: 9.0.1(postcss@8.5.26)
+      postcss-double-position-gradients: 6.0.4(postcss@8.5.26)
+      postcss-focus-visible: 10.0.1(postcss@8.5.26)
+      postcss-focus-within: 9.0.1(postcss@8.5.26)
+      postcss-font-variant: 5.0.0(postcss@8.5.26)
+      postcss-gap-properties: 6.0.0(postcss@8.5.26)
+      postcss-image-set-function: 7.0.0(postcss@8.5.26)
+      postcss-lab-function: 7.0.12(postcss@8.5.26)
+      postcss-logical: 8.1.0(postcss@8.5.26)
+      postcss-nesting: 13.0.2(postcss@8.5.26)
+      postcss-opacity-percentage: 3.0.0(postcss@8.5.26)
+      postcss-overflow-shorthand: 6.0.0(postcss@8.5.26)
+      postcss-page-break: 3.0.4(postcss@8.5.26)
+      postcss-place: 10.0.0(postcss@8.5.26)
+      postcss-pseudo-class-any-link: 10.0.1(postcss@8.5.26)
+      postcss-replace-overflow-wrap: 4.0.0(postcss@8.5.26)
+      postcss-selector-not: 8.0.1(postcss@8.5.26)
 
-  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.16):
+  postcss-pseudo-class-any-link@10.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
-  postcss-reduce-idents@6.0.3(postcss@8.5.16):
+  postcss-reduce-idents@6.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-reduce-initial@6.1.0(postcss@8.5.16):
+  postcss-reduce-initial@6.1.0(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.5
+      browserslist: 4.28.8
       caniuse-api: 3.0.0
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-reduce-transforms@6.0.2(postcss@8.5.16):
+  postcss-reduce-transforms@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
 
-  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.16):
+  postcss-replace-overflow-wrap@4.0.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss-selector-not@8.0.1(postcss@8.5.16):
+  postcss-selector-not@8.0.1(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
-      postcss-selector-parser: 7.1.4
+      postcss: 8.5.26
+      postcss-selector-parser: 7.1.5
 
   postcss-selector-parser@6.1.4:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-selector-parser@7.1.4:
+  postcss-selector-parser@7.1.5:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  postcss-sort-media-queries@5.2.0(postcss@8.5.16):
+  postcss-sort-media-queries@5.2.0(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       sort-css-media-queries: 2.2.0
 
-  postcss-svgo@6.0.3(postcss@8.5.16):
+  postcss-svgo@6.0.3(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-value-parser: 4.2.0
-      svgo: 3.3.3
+      svgo: 3.3.4
 
-  postcss-unique-selectors@6.0.4(postcss@8.5.16):
+  postcss-unique-selectors@6.0.4(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
   postcss-value-parser@4.2.0: {}
 
-  postcss-zindex@6.0.2(postcss@8.5.16):
+  postcss-zindex@6.0.2(postcss@8.5.26):
     dependencies:
-      postcss: 8.5.16
+      postcss: 8.5.26
 
-  postcss@8.5.16:
+  postcss@8.5.26:
     dependencies:
-      nanoid: 3.3.15
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -20538,7 +20320,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.9.4: {}
+  prettier@3.9.6: {}
 
   pretty-error@4.0.0:
     dependencies:
@@ -20547,11 +20329,11 @@ snapshots:
 
   pretty-time@1.1.0: {}
 
-  prism-react-renderer@2.4.1(react@19.2.7):
+  prism-react-renderer@2.4.1(react@19.2.8):
     dependencies:
       "@types/prismjs": 1.26.6
       clsx: 2.1.1
-      react: 19.2.7
+      react: 19.2.8
 
   prismjs@1.30.0: {}
 
@@ -20594,7 +20376,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  pvutils@1.1.5: {}
+  pvutils@1.2.0: {}
 
   qs@6.15.3:
     dependencies:
@@ -20631,48 +20413,48 @@ snapshots:
       minimist: 1.2.8
       strip-json-comments: 2.0.1
 
-  react-colorful@5.7.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  react-colorful@5.8.0(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
 
-  react-dom@19.2.7(react@19.2.7):
+  react-dom@19.2.8(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
       scheduler: 0.27.0
 
   react-fast-compare@3.2.2: {}
 
   react-is@16.13.1: {}
 
-  react-json-view-lite@2.5.0(react@19.2.7):
+  react-json-view-lite@2.5.0(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
-  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.7))(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
-    dependencies:
-      "@babel/runtime": 7.29.7
-      react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.2.7)"
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
-
-  react-router-config@5.1.1(react-router@5.3.4(react@19.2.7))(react@19.2.7):
+  react-loadable-ssr-addon-v5-slorber@1.0.3(@docusaurus/react-loadable@6.0.0(react@19.2.8))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       "@babel/runtime": 7.29.7
-      react: 19.2.7
-      react-router: 5.3.4(react@19.2.7)
+      react-loadable: "@docusaurus/react-loadable@6.0.0(react@19.2.8)"
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
-  react-router-dom@5.3.4(react@19.2.7):
+  react-router-config@5.1.1(react-router@5.3.4(react@19.2.8))(react@19.2.8):
+    dependencies:
+      "@babel/runtime": 7.29.7
+      react: 19.2.8
+      react-router: 5.3.4(react@19.2.8)
+
+  react-router-dom@5.3.4(react@19.2.8):
     dependencies:
       "@babel/runtime": 7.29.7
       history: 4.10.1
       loose-envify: 1.4.0
       prop-types: 15.8.1
-      react: 19.2.7
-      react-router: 5.3.4(react@19.2.7)
+      react: 19.2.8
+      react-router: 5.3.4(react@19.2.8)
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react-router@5.3.4(react@19.2.7):
+  react-router@5.3.4(react@19.2.8):
     dependencies:
       "@babel/runtime": 7.29.7
       history: 4.10.1
@@ -20680,12 +20462,12 @@ snapshots:
       loose-envify: 1.4.0
       path-to-regexp: 1.9.0
       prop-types: 15.8.1
-      react: 19.2.7
+      react: 19.2.8
       react-is: 16.13.1
       tiny-invariant: 1.3.3
       tiny-warning: 1.0.3
 
-  react@19.2.7: {}
+  react@19.2.8: {}
 
   readable-stream@2.3.8:
     dependencies:
@@ -20713,10 +20495,10 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.17.0):
+  recma-jsx@1.0.1(acorn@8.18.0):
     dependencies:
-      acorn: 8.17.0
-      acorn-jsx: 5.3.2(acorn@8.17.0)
+      acorn: 8.18.0
+      acorn-jsx: 5.3.2(acorn@8.18.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -20775,20 +20557,20 @@ snapshots:
       hast-util-raw: 9.1.0
       vfile: 6.0.3
 
-  rehype-recma@1.0.0:
+  rehype-recma@1.0.0(supports-color@8.1.1):
     dependencies:
       "@types/estree": 1.0.9
       "@types/hast": 3.0.5
-      hast-util-to-estree: 3.1.3
+      hast-util-to-estree: 3.1.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   relateurl@0.2.7: {}
 
-  remark-directive@3.0.1:
+  remark-directive@3.0.1(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
-      mdast-util-directive: 3.1.0
+      mdast-util-directive: 3.1.0(supports-color@8.1.1)
       micromark-extension-directive: 3.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -20802,37 +20584,37 @@ snapshots:
       node-emoji: 2.2.0
       unified: 11.0.5
 
-  remark-frontmatter@5.0.0:
+  remark-frontmatter@5.0.0(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
-      mdast-util-frontmatter: 2.0.1
+      mdast-util-frontmatter: 2.0.1(supports-color@8.1.1)
       micromark-extension-frontmatter: 2.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-gfm@4.0.1:
+  remark-gfm@4.0.1(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
-      mdast-util-gfm: 3.1.0
+      mdast-util-gfm: 3.1.0(supports-color@8.1.1)
       micromark-extension-gfm: 3.0.0
-      remark-parse: 11.0.0
+      remark-parse: 11.0.0(supports-color@8.1.1)
       remark-stringify: 11.0.0
       unified: 11.0.5
     transitivePeerDependencies:
       - supports-color
 
-  remark-mdx@3.1.1:
+  remark-mdx@3.1.1(supports-color@8.1.1):
     dependencies:
-      mdast-util-mdx: 3.0.0
+      mdast-util-mdx: 3.0.0(supports-color@8.1.1)
       micromark-extension-mdxjs: 3.0.0
     transitivePeerDependencies:
       - supports-color
 
-  remark-parse@11.0.0:
+  remark-parse@11.0.0(supports-color@8.1.1):
     dependencies:
       "@types/mdast": 4.0.4
-      mdast-util-from-markdown: 2.0.3
+      mdast-util-from-markdown: 2.0.3(supports-color@8.1.1)
       micromark-util-types: 2.0.2
       unified: 11.0.5
     transitivePeerDependencies:
@@ -20885,39 +20667,32 @@ snapshots:
     dependencies:
       lowercase-keys: 3.0.0
 
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-
   retry@0.13.1: {}
 
   reusify@1.1.0: {}
 
-  rfdc@1.4.1: {}
-
   robust-predicates@3.0.3: {}
 
-  rolldown@1.1.5:
+  rolldown@1.2.5:
     dependencies:
-      "@oxc-project/types": 0.139.0
+      "@oxc-project/types": 0.146.0
       "@rolldown/pluginutils": 1.0.1
     optionalDependencies:
-      "@rolldown/binding-android-arm64": 1.1.5
-      "@rolldown/binding-darwin-arm64": 1.1.5
-      "@rolldown/binding-darwin-x64": 1.1.5
-      "@rolldown/binding-freebsd-x64": 1.1.5
-      "@rolldown/binding-linux-arm-gnueabihf": 1.1.5
-      "@rolldown/binding-linux-arm64-gnu": 1.1.5
-      "@rolldown/binding-linux-arm64-musl": 1.1.5
-      "@rolldown/binding-linux-ppc64-gnu": 1.1.5
-      "@rolldown/binding-linux-s390x-gnu": 1.1.5
-      "@rolldown/binding-linux-x64-gnu": 1.1.5
-      "@rolldown/binding-linux-x64-musl": 1.1.5
-      "@rolldown/binding-openharmony-arm64": 1.1.5
-      "@rolldown/binding-wasm32-wasi": 1.1.5
-      "@rolldown/binding-win32-arm64-msvc": 1.1.5
-      "@rolldown/binding-win32-x64-msvc": 1.1.5
+      "@rolldown/binding-android-arm-eabi": 1.2.5
+      "@rolldown/binding-android-arm64": 1.2.5
+      "@rolldown/binding-darwin-arm64": 1.2.5
+      "@rolldown/binding-darwin-x64": 1.2.5
+      "@rolldown/binding-freebsd-x64": 1.2.5
+      "@rolldown/binding-linux-arm-gnueabihf": 1.2.5
+      "@rolldown/binding-linux-arm64-gnu": 1.2.5
+      "@rolldown/binding-linux-arm64-musl": 1.2.5
+      "@rolldown/binding-linux-ppc64-gnu": 1.2.5
+      "@rolldown/binding-linux-s390x-gnu": 1.2.5
+      "@rolldown/binding-linux-x64-gnu": 1.2.5
+      "@rolldown/binding-linux-x64-musl": 1.2.5
+      "@rolldown/binding-openharmony-arm64": 1.2.5
+      "@rolldown/binding-win32-arm64-msvc": 1.2.5
+      "@rolldown/binding-win32-x64-msvc": 1.2.5
 
   roughjs@4.6.6:
     dependencies:
@@ -20930,7 +20705,7 @@ snapshots:
     dependencies:
       escalade: 3.2.0
       picocolors: 1.1.1
-      postcss: 8.5.16
+      postcss: 8.5.26
       strip-json-comments: 3.1.1
 
   run-applescript@7.1.0: {}
@@ -20947,7 +20722,7 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sax@1.6.0: {}
+  sax@1.6.1: {}
 
   saxes@6.0.0:
     dependencies:
@@ -20994,9 +20769,9 @@ snapshots:
 
   semver@7.8.5: {}
 
-  send@0.19.2:
+  send@0.19.2(supports-color@8.1.1):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 2.0.0
@@ -21026,11 +20801,11 @@ snapshots:
       path-to-regexp: 3.3.0
       range-parser: 1.2.0
 
-  serve-index@1.9.2:
+  serve-index@1.9.2(supports-color@8.1.1):
     dependencies:
       accepts: 1.3.8
       batch: 0.6.1
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@8.1.1)
       escape-html: 1.0.3
       http-errors: 1.8.1
       mime-types: 2.1.35
@@ -21038,12 +20813,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.3:
+  serve-static@1.16.3(supports-color@8.1.1):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.2
+      send: 0.19.2(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21070,7 +20845,7 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shell-quote@1.9.0: {}
+  shell-quote@1.10.0: {}
 
   side-channel-list@1.0.1:
     dependencies:
@@ -21104,8 +20879,6 @@ snapshots:
 
   signal-exit@3.0.7: {}
 
-  signal-exit@4.1.0: {}
-
   simple-concat@1.0.1: {}
 
   simple-get@4.0.1:
@@ -21127,7 +20900,7 @@ snapshots:
       "@types/node": 17.0.45
       "@types/sax": 1.2.7
       arg: 5.0.2
-      sax: 1.6.0
+      sax: 1.6.1
 
   skin-tone@2.0.0:
     dependencies:
@@ -21136,16 +20909,6 @@ snapshots:
   slash@3.0.0: {}
 
   slash@4.0.0: {}
-
-  slice-ansi@7.1.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
-
-  slice-ansi@8.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 5.1.0
 
   snake-case@3.0.4:
     dependencies:
@@ -21173,9 +20936,9 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
-  spdy-transport@3.0.0:
+  spdy-transport@3.0.0(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -21184,13 +20947,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  spdy@4.0.2:
+  spdy@4.0.2(supports-color@8.1.1):
     dependencies:
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
-      spdy-transport: 3.0.0
+      spdy-transport: 3.0.0(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -21208,6 +20971,8 @@ snapshots:
 
   std-env@4.2.0: {}
 
+  strictdom@1.0.1: {}
+
   string-argv@0.3.2: {}
 
   string-width@4.2.3:
@@ -21220,17 +20985,6 @@ snapshots:
     dependencies:
       eastasianwidth: 0.2.0
       emoji-regex: 9.2.2
-      strip-ansi: 7.2.0
-
-  string-width@7.2.0:
-    dependencies:
-      emoji-regex: 10.6.0
-      get-east-asian-width: 1.6.0
-      strip-ansi: 7.2.0
-
-  string-width@8.2.2:
-    dependencies:
-      get-east-asian-width: 1.6.0
       strip-ansi: 7.2.0
 
   string_decoder@1.1.1:
@@ -21258,7 +21012,7 @@ snapshots:
 
   strip-ansi@7.2.0:
     dependencies:
-      ansi-regex: 6.2.2
+      ansi-regex: 6.3.0
 
   strip-bom-string@1.0.0: {}
 
@@ -21276,10 +21030,10 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  stylehacks@6.1.1(postcss@8.5.16):
+  stylehacks@6.1.1(postcss@8.5.26):
     dependencies:
-      browserslist: 4.28.5
-      postcss: 8.5.16
+      browserslist: 4.28.8
+      postcss: 8.5.26
       postcss-selector-parser: 6.1.4
 
   stylis@4.4.0: {}
@@ -21294,9 +21048,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
-  svg-parser@2.0.4: {}
+  svg-parser@2.0.5: {}
 
-  svgo@3.3.3:
+  svgo@3.3.4:
     dependencies:
       commander: 7.2.0
       css-select: 5.2.2
@@ -21304,19 +21058,19 @@ snapshots:
       css-what: 6.2.2
       csso: 5.0.5
       picocolors: 1.1.1
-      sax: 1.6.0
+      sax: 1.6.1
 
-  swc-loader@0.2.7(@swc/core@1.15.43)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  swc-loader@0.2.7(@swc/core@1.16.1)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
-      "@swc/core": 1.15.43
+      "@swc/core": 1.16.1
       "@swc/counter": 0.1.3
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
   symbol-tree@3.2.4: {}
 
   tailwind-merge@3.6.0: {}
 
-  tailwindcss@4.3.2: {}
+  tailwindcss@4.3.3: {}
 
   tapable@2.3.3: {}
 
@@ -21335,28 +21089,31 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  terser-webpack-plugin@5.6.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  terser-webpack-plugin@5.6.1(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       "@jridgewell/trace-mapping": 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
-      terser: 5.49.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      terser: 5.50.0
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     optionalDependencies:
-      "@swc/core": 1.15.43
+      "@swc/core": 1.16.1
+      "@swc/html": 1.16.1
       clean-css: 5.3.3
-      cssnano: 6.1.2(postcss@8.5.16)
+      cssnano: 6.1.2(postcss@8.5.26)
+      csso: 5.0.5
       html-minifier-terser: 7.2.0
-      postcss: 8.5.16
+      lightningcss: 1.33.0
+      postcss: 8.5.26
 
-  terser@5.49.0:
+  terser@5.50.0:
     dependencies:
       "@jridgewell/source-map": 0.3.11
-      acorn: 8.17.0
+      acorn: 8.18.0
       commander: 2.20.3
       source-map-support: 0.5.21
 
-  thingies@2.6.0(tslib@2.8.1):
+  thingies@2.6.1(tslib@2.8.1):
     dependencies:
       tslib: 2.8.1
 
@@ -21368,7 +21125,7 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.2.4: {}
+  tinyexec@1.3.0: {}
 
   tinyglobby@0.2.17:
     dependencies:
@@ -21377,13 +21134,13 @@ snapshots:
 
   tinypool@1.1.1: {}
 
-  tinyrainbow@3.1.0: {}
+  tinyrainbow@3.1.1: {}
 
-  tldts-core@7.4.7: {}
+  tldts-core@7.4.10: {}
 
-  tldts@7.4.7:
+  tldts@7.4.10:
     dependencies:
-      tldts-core: 7.4.7
+      tldts-core: 7.4.10
 
   to-regex-range@5.0.1:
     dependencies:
@@ -21395,7 +21152,7 @@ snapshots:
 
   tough-cookie@6.0.2:
     dependencies:
-      tldts: 7.4.7
+      tldts: 7.4.10
 
   tr46@6.0.0:
     dependencies:
@@ -21459,17 +21216,17 @@ snapshots:
       "@gerrit0/mini-shiki": 3.23.0
       lunr: 2.3.9
       markdown-it: 14.3.0
-      minimatch: 10.2.5
+      minimatch: 10.2.6
       typescript: 6.0.3
       yaml: 2.9.0
 
-  typescript-eslint@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3):
+  typescript-eslint@8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3):
     dependencies:
-      "@typescript-eslint/eslint-plugin": 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      "@typescript-eslint/parser": 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      "@typescript-eslint/typescript-estree": 8.63.0(typescript@6.0.3)
-      "@typescript-eslint/utils": 8.63.0(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.6.0(jiti@2.7.0)
+      "@typescript-eslint/eslint-plugin": 8.67.0(@typescript-eslint/parser@8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      "@typescript-eslint/parser": 8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      "@typescript-eslint/typescript-estree": 8.67.0(supports-color@8.1.1)(typescript@6.0.3)
+      "@typescript-eslint/utils": 8.67.0(eslint@10.9.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      eslint: 10.9.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -21484,7 +21241,7 @@ snapshots:
 
   undici-types@8.3.0: {}
 
-  undici@7.28.0: {}
+  undici@7.29.0: {}
 
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
@@ -21544,30 +21301,30 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  unplugin-dts@1.0.3(@microsoft/api-extractor@7.58.9(@types/node@26.1.1))(@rspack/core@1.7.12)(rolldown@1.1.5)(typescript@6.0.3)(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))(webpack@5.108.4):
+  unplugin-dts@1.0.3(@microsoft/api-extractor@7.59.0(@types/node@26.2.0))(@rspack/core@1.7.12)(rolldown@1.2.5)(supports-color@8.1.1)(typescript@6.0.3)(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       "@rollup/pluginutils": 5.4.0
       "@volar/typescript": 2.4.28
       compare-versions: 6.1.1
-      debug: 4.4.3
+      debug: 4.4.3(supports-color@8.1.1)
       kolorist: 1.8.0
       local-pkg: 1.2.1
       magic-string: 0.30.21
       typescript: 6.0.3
       unplugin: 2.3.11
     optionalDependencies:
-      "@microsoft/api-extractor": 7.58.9(@types/node@26.1.1)
+      "@microsoft/api-extractor": 7.59.0(@types/node@26.2.0)
       "@rspack/core": 1.7.12
-      rolldown: 1.1.5
-      vite: 8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
-      webpack: 5.108.4
+      rolldown: 1.2.5
+      vite: 8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - supports-color
 
   unplugin@2.3.11:
     dependencies:
       "@jridgewell/remapping": 2.3.5
-      acorn: 8.17.0
+      acorn: 8.18.0
       picomatch: 4.0.5
       webpack-virtual-modules: 0.6.2
 
@@ -21577,9 +21334,9 @@ snapshots:
 
   unzipit@2.0.0: {}
 
-  update-browserslist-db@1.2.3(browserslist@4.28.5):
+  update-browserslist-db@1.3.1(browserslist@4.28.8):
     dependencies:
-      browserslist: 4.28.5
+      browserslist: 4.28.8
       escalade: 3.2.0
       picocolors: 1.1.1
 
@@ -21604,18 +21361,18 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)))(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)))(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      file-loader: 6.2.0(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
 
-  use-sync-external-store@1.6.0(react@19.2.7):
+  use-sync-external-store@1.6.0(react@19.2.8):
     dependencies:
-      react: 19.2.7
+      react: 19.2.8
 
   util-deprecate@1.0.2: {}
 
@@ -21625,7 +21382,7 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
-  uuid@14.0.1: {}
+  uuid@14.0.2: {}
 
   uuid@8.3.2: {}
 
@@ -21650,50 +21407,50 @@ snapshots:
       "@types/unist": 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-singlefile@2.3.3(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)):
+  vite-plugin-singlefile@2.3.3(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)):
     dependencies:
       micromatch: 4.0.8
-      vite: 8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
+      vite: 8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
 
-  vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0):
+  vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0):
     dependencies:
-      lightningcss: 1.32.0
+      lightningcss: 1.33.0
       picomatch: 4.0.5
-      postcss: 8.5.16
-      rolldown: 1.1.5
+      postcss: 8.5.26
+      rolldown: 1.2.5
       tinyglobby: 0.2.17
     optionalDependencies:
-      "@types/node": 26.1.1
+      "@types/node": 26.2.0
       fsevents: 2.3.3
       jiti: 2.7.0
-      terser: 5.49.0
+      terser: 5.50.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@26.1.1)(@vitest/coverage-v8@4.1.10)(jsdom@29.1.1(canvas@3.2.3))(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)):
+  vitest@4.1.11(@types/node@26.2.0)(@vitest/coverage-v8@4.1.11)(jsdom@29.1.1(canvas@3.2.3))(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)):
     dependencies:
-      "@vitest/expect": 4.1.10
-      "@vitest/mocker": 4.1.10(vite@8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0))
-      "@vitest/pretty-format": 4.1.10
-      "@vitest/runner": 4.1.10
-      "@vitest/snapshot": 4.1.10
-      "@vitest/spy": 4.1.10
-      "@vitest/utils": 4.1.10
-      es-module-lexer: 2.3.0
+      "@vitest/expect": 4.1.11
+      "@vitest/mocker": 4.1.11(vite@8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
+      "@vitest/pretty-format": 4.1.11
+      "@vitest/runner": 4.1.11
+      "@vitest/snapshot": 4.1.11
+      "@vitest/spy": 4.1.11
+      "@vitest/utils": 4.1.11
+      es-module-lexer: 2.3.2
       expect-type: 1.4.0
       magic-string: 0.30.21
-      obug: 2.1.3
+      obug: 2.1.4
       pathe: 2.0.3
       picomatch: 4.0.5
       std-env: 4.2.0
       tinybench: 2.9.0
-      tinyexec: 1.2.4
+      tinyexec: 1.3.0
       tinyglobby: 0.2.17
-      tinyrainbow: 3.1.0
-      vite: 8.1.4(@types/node@26.1.1)(jiti@2.7.0)(terser@5.49.0)(yaml@2.9.0)
+      tinyrainbow: 3.1.1
+      vite: 8.2.2(@types/node@26.2.0)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      "@types/node": 26.1.1
-      "@vitest/coverage-v8": 4.1.10(vitest@4.1.10)
+      "@types/node": 26.2.0
+      "@vitest/coverage-v8": 4.1.11(vitest@4.1.11)
       jsdom: 29.1.1(canvas@3.2.3)
     transitivePeerDependencies:
       - msw
@@ -21719,7 +21476,7 @@ snapshots:
   webpack-bundle-analyzer@4.10.2:
     dependencies:
       "@discoveryjs/json-ext": 0.5.7
-      acorn: 8.17.0
+      acorn: 8.18.0
       acorn-walk: 8.3.5
       commander: 7.2.0
       debounce: 1.2.1
@@ -21729,25 +21486,23 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 2.0.4
-      ws: 7.5.11
+      ws: 7.5.13
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
 
-  webpack-dev-middleware@7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  webpack-dev-middleware@7.4.5(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       colorette: 2.0.20
-      memfs: 4.64.0(tslib@2.8.1)
+      memfs: 4.68.1
       mime-types: 3.0.2
       on-finished: 2.4.1
       range-parser: 1.3.0
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
-    transitivePeerDependencies:
-      - tslib
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
-  webpack-dev-server@5.2.6(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  webpack-dev-server@5.2.6(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       "@types/bonjour": 3.5.13
       "@types/connect-history-api-fallback": 1.5.4
@@ -21758,32 +21513,31 @@ snapshots:
       "@types/sockjs": 0.3.36
       "@types/ws": 8.18.1
       ansi-html-community: 0.0.8
-      bonjour-service: 1.4.3
+      bonjour-service: 1.4.4
       chokidar: 3.6.0
       colorette: 2.0.20
-      compression: 1.8.1
+      compression: 1.8.1(supports-color@8.1.1)
       connect-history-api-fallback: 2.0.0
-      express: 4.22.2
+      express: 4.22.2(supports-color@8.1.1)
       graceful-fs: 4.2.11
-      http-proxy-middleware: 2.0.10(@types/express@4.17.25)
-      ipaddr.js: 2.4.0
+      http-proxy-middleware: 2.0.10(@types/express@4.17.25)(debug@4.4.3(supports-color@8.1.1))
+      ipaddr.js: 2.5.0
       launch-editor: 2.14.1
       open: 10.2.0
       p-retry: 6.2.1
       schema-utils: 4.3.3
       selfsigned: 5.5.0
-      serve-index: 1.9.2
+      serve-index: 1.9.2(supports-color@8.1.1)
       sockjs: 0.3.24
-      spdy: 4.0.2
-      webpack-dev-middleware: 7.4.5(tslib@2.8.1)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      ws: 8.21.0
+      spdy: 4.0.2(supports-color@8.1.1)
+      webpack-dev-middleware: 7.4.5(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
+      ws: 8.21.3
     optionalDependencies:
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
     transitivePeerDependencies:
       - bufferutil
       - debug
       - supports-color
-      - tslib
       - utf-8-validate
 
   webpack-merge@5.10.0:
@@ -21802,64 +21556,23 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.108.4:
+  webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26):
     dependencies:
       "@types/estree": 1.0.9
       "@types/json-schema": 7.0.15
       "@webassemblyjs/ast": 1.14.1
       "@webassemblyjs/wasm-edit": 1.14.1
       "@webassemblyjs/wasm-parser": 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.5
+      acorn: 8.18.0
+      browserslist: 4.28.8
       chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.2
-      es-module-lexer: 2.3.0
+      enhanced-resolve: 5.24.5
+      es-module-lexer: 2.3.2
       eslint-scope: 5.1.1
       events: 3.3.0
       graceful-fs: 4.2.11
-      loader-runner: 4.3.2
       mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(webpack@5.108.4)
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.1
-    transitivePeerDependencies:
-      - "@minify-html/node"
-      - "@swc/core"
-      - "@swc/css"
-      - "@swc/html"
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-    optional: true
-
-  webpack@5.108.4(@swc/core@1.15.43)(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.16):
-    dependencies:
-      "@types/estree": 1.0.9
-      "@types/json-schema": 7.0.15
-      "@webassemblyjs/ast": 1.14.1
-      "@webassemblyjs/wasm-edit": 1.14.1
-      "@webassemblyjs/wasm-parser": 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.5
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.2
-      es-module-lexer: 2.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43)(@swc/html@1.15.43)(lightningcss@1.32.0)(postcss@8.5.16)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
+      minimizer-webpack-plugin: 5.6.1(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26))
       neo-async: 2.6.2
       schema-utils: 4.3.3
       tapable: 2.3.3
@@ -21879,83 +21592,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  webpack@5.108.4(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16):
-    dependencies:
-      "@types/estree": 1.0.9
-      "@types/json-schema": 7.0.15
-      "@webassemblyjs/ast": 1.14.1
-      "@webassemblyjs/wasm-edit": 1.14.1
-      "@webassemblyjs/wasm-parser": 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.5
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.2
-      es-module-lexer: 2.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.16))(html-minifier-terser@7.2.0)(postcss@8.5.16)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.1
-    transitivePeerDependencies:
-      - "@minify-html/node"
-      - "@swc/core"
-      - "@swc/css"
-      - "@swc/html"
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16):
-    dependencies:
-      "@types/estree": 1.0.9
-      "@types/json-schema": 7.0.15
-      "@webassemblyjs/ast": 1.14.1
-      "@webassemblyjs/wasm-edit": 1.14.1
-      "@webassemblyjs/wasm-parser": 1.14.1
-      acorn: 8.17.0
-      acorn-import-phases: 1.0.4(acorn@8.17.0)
-      browserslist: 4.28.5
-      chrome-trace-event: 1.0.4
-      enhanced-resolve: 5.24.2
-      es-module-lexer: 2.3.0
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      graceful-fs: 4.2.11
-      loader-runner: 4.3.2
-      mime-db: 1.54.0
-      minimizer-webpack-plugin: 5.6.1(@swc/core@1.15.43)(postcss@8.5.16)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16))
-      neo-async: 2.6.2
-      schema-utils: 4.3.3
-      tapable: 2.3.3
-      watchpack: 2.5.2
-      webpack-sources: 3.5.1
-    transitivePeerDependencies:
-      - "@minify-html/node"
-      - "@swc/core"
-      - "@swc/css"
-      - "@swc/html"
-      - clean-css
-      - cssnano
-      - csso
-      - esbuild
-      - html-minifier-terser
-      - lightningcss
-      - postcss
-      - uglify-js
-
-  webpackbar@7.0.0(@rspack/core@1.7.12)(webpack@5.108.4(@swc/core@1.15.43)(postcss@8.5.16)):
+  webpackbar@7.0.0(@rspack/core@1.7.12)(webpack@5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)):
     dependencies:
       ansis: 3.17.0
       consola: 3.4.2
@@ -21963,7 +21600,7 @@ snapshots:
       std-env: 3.10.0
     optionalDependencies:
       "@rspack/core": 1.7.12
-      webpack: 5.108.4(@swc/core@1.15.43)(postcss@8.5.16)
+      webpack: 5.109.2(@swc/core@1.16.1)(@swc/html@1.16.1)(clean-css@5.3.3)(cssnano@6.1.2(postcss@8.5.26))(csso@5.0.5)(html-minifier-terser@7.2.0)(lightningcss@1.33.0)(postcss@8.5.26)
 
   websocket-driver@0.7.5:
     dependencies:
@@ -22000,22 +21637,10 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
-  wrap-ansi@10.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 8.2.2
-      strip-ansi: 7.2.0
-
   wrap-ansi@8.1.0:
     dependencies:
       ansi-styles: 6.2.3
       string-width: 5.1.2
-      strip-ansi: 7.2.0
-
-  wrap-ansi@9.0.2:
-    dependencies:
-      ansi-styles: 6.2.3
-      string-width: 7.2.0
       strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
@@ -22027,9 +21652,9 @@ snapshots:
       signal-exit: 3.0.7
       typedarray-to-buffer: 3.1.5
 
-  ws@7.5.11: {}
+  ws@7.5.13: {}
 
-  ws@8.21.0: {}
+  ws@8.21.3: {}
 
   wsl-utils@0.1.0:
     dependencies:
@@ -22039,7 +21664,7 @@ snapshots:
 
   xml-js@1.6.11:
     dependencies:
-      sax: 1.6.0
+      sax: 1.6.1
 
   xml-name-validator@5.0.0: {}
 
@@ -22064,11 +21689,11 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@5.0.14(@types/react@19.2.17)(immer@11.1.11)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+  zustand@5.0.15(@types/react@19.2.18)(immer@11.1.18)(react@19.2.8)(use-sync-external-store@1.6.0(react@19.2.8)):
     optionalDependencies:
-      "@types/react": 19.2.17
-      immer: 11.1.11
-      react: 19.2.7
-      use-sync-external-store: 1.6.0(react@19.2.7)
+      "@types/react": 19.2.18
+      immer: 11.1.18
+      react: 19.2.8
+      use-sync-external-store: 1.6.0(react@19.2.8)
 
   zwitch@2.0.4: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,13 +8,7 @@ allowBuilds:
   core-js: true
   omezarr-tilesource: true
 
+minimumReleaseAge: 1440
+
 minimumReleaseAgeExclude:
   - "@types/node@26.0.1"
-
-onlyBuiltDependencies:
-  - "@swc/core"
-  - canvas
-  - core-js
-  - core-js-pure
-  - esbuild
-  - omezarr-tilesource

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,12 +1,12 @@
 {
   "compilerOptions": {
     "target": "ES2025",
-    "useDefineForClassFields": true,
     "module": "ESNext",
     "skipLibCheck": true,
 
     /* Bundler mode */
     "moduleResolution": "bundler",
+    "customConditions": ["tissuumaps-development"],
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",


### PR DESCRIPTION
# References and relevant issues

<!--
What relevant resources were used in the creation of this PR?
If this PR addresses an existing issue on the repo, please link to that issue here as "Closes #(issue-number)".
If this PR depends on another PR (even in another repo), please link to it with "Depends on #(PR-number)" or "Depends on org/repo#(PR-number)".
-->

None.

# Type of change

<!-- If "Other", please specify. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

<!-- Specify what changes have been made and why. -->

- Updated dependencies across the monorepo (Vite 8.2.2 / Rolldown, Vitest 4.1.11, ESLint 10.9.0, React 19.2.8, OpenSeadragon 6.1.0, TypeScript ESLint 8.67.0, and transitive updates), and refreshed `pnpm-lock.yaml`.
- Replaced the generic `development` export condition with a project-specific `tissuumaps-development` condition in all workspace packages, wired through `tsconfig.base.json` (`customConditions`) and the Vite configs (`resolve.conditions` / `ssr.resolve.conditions`, development-only). The generic `development` condition is set by tooling we do not control and was leaking source-resolution into non-development builds.
- Upgraded the Vite configs: `rollupOptions` → `rolldownOptions`, `__dirname` → `import.meta.dirname`, explicit `external` lists for peer dependencies, and disabled Rolldown plugin timing checks.
- Declared `openseadragon` and `zustand` as peer dependencies (with matching dev dependencies) where they were previously bundled or implicitly resolved; added `openseadragon` to `@tissuumaps/storage`, dropped the unused `geojson` dependency, and added `@tissuumaps/plugins` to the app dependencies.
- Added `"license": "MIT"` to all published packages; moved `engines` to a consistent position and added a `pnpm: ">=11.15.1"` engine constraint at the root.
- Set `minimumReleaseAge: 1440` in `pnpm-workspace.yaml` (and dropped the now-redundant `onlyBuiltDependencies`, superseded by `allowBuilds`).
- Switched CI and deploy workflows to `pnpm install --frozen-lockfile` so builds fail on an out-of-date lockfile instead of silently resolving new versions.
- ESLint: enabled `object-shorthand`, removed `@typescript-eslint/promise-function-async` (superseded by the `require-await`-based convention).
- Removed `useDefineForClassFields` from `tsconfig.base.json` (now the default at the configured target) and fixed `clean` script ordering/paths.

# Screenshot of the fix

<!-- Attach screenshot if relevant. -->

N/A.

# Use of AI

<!-- Please specify if AI was used in any way during the process of creating the pull request and the code inside it. If yes, specify in which way it was used. -->

AI (Claude Code) was used to summarize the diff for this PR description. The changes themselves were made with supervised support of Claude Code.

# Testing

<!-- Please delete options that are not relevant -->

- A rebuild is needed due to new dependencies
- Instructions on how to test: run `pnpm install --frozen-lockfile`, then `pnpm run build`, `pnpm run lint`, and `pnpm run test`. Also verify `pnpm run dev` still resolves workspace packages to their sources (via the `tissuumaps-development` condition) and that a production build resolves to `dist`.

# Further comments

<!-- Specify questions or related information. -->

Note the pnpm version requirement (`>=11.15.1`) for `minimumReleaseAge` / `allowBuilds` support.

<!--
Final Checklist:
- My PR is the minimum possible work for the desired functionality
- I have commented my code, particularly in hard-to-understand areas
- I have made corresponding changes to docstrings and documentation (if applicable)
- I have added tests that prove my fix is effective or that my feature works (if applicable)
-->
