### PR TITLE
refactor: async style, abort handling and WebGL points renderer init

### DIFF
--- a/apps/tissuumaps/src/hooks/useControlled.ts
+++ b/apps/tissuumaps/src/hooks/useControlled.ts
@@ -1,5 +1,19 @@
 import { useState } from "react";
 
+/**
+ * Backs a component value that may be controlled by its parent or not
+ *
+ * The value is controlled whenever `controlledValue` is not `undefined`;
+ * otherwise, the internally kept value is used. In both cases, the returned
+ * setter updates the internal value and notifies `setControlledValue`, so that
+ * a component switching from uncontrolled to controlled does not jump back to
+ * an outdated value.
+ *
+ * @param controlledValue - The value set by the parent, if it is controlling it
+ * @param setControlledValue - Called with every new value, if provided
+ * @param defaultUncontrolledValue - The initial value used while uncontrolled
+ * @returns The current value and a setter for it
+ */
 export function useControlled<T>(
   controlledValue: T | undefined,
   setControlledValue: ((value: T) => void) | undefined,

--- a/packages/@tissuumaps-storage/src/csv/CSVTableData.ts
+++ b/packages/@tissuumaps-storage/src/csv/CSVTableData.ts
@@ -1,7 +1,6 @@
 import {
   type GenericArray,
   ParseUtils,
-  type ProgressCallback,
   type TableData,
   type TypedArray,
 } from "@tissuumaps/core";
@@ -43,61 +42,48 @@ export class CSVTableData implements TableData {
     return this._names;
   }
 
-  async suggestColumnQueries(
-    currentQuery: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string[]> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
+  suggestColumnQueries(currentQuery: string): Promise<string[]> {
     const filteredColumns = this._columns.filter((column) =>
       column.includes(currentQuery),
     );
     return Promise.resolve(filteredColumns);
   }
 
-  async resolveColumnQuery(
-    query: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string | null> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
+  resolveColumnQuery(query: string): Promise<string | null> {
     const column = this._columns.includes(query) ? query : null;
     return Promise.resolve(column);
   }
 
-  async loadValues<T>(
-    column: string,
-    options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
-  ): Promise<GenericArray<T>> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
+  loadValues<T>(column: string): Promise<GenericArray<T>> {
     const columnValues = this._columnValues.get(column);
     if (columnValues === undefined) {
-      throw new Error(`Column ${column} does not exist in the table`);
+      return Promise.reject(
+        new Error(`Column ${column} does not exist in the table`),
+      );
     }
     return Promise.resolve(columnValues as GenericArray<T>);
   }
 
   async loadUniqueValues<T>(
     column: string,
-    options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
+    options?: { signal?: AbortSignal },
   ): Promise<GenericArray<T>> {
-    const { signal, onProgress } = options ?? {};
+    const { signal } = options ?? {};
     signal?.throwIfAborted();
-    const values = await this.loadValues(column, { signal, onProgress });
-    signal?.throwIfAborted(); // bail out before the O(n) Set construction below
+    const values = await this.loadValues(column);
+    signal?.throwIfAborted(); // loadValues() does not throw on abort
     const uniqueValues = Array.from(new Set(values));
     return uniqueValues as GenericArray<T>;
   }
 
   async loadValueRange(
     column: string,
-    options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
+    options?: { signal?: AbortSignal },
   ): Promise<[number, number] | undefined> {
-    const { signal, onProgress } = options ?? {};
+    const { signal } = options ?? {};
     signal?.throwIfAborted();
-    const values = await this.loadValues(column, { signal, onProgress });
-    signal?.throwIfAborted(); // bail out before the O(n) min/max scan below
+    const values = await this.loadValues(column);
+    signal?.throwIfAborted(); // loadValues() does not throw on abort
     if (typeof values[0] === "number") {
       let vmin, vmax;
       for (let i = 0; i < values.length; i++) {

--- a/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesData.ts
+++ b/packages/@tissuumaps-storage/src/geojson/GeoJSONShapesData.ts
@@ -1,8 +1,4 @@
-import type {
-  ProgressCallback,
-  ShapesData,
-  ShapesGeometry,
-} from "@tissuumaps/core";
+import type { ShapesData, ShapesGeometry } from "@tissuumaps/core";
 
 export class GeoJSONShapesData implements ShapesData {
   private readonly _geometry: ShapesGeometry;
@@ -35,12 +31,7 @@ export class GeoJSONShapesData implements ShapesData {
     return this._names;
   }
 
-  async loadGeometry(options?: {
-    signal?: AbortSignal;
-    onProgress?: ProgressCallback;
-  }): Promise<ShapesGeometry> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
+  loadGeometry(): Promise<ShapesGeometry> {
     return Promise.resolve(this._geometry);
   }
 

--- a/packages/@tissuumaps-storage/src/geojson/runGeoJSONWorker.ts
+++ b/packages/@tissuumaps-storage/src/geojson/runGeoJSONWorker.ts
@@ -7,14 +7,16 @@ import type {
 } from "./geojson.worker";
 import GeoJSONWorker from "./geojson.worker?worker&inline";
 
-export async function runGeoJSONWorker<TRequest extends GeoJSONWorkerRequest>(
+export function runGeoJSONWorker<TRequest extends GeoJSONWorkerRequest>(
   request: TRequest,
   options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
 ): Promise<GeoJSONWorkerResponseFor<TRequest>> {
   const { signal, onProgress } = options ?? {};
-  signal?.throwIfAborted();
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason as Error);
+  }
   const worker = new GeoJSONWorker();
-  return await new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const onAbort = () => {
       worker.terminate();
       reject(signal!.reason as Error);

--- a/packages/@tissuumaps-storage/src/parquet/ParquetTableData.ts
+++ b/packages/@tissuumaps-storage/src/parquet/ParquetTableData.ts
@@ -44,24 +44,14 @@ export class ParquetTableData implements TableData {
     return this._names;
   }
 
-  async suggestColumnQueries(
-    currentQuery: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string[]> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
+  suggestColumnQueries(currentQuery: string): Promise<string[]> {
     const filteredColumns = this._columns.filter((column) =>
       column.includes(currentQuery),
     );
     return Promise.resolve(filteredColumns);
   }
 
-  async resolveColumnQuery(
-    query: string,
-    options?: { signal?: AbortSignal },
-  ): Promise<string | null> {
-    const { signal } = options ?? {};
-    signal?.throwIfAborted();
+  resolveColumnQuery(query: string): Promise<string | null> {
     const column = this._columns.includes(query) ? query : null;
     return Promise.resolve(column);
   }
@@ -86,7 +76,6 @@ export class ParquetTableData implements TableData {
     const { signal, onProgress } = options ?? {};
     signal?.throwIfAborted();
     const values = await this.loadValues(column, { signal, onProgress });
-    signal?.throwIfAborted(); // bail out before the O(n) Set construction below
     const uniqueValues = Array.from(new Set(values));
     return uniqueValues as GenericArray<T>;
   }

--- a/packages/@tissuumaps-storage/src/parquet/parquet.worker.ts
+++ b/packages/@tissuumaps-storage/src/parquet/parquet.worker.ts
@@ -107,21 +107,21 @@ ctx.onmessage = (event) => {
   })();
 };
 
-async function openParquet(source: ParquetSource): Promise<AsyncBuffer> {
+function openParquet(source: ParquetSource): Promise<AsyncBuffer> {
   if (source.file !== undefined) {
-    return {
+    return Promise.resolve({
       byteLength: source.file.size,
-      slice: async (start: number, end?: number) =>
+      slice: (start: number, end?: number) =>
         source.file!.slice(start, end).arrayBuffer(),
-    };
+    });
   }
   if (source.url !== undefined) {
-    return await asyncBufferFromUrl({
+    return asyncBufferFromUrl({
       url: source.url,
       requestInit: { headers: source.headers },
     });
   }
-  throw new Error("A URL or file is required to load data.");
+  return Promise.reject(new Error("A URL or file is required to load data."));
 }
 
 function getNumRows(metadata: FileMetaData): number {

--- a/packages/@tissuumaps-storage/src/parquet/runParquetWorker.ts
+++ b/packages/@tissuumaps-storage/src/parquet/runParquetWorker.ts
@@ -7,14 +7,16 @@ import type {
 } from "./parquet.worker";
 import ParquetWorker from "./parquet.worker?worker&inline";
 
-export async function runParquetWorker<TRequest extends ParquetWorkerRequest>(
+export function runParquetWorker<TRequest extends ParquetWorkerRequest>(
   request: TRequest,
   options?: { signal?: AbortSignal; onProgress?: ProgressCallback },
 ): Promise<ParquetWorkerResponseFor<TRequest>> {
   const { signal, onProgress } = options ?? {};
-  signal?.throwIfAborted();
+  if (signal?.aborted) {
+    return Promise.reject(signal.reason as Error);
+  }
   const worker = new ParquetWorker();
-  return await new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const onAbort = () => {
       worker.terminate();
       reject(signal!.reason as Error);

--- a/packages/@tissuumaps-storage/src/table/TablePointsData.ts
+++ b/packages/@tissuumaps-storage/src/table/TablePointsData.ts
@@ -43,7 +43,6 @@ export class TablePointsData implements PointsData {
       onProgress,
     });
     let [xs, ys] = await Promise.all([xPromise, yPromise]);
-    signal?.throwIfAborted(); // bail out before the O(n) Float32Array conversions below
     if (!(xs instanceof Float32Array)) {
       xs = new Float32Array(xs);
     }

--- a/packages/@tissuumaps-viewer/src/adapter.ts
+++ b/packages/@tissuumaps-viewer/src/adapter.ts
@@ -20,7 +20,6 @@ import type {
 } from "@tissuumaps/core";
 
 export interface ViewerAdapter {
-  interactionMode: InteractionMode;
   layers: Layer[];
   images: Image[];
   labels: Labels[];
@@ -54,5 +53,8 @@ export interface ViewerAdapter {
     table: Table,
     options?: { signal?: AbortSignal },
   ) => Promise<TableData>;
+
+  // shapes drawing
+  interactionMode: InteractionMode;
   addShape?: (shape: MultiPolygon) => void;
 }

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -82,37 +82,37 @@ export function useWebGL(
       if (containerSizeRef.current !== null) {
         context.resizeCanvas(canvas, containerSizeRef.current);
       }
-      let pointsRenderer: WebGLPointsRenderer | undefined;
+      const {
+        promise: pointsRendererInitPromise,
+        resolve: resolvePointsRendererInitPromise,
+        reject: rejectPointsRendererInitPromise,
+      } = Promise.withResolvers<void>();
+      pointsRendererInitPromise.catch(() => {}); // prevent unhandled rejections in console
+      let pointsRenderer: WebGLPointsRenderer;
       try {
-        pointsRenderer = await new Promise<WebGLPointsRenderer>(
-          (resolve, reject) => {
-            try {
-              const pointsRenderer = new WebGLPointsRenderer(
-                context,
-                () => resolve(pointsRenderer),
-                reject,
-                {
-                  viewport: viewportRef.current ?? undefined,
-                  renderOptions: glOptionsRef.current.pointsRenderOptions,
-                  signal: abortController.signal,
-                },
-              );
-            } catch (error) {
-              reject(
-                new Error("Error creating points renderer", { cause: error }),
-              );
-            }
+        pointsRenderer = new WebGLPointsRenderer(
+          context,
+          resolvePointsRendererInitPromise,
+          rejectPointsRendererInitPromise,
+          {
+            viewport: viewportRef.current ?? undefined,
+            renderOptions: glOptionsRef.current.pointsRenderOptions,
+            signal: abortController.signal,
           },
         );
-        abortController.signal.throwIfAborted();
       } catch (error) {
-        if (pointsRenderer !== undefined) {
-          pointsRenderer.destroy();
-        }
+        context.destroy();
+        throw new Error("Error creating points renderer", { cause: error });
+      }
+      try {
+        await pointsRendererInitPromise;
+        abortController.signal.throwIfAborted(); // points renderer does not throw on abort
+      } catch (error) {
+        pointsRenderer.destroy();
         context.destroy();
         throw error;
       }
-      let shapesRenderer: WebGLShapesRenderer | undefined;
+      let shapesRenderer: WebGLShapesRenderer;
       try {
         shapesRenderer = new WebGLShapesRenderer(context, {
           viewport: viewportRef.current ?? undefined,


### PR DESCRIPTION
# References and relevant issues

Follow-up cleanups on top of #168. No issue.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- **`useWebGL`: points renderer init rewritten around `Promise.withResolvers`.** The renderer used to be constructed *inside* a `new Promise` executor while its own `onReady`/`onError` callbacks closed over the variable being assigned. Now the resolvers are created first and the constructor runs outside the promise, which separates the two failure modes: a throwing constructor destroys the context and is wrapped as "Error creating points renderer", while a failed (or aborted) initialization destroys renderer *and* context and rethrows as-is. `pointsRenderer` is no longer `| undefined`, and the init promise gets a no-op `.catch()` so a rejection handled later does not surface as an unhandled rejection.
- **Sync-bodied promise-returning functions are no longer `async`**, per the repo's async style rule: `CSVTableData.suggestColumnQueries`/`resolveColumnQuery`/`loadValues`, `ParquetTableData.suggestColumnQueries`/`resolveColumnQuery`, `GeoJSONShapesData.loadGeometry`, `runGeoJSONWorker`, `runParquetWorker` and `parquet.worker`'s `openParquet` now return `Promise.resolve`/`Promise.reject` instead of throwing out of an `async` body.
- **Dropped unused `options` parameters** from those same in-memory accessors — they resolve data that is already in memory, so there was nothing for `signal`/`onProgress` to do. The `TableData`/`ShapesData` interfaces in `@tissuumaps/core` are unchanged; the implementations simply take fewer parameters.
- **Removed redundant `throwIfAborted()` calls** where the awaited call already rejects on abort (`ParquetTableData.loadUniqueValues`, `TablePointsData.loadGeometry`). The remaining checks in `CSVTableData.loadUniqueValues`/`loadValueRange` stay, now with a comment saying why they are still needed (`loadValues()` no longer throws on abort there).
- **`runGeoJSONWorker`/`runParquetWorker`** report an already-aborted signal as a rejection instead of a synchronous throw, so callers see one consistent failure path.
- **`ViewerAdapter`: `interactionMode` moved** next to `addShape` under a `// shapes drawing` comment. Grouping only, no signature change.
- **TSDoc added for `useControlled`**, documenting the controlled/uncontrolled switch and why the setter also updates the internal value.

# Screenshot of the fix

N/A — no user-visible change intended.

# Use of AI

Yes. The changes and this description were written with the assistance of Claude Code (Opus 5).

# Testing

- Instructions on how to test

Refactor only; existing tests cover the touched data classes. Worth exercising by hand: WebGL startup (including a mount/unmount that aborts init mid-flight) and loading CSV/Parquet/GeoJSON objects.

# Further comments

Two deliberate behavior changes around abort, both on already-in-memory paths: passing an *already aborted* signal to `CSVTableData.loadValues`, `GeoJSONShapesData.loadGeometry` or the two `resolveColumnQuery`/`suggestColumnQueries` pairs now resolves rather than rejecting, and `TablePointsData.loadGeometry` no longer bails out between the awaited column loads and the `Float32Array` conversions, so a late abort still pays for those conversions.
