### PR TITLE
feat(image)!: multi-channel image rendering with per-channel color and opacity

### DIFF
--- a/apps/tissuumaps/src/data/cache/wrappers/ImageDataWrapper.ts
+++ b/apps/tissuumaps/src/data/cache/wrappers/ImageDataWrapper.ts
@@ -13,8 +13,16 @@ export class ImageDataWrapper
   extends DataWrapperBase<ImageData>
   implements ImageData
 {
-  getTileSource(): string | TileSourceConfig | CustomTileSource {
+  getSizeC(): number | undefined {
+    return this.data.getSizeC();
+  }
+
+  getChannelNames(): string[] | undefined {
+    return this.data.getChannelNames();
+  }
+
+  getTileSource(c?: number): string | TileSourceConfig | CustomTileSource {
     // caching is handled by renderers
-    return this.data.getTileSource();
+    return this.data.getTileSource(c);
   }
 }

--- a/apps/tissuumaps/src/data/cache/wrappers/ImageDataWrapper.ts
+++ b/apps/tissuumaps/src/data/cache/wrappers/ImageDataWrapper.ts
@@ -1,4 +1,5 @@
 import type {
+  Color,
   CustomTileSource,
   ImageData,
   TileSourceConfig,
@@ -17,12 +18,24 @@ export class ImageDataWrapper
     return this.data.getSizeC();
   }
 
-  getChannelNames(): string[] | undefined {
-    return this.data.getChannelNames();
-  }
-
   getTileSource(c?: number): string | TileSourceConfig | CustomTileSource {
     // caching is handled by renderers
     return this.data.getTileSource(c);
+  }
+
+  getChannelName(c: number): string | undefined {
+    return this.data.getChannelName?.(c);
+  }
+
+  getChannelVisibility(c: number): boolean | undefined {
+    return this.data.getChannelVisibility?.(c);
+  }
+
+  getChannelOpacity(c: number): number | undefined {
+    return this.data.getChannelOpacity?.(c);
+  }
+
+  getChannelColor(c: number): Color | undefined {
+    return this.data.getChannelColor?.(c);
   }
 }

--- a/packages/@tissuumaps-core/src/index.ts
+++ b/packages/@tissuumaps-core/src/index.ts
@@ -58,6 +58,7 @@ export {
   createImageDataSource,
   imageDataSourceDefaults,
   imageDefaults,
+  type Channel,
   type Image,
   type ImageDataSource,
   type RawImage,

--- a/packages/@tissuumaps-core/src/model/image.ts
+++ b/packages/@tissuumaps-core/src/model/image.ts
@@ -13,12 +13,28 @@ import {
 export const imageDefaults = {} as const satisfies Partial<RawImage>;
 
 /**
+ * A channel of a two-dimensional raster image
+ */
+export type Channel = {
+  /** The name of the channel (overrides data provider) */
+  name?: string;
+
+  /** The visibility of the channel */
+  visibility?: boolean;
+
+  /** The opacity of the channel */
+  opacity?: number;
+};
+
+/**
  * A two-dimensional raster image
  */
-// eslint-disable-next-line @typescript-eslint/no-empty-object-type
 export interface RawImage extends RawSingleLayerDataObject<
   RawImageDataSource<string>
-> {}
+> {
+  /** The channels of the image */
+  channels?: Channel[];
+}
 
 /**
  * A {@link RawImage} with {@link imageDefaults} applied

--- a/packages/@tissuumaps-core/src/model/image.ts
+++ b/packages/@tissuumaps-core/src/model/image.ts
@@ -14,15 +14,28 @@ export const imageDefaults = {} as const satisfies Partial<RawImage>;
 
 /**
  * A channel of a two-dimensional raster image
+ *
+ * Channels are only applied to multi-channel image data, as reported by the
+ * image's data provider.
  */
 export type Channel = {
-  /** The name of the channel (overrides data provider) */
+  /**
+   * Channel name, overriding the name reported by the data provider
+   */
   name?: string;
 
-  /** The visibility of the channel */
+  /**
+   * Channel visibility
+   *
+   * @defaultValue `true`
+   */
   visibility?: boolean;
 
-  /** The opacity of the channel */
+  /**
+   * Channel opacity, in the range [0, 1], multiplied with the image opacity
+   *
+   * @defaultValue `1`
+   */
   opacity?: number;
 };
 
@@ -32,7 +45,12 @@ export type Channel = {
 export interface RawImage extends RawSingleLayerDataObject<
   RawImageDataSource<string>
 > {
-  /** The channels of the image */
+  /**
+   * The channels of the image, indexed by channel
+   *
+   * Channels beyond the end of the array, and channels of images whose data is
+   * not multi-channel, use the default values of {@link Channel}.
+   */
   channels?: Channel[];
 }
 

--- a/packages/@tissuumaps-core/src/model/image.ts
+++ b/packages/@tissuumaps-core/src/model/image.ts
@@ -6,6 +6,7 @@ import {
   createDataSource,
   createSingleLayerDataObject,
 } from "./base";
+import type { Color } from "./primitives";
 
 /**
  * Default values for {@link RawImage}
@@ -37,6 +38,13 @@ export type Channel = {
    * @defaultValue `1`
    */
   opacity?: number;
+
+  /**
+   * Channel color, multiplied with the channel's image data
+   *
+   * Without a color, the channel's image data is rendered in its own colors.
+   */
+  color?: Color;
 };
 
 /**

--- a/packages/@tissuumaps-core/src/storage/image.ts
+++ b/packages/@tissuumaps-core/src/storage/image.ts
@@ -1,4 +1,5 @@
 import type { ImageDataSource } from "../model/image";
+import type { Color } from "../model/primitives";
 import type { Data, DataProvider } from "./base";
 
 /**
@@ -27,9 +28,6 @@ export interface ImageData extends Data {
   /** Returns the number of channels in the image, or undefined if not multi-channel */
   getSizeC(): number | undefined;
 
-  /** Returns the names of the image's channels, or undefined if not multi-channel */
-  getChannelNames(): string[] | undefined;
-
   /**
    * Returns the tile source of a channel, or the only tile source of image data that is not multi-channel
    *
@@ -41,6 +39,18 @@ export interface ImageData extends Data {
    * passed for image data that is not multi-channel, or if `c` is out of bounds
    */
   getTileSource(c?: number): string | TileSourceConfig | CustomTileSource;
+
+  /** Returns the name of a specific channel, or undefined if not multi-channel */
+  getChannelName?: (c: number) => string | undefined;
+
+  /** Returns the visibility of a specific channel, or undefined if not multi-channel or not available */
+  getChannelVisibility?: (c: number) => boolean | undefined;
+
+  /** Returns the opacity of a specific channel, or undefined if not multi-channel or not available */
+  getChannelOpacity?: (c: number) => number | undefined;
+
+  /** Returns the color of a specific channel, or undefined if not multi-channel or notavailable */
+  getChannelColor?: (c: number) => Color | undefined;
 }
 
 /** Configuration object accepted by OpenSeadragon as a tile source */

--- a/packages/@tissuumaps-core/src/storage/image.ts
+++ b/packages/@tissuumaps-core/src/storage/image.ts
@@ -18,8 +18,19 @@ export interface ImageDataProvider<
  * Loaded image data providing an OpenSeadragon-compatible tile source
  */
 export interface ImageData extends Data {
-  /** Returns a tile source descriptor for use with OpenSeadragon */
-  getTileSource(): string | TileSourceConfig | CustomTileSource;
+  /** Returns the number of channels in the image, or undefined if not multi-channel */
+  getSizeC(): number | undefined;
+
+  /** Returns the names of the image's channels, or undefined if not multi-channel */
+  getChannelNames(): string[] | undefined;
+
+  /**
+   * Returns the tile source for a specific channel, or undefined if not multi-channel
+   *
+   * @param c - The channel index (0-based)
+   * @returns The tile source for the channel, or undefined if not multi-channel
+   */
+  getTileSource(c?: number): string | TileSourceConfig | CustomTileSource;
 }
 
 /** Configuration object accepted by OpenSeadragon as a tile source */

--- a/packages/@tissuumaps-core/src/storage/image.ts
+++ b/packages/@tissuumaps-core/src/storage/image.ts
@@ -15,7 +15,13 @@ export interface ImageDataProvider<
 > extends DataProvider<TImageDataSource, TImageData> {}
 
 /**
- * Loaded image data providing an OpenSeadragon-compatible tile source
+ * Loaded image data providing one or more OpenSeadragon-compatible tile sources
+ *
+ * Image data is either multi-channel, in which case it provides one tile source
+ * per channel, addressed by channel index; or it is not, in which case it
+ * provides a single tile source that is not addressed by channel.
+ * {@link ImageData.getSizeC} and {@link ImageData.getChannelNames} return
+ * `undefined` for image data that is not multi-channel.
  */
 export interface ImageData extends Data {
   /** Returns the number of channels in the image, or undefined if not multi-channel */
@@ -25,10 +31,14 @@ export interface ImageData extends Data {
   getChannelNames(): string[] | undefined;
 
   /**
-   * Returns the tile source for a specific channel, or undefined if not multi-channel
+   * Returns the tile source of a channel, or the only tile source of image data that is not multi-channel
    *
-   * @param c - The channel index (0-based)
-   * @returns The tile source for the channel, or undefined if not multi-channel
+   * @param c - The channel index (0-based), required for multi-channel image
+   * data and to be omitted otherwise
+   * @returns The tile source, which can be a URL string, a TileSourceConfig
+   * object, or a CustomTileSource object
+   * @throws Error if `c` is omitted for multi-channel image data, if `c` is
+   * passed for image data that is not multi-channel, or if `c` is out of bounds
    */
   getTileSource(c?: number): string | TileSourceConfig | CustomTileSource;
 }

--- a/packages/@tissuumaps-core/src/storage/image.ts
+++ b/packages/@tissuumaps-core/src/storage/image.ts
@@ -21,8 +21,7 @@ export interface ImageDataProvider<
  * Image data is either multi-channel, in which case it provides one tile source
  * per channel, addressed by channel index; or it is not, in which case it
  * provides a single tile source that is not addressed by channel.
- * {@link ImageData.getSizeC} and {@link ImageData.getChannelNames} return
- * `undefined` for image data that is not multi-channel.
+ * {@link ImageData.getSizeC} returns `undefined` for image data that is not multi-channel.
  */
 export interface ImageData extends Data {
   /** Returns the number of channels in the image, or undefined if not multi-channel */

--- a/packages/@tissuumaps-core/src/storage/image.ts
+++ b/packages/@tissuumaps-core/src/storage/image.ts
@@ -48,7 +48,7 @@ export interface ImageData extends Data {
   /** Returns the opacity of a specific channel, or undefined if not multi-channel or not available */
   getChannelOpacity?: (c: number) => number | undefined;
 
-  /** Returns the color of a specific channel, or undefined if not multi-channel or notavailable */
+  /** Returns the color of a specific channel, or undefined if not multi-channel or not available */
   getChannelColor?: (c: number) => Color | undefined;
 }
 

--- a/packages/@tissuumaps-core/src/types/render.ts
+++ b/packages/@tissuumaps-core/src/types/render.ts
@@ -27,11 +27,13 @@ export type OpenSeadragonOptions = {
  * element references. Options taking an element are therefore either narrowed to
  * an element ID or disallowed. In addition, `element` is omitted, as the viewer
  * sets it to its own container element (which takes precedence over
- * OpenSeadragon's `id` option).
+ * OpenSeadragon's `id` option), and `compositeOperation` is omitted, as viewer
+ * options are applied to every tiled image in the world, which would overwrite
+ * the composite operations that the renderers set per tiled image.
  */
 export type OpenSeadragonViewerOptions = Omit<
   OpenSeadragon.Options,
-  "element"
+  "element" | "compositeOperation"
 > & {
   /** Unsupported, use `navigatorId` instead */
   navigatorElement?: never;

--- a/packages/@tissuumaps-core/src/utils/ColorUtils.test.ts
+++ b/packages/@tissuumaps-core/src/utils/ColorUtils.test.ts
@@ -114,6 +114,46 @@ describe("ColorUtils", () => {
     });
   });
 
+  describe("colorsEqual", () => {
+    it("returns true for identical colors", () => {
+      expect(
+        ColorUtils.colorsEqual({ r: 1, g: 2, b: 3 }, { r: 1, g: 2, b: 3 }),
+      ).toBe(true);
+    });
+
+    it("returns false when a component differs", () => {
+      expect(
+        ColorUtils.colorsEqual({ r: 1, g: 2, b: 3 }, { r: 1, g: 2, b: 4 }),
+      ).toBe(false);
+      expect(
+        ColorUtils.colorsEqual({ r: 1, g: 2, b: 3 }, { r: 1, g: 9, b: 3 }),
+      ).toBe(false);
+      expect(
+        ColorUtils.colorsEqual({ r: 1, g: 2, b: 3 }, { r: 9, g: 2, b: 3 }),
+      ).toBe(false);
+    });
+
+    it("compares fractional components exactly", () => {
+      expect(
+        ColorUtils.colorsEqual(
+          { r: 127.5, g: 0, b: 0 },
+          { r: 127.5, g: 0, b: 0 },
+        ),
+      ).toBe(true);
+      expect(
+        ColorUtils.colorsEqual(
+          { r: 127.5, g: 0, b: 0 },
+          { r: 128, g: 0, b: 0 },
+        ),
+      ).toBe(false);
+    });
+
+    it("returns true for the same object", () => {
+      const color = { r: 10, g: 20, b: 30 };
+      expect(ColorUtils.colorsEqual(color, color)).toBe(true);
+    });
+  });
+
   describe("fromHex / toHex roundtrip", () => {
     it.each(["#000000", "#ffffff", "#1a2b3c", "#ff8800"])(
       "roundtrips %s",

--- a/packages/@tissuumaps-core/src/utils/ColorUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/ColorUtils.ts
@@ -74,4 +74,17 @@ export class ColorUtils {
     const bHex = Math.round(color.b).toString(16).padStart(2, "0");
     return `#${rHex}${gHex}${bHex}`;
   }
+
+  /**
+   * Checks whether two colors have identical RGB components
+   *
+   * Components are compared exactly, without rounding or tolerance.
+   *
+   * @param a - The first color
+   * @param b - The second color
+   * @returns `true` if all three components are equal, `false` otherwise
+   */
+  static colorsEqual(a: Color, b: Color): boolean {
+    return a.r === b.r && a.g === b.g && a.b === b.b;
+  }
 }

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonContext.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonContext.ts
@@ -90,11 +90,11 @@ export class OpenSeadragonContext {
           ctx.save(); // push context state
           // pre-multiply alpha
           ctx.globalCompositeOperation = "destination-over";
-          ctx.fillStyle = "rgb(0 0 0 / 1)";
+          ctx.fillStyle = "rgba(0, 0, 0, 1)";
           ctx.fillRect(0, 0, width, height);
           // multiply with color
           ctx.globalCompositeOperation = "multiply";
-          ctx.fillStyle = `rgb(${r} ${g} ${b} / 1)`;
+          ctx.fillStyle = `rgba(${r}, ${g}, ${b}, 1)`;
           ctx.fillRect(0, 0, width, height);
           ctx.restore(); // pop context state
           await event.setData(ctx, "context2d");

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonContext.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonContext.ts
@@ -1,6 +1,8 @@
 import OpenSeadragon from "openseadragon";
 
 import {
+  type Color,
+  ColorUtils,
   type Dims,
   GeometryUtils,
   type OpenSeadragonViewerOptions,
@@ -30,9 +32,19 @@ import { OpenSeadragonUtils } from "./OpenSeadragonUtils";
  * Queued world mutations are ordered by request, so a caller that removes tiled
  * images before requesting additions still resolves its indices against the
  * world as it is once those removals have been applied.
+ *
+ * Tiled images can also be tinted (see {@link setTiledImageTint}). As
+ * OpenSeadragon has no notion of a per-image color, the tint is applied to the
+ * tiles themselves, in a `tile-invalidated` handler installed on the viewer.
+ * Tints are kept per tile source, rather than per tiled image, which is the
+ * granularity at which OpenSeadragon keys its tile caches, and which also covers
+ * the navigator: it mirrors the world with tiled images of its own, but shares
+ * their tile sources, and its tiles are invalidated through this viewer.
  */
 export class OpenSeadragonContext {
   readonly viewer: OpenSeadragon.Viewer;
+  private readonly _tileSourceTints: WeakMap<OpenSeadragon.TileSource, Color> =
+    new WeakMap();
   private _animationMemory?: {
     viewerOptions: Partial<OpenSeadragonViewerOptions>;
     tiledImageViewerOptions: WeakMap<
@@ -63,6 +75,30 @@ export class OpenSeadragonContext {
       // disable key bindings for rotation and flipping
       if (["r", "R", "f"].includes(event.originalEvent.key)) {
         event.preventDefaultAction = true;
+      }
+    });
+    this.viewer.addHandler("tile-invalidated", async (event) => {
+      const tiledImage = event.tile.tiledImage;
+      if (tiledImage !== null) {
+        const tint = this._tileSourceTints.get(tiledImage.source);
+        if (tint !== undefined) {
+          const { r, g, b } = tint;
+          const ctx = (await event.getData(
+            "context2d",
+          )) as CanvasRenderingContext2D;
+          const { width, height } = ctx.canvas;
+          ctx.save(); // push context state
+          // pre-multiply alpha
+          ctx.globalCompositeOperation = "destination-over";
+          ctx.fillStyle = "rgb(0 0 0 / 1)";
+          ctx.fillRect(0, 0, width, height);
+          // multiply with color
+          ctx.globalCompositeOperation = "multiply";
+          ctx.fillStyle = `rgb(${r} ${g} ${b} / 1)`;
+          ctx.fillRect(0, 0, width, height);
+          ctx.restore(); // pop context state
+          await event.setData(ctx, "context2d");
+        }
       }
     });
   }
@@ -311,6 +347,59 @@ export class OpenSeadragonContext {
    */
   getTiledImageIndex(tiledImage: OpenSeadragon.TiledImage): number {
     return this.viewer.world.getIndexOfItem(tiledImage);
+  }
+
+  /**
+   * Sets the tint color of a tiled image
+   *
+   * The tint is applied per tile: the tile is first composited over opaque
+   * black, which turns its transparency into intensity, and is then multiplied
+   * with `tint`. Passing `undefined` leaves the tiles untinted. It is applied to
+   * every tile of the tiled image, including those loaded later.
+   *
+   * As tinting drops the transparency of a tile, tinted tiled images must be
+   * composited additively onto an opaque backdrop.
+   *
+   * The tint is remembered per tile source, until the tile source is
+   * garbage-collected, because that is what OpenSeadragon keys its tile caches
+   * by: tiles that share their original data share their tinted data, too.
+   * Tiled images that share a tile source therefore also share a tint, with the
+   * last one set winning - including the tiled images of the navigator, which
+   * mirror those of this viewer and are tinted along with them.
+   *
+   * The tint is only written, and its tiles are only invalidated, if it actually
+   * changed: invalidating them re-runs the tinting on every loaded tile of the
+   * tile source, starting over from the original tile data.
+   *
+   * @param tiledImage - The tiled image to update
+   * @param tint - The color to tint the tiled image with, or `undefined` for
+   * no tint
+   */
+  setTiledImageTint(
+    tiledImage: OpenSeadragon.TiledImage,
+    tint: Color | undefined,
+  ): void {
+    const oldTint = this._tileSourceTints.get(tiledImage.source);
+    if (
+      (oldTint === undefined && tint !== undefined) ||
+      (oldTint !== undefined && tint === undefined) ||
+      (oldTint !== undefined &&
+        tint !== undefined &&
+        !ColorUtils.colorsEqual(oldTint, tint))
+    ) {
+      if (tint !== undefined) {
+        this._tileSourceTints.set(tiledImage.source, tint);
+      } else {
+        this._tileSourceTints.delete(tiledImage.source);
+      }
+      tiledImage
+        .requestInvalidate(/* restoreTiles */ true, /* viewportOnly */ false)
+        .catch((error) => {
+          console.error(
+            `Failed to invalidate tiles of tinted OpenSeadragon image: ${error}`,
+          );
+        });
+    }
   }
 
   /**

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonContext.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonContext.ts
@@ -7,8 +7,7 @@ import {
   type Rect,
 } from "@tissuumaps/core";
 
-const transparentPixelUrl =
-  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAEElEQVR4AQEFAPr/AAAAAAAABQABZHiVOAAAAABJRU5ErkJggg==";
+import { OpenSeadragonUtils } from "./OpenSeadragonUtils";
 
 /**
  * A wrapper around an OpenSeadragon viewer
@@ -233,6 +232,11 @@ export class OpenSeadragonContext {
    * another, in the order in which they were requested. The index is resolved in
    * between, when nothing else can shift the world anymore.
    *
+   * The tile source may also be a promise of an already opened tile source,
+   * which is only awaited once the addition is executed. Callers can thus derive
+   * a tile source from another one that is still being opened, without giving up
+   * their place in the queue and thereby their world index.
+   *
    * Rejects right away once the context has been destroyed.
    *
    * Aborting before the addition is executed skips it entirely. Later than that,
@@ -265,7 +269,7 @@ export class OpenSeadragonContext {
       );
     }
     const { signal, getIndex } = options ?? {};
-    const tileSourcePromise = this._openTileSource(tiledImageOptions, {
+    const tileSourcePromise = this.openTileSource(tiledImageOptions, {
       signal,
     });
     tileSourcePromise.catch(() => {}); // prevent unhandled rejections in console
@@ -363,14 +367,10 @@ export class OpenSeadragonContext {
         x: newBounds.x,
         y: newBounds.y,
         width: newBounds.width,
-        tileSource: {
-          width: newBounds.width,
-          height: newBounds.height,
-          tileSize: Math.max(newBounds.width, newBounds.height),
-          minLevel: 0,
-          maxLevel: 0,
-          getTileUrl: () => transparentPixelUrl,
-        },
+        tileSource: OpenSeadragonUtils.createPixelTileSource(
+          { width: newBounds.width, height: newBounds.height },
+          OpenSeadragonUtils.transparentPixelUrl,
+        ),
         opacity: 0,
       },
       { signal, getIndex },
@@ -408,11 +408,16 @@ export class OpenSeadragonContext {
   /**
    * Resolves a tile source specifier to a ready-to-use OpenSeadragon tile source
    *
-   * Fetches the image information if the specifier is a URL, and passes ready
-   * tile sources through. Doing this before the addition keeps the loading
-   * concurrent, while the additions themselves stay serialized.
+   * Fetches the image information if the specifier is a URL, awaits promised
+   * tile sources, and passes ready tile sources through. Doing this before an
+   * addition keeps the loading concurrent, while the additions themselves stay
+   * serialized (see {@link addTiledImage}).
+   *
+   * @param tiledImageOptions - Options containing the tile source to open
+   * @param options - Optional abort signal
+   * @returns A promise that resolves with the opened tile source
    */
-  private async _openTileSource(
+  async openTileSource(
     tiledImageOptions: Omit<
       OpenSeadragon.TileSourceSpecifier,
       "success" | "error"
@@ -421,14 +426,18 @@ export class OpenSeadragonContext {
   ): Promise<OpenSeadragon.TileSource> {
     const { signal } = options ?? {};
     signal?.throwIfAborted();
+    // OpenSeadragon types tile sources as `string | object`, which also covers
+    // promises of an already opened tile source; anything else is passed through
+    const tileSource = await Promise.resolve(tiledImageOptions.tileSource);
+    signal?.throwIfAborted();
     try {
-      const { source: tileSource } =
+      const { source: openedTileSource } =
         (await this.viewer.instantiateTileSourceClass(
           // this needs to be a shallow copy; OpenSeadragon mutates it!
-          { ...tiledImageOptions },
+          { ...tiledImageOptions, tileSource },
         )) as { source: OpenSeadragon.TileSource };
       signal?.throwIfAborted();
-      return tileSource;
+      return openedTileSource;
     } catch (error) {
       throw new Error("Failed to open tile source", { cause: error });
     }

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
@@ -1,4 +1,5 @@
 import type {
+  Color,
   CustomTileSource,
   Image,
   ImageData,
@@ -89,6 +90,13 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
 
   /**
    * Returns the tile sources for the given image data
+   *
+   * Multi-channel image data provides one tile source per channel, in channel
+   * order; all other image data provides a single tile source.
+   *
+   * @param data - The image data for which to retrieve the tile sources
+   * @returns The tile sources, one per channel for multi-channel image data and
+   * a single one otherwise
    */
   protected getTileSources(
     data: ImageData,
@@ -122,6 +130,38 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
   }
 
   /**
+   * Returns the tint color for one of an image's tiled images
+   *
+   * Returns the color of the channel that the tiled image renders. Channels are
+   * only applied to multi-channel image data, and channels that the image does
+   * not define have no color, in which case the channel's tiles are rendered in
+   * their own colors.
+   *
+   * Only multi-channel image data is tinted: its channels are blended additively
+   * onto an opaque backdrop (see {@link usesAdditiveBlending}), where tinting a
+   * tile may drop its transparency. Tiles of image data that is not
+   * multi-channel are composited over whatever is below them, so their
+   * transparency has to be preserved.
+   *
+   * @param ref - The image reference for which to compute the color
+   * @param c - The index of the channel rendered by the tiled image
+   * @returns The channel's color, or `undefined` for no tint
+   */
+  protected override getTiledImageColor(
+    ref: ObjectRef<Image, ImageData>,
+    c: number,
+  ): Color | undefined {
+    if (
+      ref.data.getSizeC() === undefined ||
+      ref.object.channels === undefined
+    ) {
+      return undefined;
+    }
+    const { color: channelColor } = ref.object.channels[c] ?? {};
+    return channelColor;
+  }
+
+  /**
    * Computes the effective opacity for one of an image's tiled images
    *
    * Multiplies the layer and image opacity computed by the base class with the
@@ -135,11 +175,11 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
    * `undefined` for the image's backdrop
    * @returns The effective opacity for the tiled image
    */
-  protected override getOpacity(
+  protected override getTiledImageOpacity(
     ref: ObjectRef<Image, ImageData>,
     c?: number,
   ): number {
-    let opacity = super.getOpacity(ref, c);
+    let opacity = super.getTiledImageOpacity(ref, c);
     if (
       opacity > 0 &&
       c !== undefined &&

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
@@ -151,11 +151,8 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
     ref: ObjectRef<Image, ImageData>,
     c: number,
   ): Color | undefined {
-    if (
-      ref.data.getSizeC() !== undefined &&
-      ref.object.channels !== undefined
-    ) {
-      const channel = ref.object.channels[c];
+    if (ref.data.getSizeC() !== undefined) {
+      const channel = ref.object.channels?.[c];
       const channelColor =
         channel?.color !== undefined
           ? channel.color
@@ -184,13 +181,8 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
     c?: number,
   ): number {
     let opacity = super.getTiledImageOpacity(ref, c);
-    if (
-      opacity > 0 &&
-      c !== undefined &&
-      ref.data.getSizeC() !== undefined &&
-      ref.object.channels !== undefined
-    ) {
-      const channel = ref.object.channels[c];
+    if (opacity > 0 && c !== undefined && ref.data.getSizeC() !== undefined) {
+      const channel = ref.object.channels?.[c];
       const channelVisibility =
         channel?.visibility !== undefined
           ? channel.visibility

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
@@ -74,7 +74,8 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
         this.updateRenderedObject(renderedImage, newRef);
       }
       newRenderedImages.push(renderedImage);
-      offset += renderedImage.tiledImageCount;
+      const useBackdrop = this.usesAdditiveBlending(renderedImage.ref.data);
+      offset += (useBackdrop ? 1 : 0) + renderedImage.tileSourceCount;
     }
     this.renderedObjects = newRenderedImages;
     await Promise.allSettled(
@@ -105,24 +106,43 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
   }
 
   /**
+   * Returns whether the channels of the given image data are blended additively
+   *
+   * Multi-channel image data blends additively, so that its channels add up
+   * rather than hide one another. Image data that is not multi-channel has a
+   * single tile source, so there is nothing to add up, and it keeps
+   * OpenSeadragon's default compositing, which preserves the transparency of its
+   * tiles.
+   *
+   * @param data - The image data to check
+   * @returns Whether the image's channels are blended additively
+   */
+  protected override usesAdditiveBlending(data: ImageData): boolean {
+    return data.getSizeC() !== undefined;
+  }
+
+  /**
    * Computes the effective opacity for one of an image's tiled images
    *
    * Multiplies the layer and image opacity computed by the base class with the
    * visibility and opacity of the channel that the tiled image renders. Channels
    * are only applied to multi-channel image data, and channels that the image
-   * does not define are visible at full opacity.
+   * does not define are visible at full opacity. Without a channel index, i.e.
+   * for the image's backdrop, the layer and image opacity is returned as is.
    *
    * @param ref - The image reference for which to compute the opacity
-   * @param c - The index of the channel rendered by the tiled image
-   * @returns The effective opacity for the channel's tiled image
+   * @param c - The index of the channel rendered by the tiled image, or
+   * `undefined` for the image's backdrop
+   * @returns The effective opacity for the tiled image
    */
   protected override getOpacity(
     ref: ObjectRef<Image, ImageData>,
-    c: number,
+    c?: number,
   ): number {
     let opacity = super.getOpacity(ref, c);
     if (
       opacity > 0 &&
+      c !== undefined &&
       ref.data.getSizeC() !== undefined &&
       ref.object.channels !== undefined
     ) {

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
@@ -152,13 +152,17 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
     c: number,
   ): Color | undefined {
     if (
-      ref.data.getSizeC() === undefined ||
-      ref.object.channels === undefined
+      ref.data.getSizeC() !== undefined &&
+      ref.object.channels !== undefined
     ) {
-      return undefined;
+      const channel = ref.object.channels[c];
+      const channelColor =
+        channel?.color !== undefined
+          ? channel.color
+          : ref.data.getChannelColor?.(c);
+      return channelColor;
     }
-    const { color: channelColor } = ref.object.channels[c] ?? {};
-    return channelColor;
+    return super.getTiledImageColor(ref, c);
   }
 
   /**
@@ -186,10 +190,16 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
       ref.data.getSizeC() !== undefined &&
       ref.object.channels !== undefined
     ) {
-      const {
-        visibility: channelVisibility = true,
-        opacity: channelOpacity = 1.0,
-      } = ref.object.channels[c] ?? {};
+      const channel = ref.object.channels[c];
+      const channelVisibility =
+        channel?.visibility !== undefined
+          ? channel.visibility
+          : (ref.data.getChannelVisibility?.(c) ?? true);
+      const channelOpacity =
+        channel?.opacity !== undefined
+          ? channel.opacity
+          : (ref.data.getChannelOpacity?.(c) ?? 1.0);
+
       opacity *= channelVisibility ? channelOpacity : 0;
     }
     return opacity;

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonImageRenderer.ts
@@ -27,6 +27,10 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
    * Resolves once the tiled images have actually been added to the world, i.e.
    * once the viewer reflects the given model state.
    *
+   * Images whose tiled images cannot be created, e.g. because their data
+   * provides no tile sources, are logged and skipped, just like images whose
+   * data failed to load (see {@link loadObjects}).
+   *
    * @param layers - Layers to render
    * @param images - Image objects to display
    * @param loadImage - Async getter for image data
@@ -49,37 +53,85 @@ export class OpenSeadragonImageRenderer extends OpenSeadragonRendererBase<
       loadImage,
       { signal },
     );
+    let offset = 0;
     const newRenderedImages: RenderedObject<Image, ImageData>[] = [];
     const renderedImagesByNewRef = await this.cleanRenderedObjects(newRefs, {
       signal,
     });
-    for (let offset = 0; offset < newRefs.length; offset++) {
-      const newRef = newRefs[offset]!;
-      const renderedImage = renderedImagesByNewRef.get(newRef);
+    for (const newRef of newRefs) {
+      let renderedImage = renderedImagesByNewRef.get(newRef);
       if (renderedImage === undefined) {
-        const newRenderedImage = this.createRenderedObject(offset, newRef, {
-          signal,
-        });
-        newRenderedImages.push(newRenderedImage);
+        try {
+          renderedImage = this.createRenderedObject(offset, newRef, { signal });
+        } catch (error) {
+          console.error(
+            `Failed to create tiled images for object with ID '${newRef.object.id}'`,
+            error,
+          );
+          continue;
+        }
       } else {
         this.updateRenderedObject(renderedImage, newRef);
-        newRenderedImages.push(renderedImage);
       }
+      newRenderedImages.push(renderedImage);
+      offset += renderedImage.tiledImageCount;
     }
     this.renderedObjects = newRenderedImages;
     await Promise.allSettled(
-      newRenderedImages.map((renderedImage) => renderedImage.tiledImagePromise),
+      newRenderedImages.map(
+        (renderedImage) => renderedImage.tiledImagesPromise,
+      ),
     );
     signal?.throwIfAborted(); // Promise.allSettled() does not throw on abort
     await this.updateBounds({ signal });
   }
 
   /**
-   * Returns the tile source for the given image data
+   * Returns the tile sources for the given image data
    */
-  protected getTileSource(
+  protected getTileSources(
     data: ImageData,
-  ): string | TileSourceConfig | CustomTileSource {
-    return data.getTileSource();
+  ): (string | TileSourceConfig | CustomTileSource)[] {
+    const tileSources: (string | TileSourceConfig | CustomTileSource)[] = [];
+    const n = data.getSizeC();
+    if (n !== undefined) {
+      for (let c = 0; c < n; c++) {
+        tileSources.push(data.getTileSource(c));
+      }
+    } else {
+      tileSources.push(data.getTileSource());
+    }
+    return tileSources;
+  }
+
+  /**
+   * Computes the effective opacity for one of an image's tiled images
+   *
+   * Multiplies the layer and image opacity computed by the base class with the
+   * visibility and opacity of the channel that the tiled image renders. Channels
+   * are only applied to multi-channel image data, and channels that the image
+   * does not define are visible at full opacity.
+   *
+   * @param ref - The image reference for which to compute the opacity
+   * @param c - The index of the channel rendered by the tiled image
+   * @returns The effective opacity for the channel's tiled image
+   */
+  protected override getOpacity(
+    ref: ObjectRef<Image, ImageData>,
+    c: number,
+  ): number {
+    let opacity = super.getOpacity(ref, c);
+    if (
+      opacity > 0 &&
+      ref.data.getSizeC() !== undefined &&
+      ref.object.channels !== undefined
+    ) {
+      const {
+        visibility: channelVisibility = true,
+        opacity: channelOpacity = 1.0,
+      } = ref.object.channels[c] ?? {};
+      opacity *= channelVisibility ? channelOpacity : 0;
+    }
+    return opacity;
   }
 }

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonLabelsRenderer.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonLabelsRenderer.ts
@@ -69,10 +69,10 @@ export class OpenSeadragonLabelsRenderer extends OpenSeadragonRendererBase<
    *
    * @todo Implement labels rendering; this always throws.
    */
-  protected getTileSource(
+  protected getTileSources(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _data: LabelsData,
-  ): string | TileSourceConfig | CustomTileSource {
+  ): (string | TileSourceConfig | CustomTileSource)[] {
     throw new Error("Method not implemented.");
   }
 }

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonRendererBase.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonRendererBase.ts
@@ -3,6 +3,7 @@ import { mat3 } from "gl-matrix";
 import OpenSeadragon from "openseadragon";
 
 import {
+  type Color,
   type CustomTileSource,
   GeometryUtils,
   type Image,
@@ -464,10 +465,10 @@ export abstract class OpenSeadragonRendererBase<
   /**
    * Applies the transform, flip, visibility, and opacity of an object reference to the rendered object's backdrop and TiledImages
    *
-   * The opacity is computed per TiledImage via {@link getOpacity}, so that
+   * The opacity is computed per TiledImage via {@link getTiledImageOpacity}, so that
    * subclasses can vary it by channel; all other properties are shared by all
    * TiledImages of an object, and by its backdrop. The backdrop is opaque where
-   * the object is, so it gets {@link getOpacity} without a channel index. The
+   * the object is, so it gets {@link getTiledImageOpacity} without a channel index. The
    * applied data source is recorded in the rendered object's state, where
    * {@link cleanRenderedObjects} picks it up to detect TiledImages that have to
    * be recreated.
@@ -488,14 +489,16 @@ export abstract class OpenSeadragonRendererBase<
       this._updateTiledImage(
         renderedObject.backdrop,
         newRef,
-        this.getOpacity(newRef),
+        undefined,
+        this.getTiledImageOpacity(newRef),
       );
     }
     for (let c = 0; c < renderedObject.tiledImages.length; c++) {
       this._updateTiledImage(
         renderedObject.tiledImages[c]!,
         newRef,
-        this.getOpacity(newRef, c),
+        this.getTiledImageColor(newRef, c),
+        this.getTiledImageOpacity(newRef, c),
       );
     }
     renderedObject.state = {
@@ -564,23 +567,27 @@ export abstract class OpenSeadragonRendererBase<
   }
 
   /**
-   * Applies the transform of an object reference and the given opacity to a single TiledImage
+   * Applies the transform of an object reference and the given color and opacity to a single TiledImage
    *
    * Only properties whose value actually changed are written, as each write
-   * triggers a redraw.
+   * triggers a redraw. The color is applied as a tint on the TiledImage's tiles
+   * (see {@link OpenSeadragonContext.setTiledImageTint}).
    *
    * @param tiledImage - The TiledImage to update
    * @param ref - The object reference whose transform to apply
+   * @param color - The color to tint the TiledImage with, or `undefined` for no
+   * tint
    * @param opacity - The effective opacity to apply
    */
   private _updateTiledImage(
     tiledImage: OpenSeadragon.TiledImage,
     ref: ObjectRef<TObject, TObjectData>,
+    color: Color | undefined,
     opacity: number,
   ): void {
     // transform --> flip, width, rotation, position
     const bounds = tiledImage.getBounds();
-    const transform = OpenSeadragonRendererBase.getTransform(
+    const transform = OpenSeadragonRendererBase.getTiledImageTransform(
       ref,
       tiledImage.getContentSize(),
     );
@@ -606,9 +613,11 @@ export abstract class OpenSeadragonRendererBase<
       if (oldOpacity === 0 && opacity > 0) {
         // OpenSeadragon does not load tiles for invisible images,
         // so we need to trigger a reload when an image becomes visible
-        tiledImage.update(true);
+        tiledImage.update(/* viewportChanged */ false);
       }
     }
+    // color
+    this.context.setTiledImageTint(tiledImage, color);
   }
 
   /**
@@ -634,6 +643,28 @@ export abstract class OpenSeadragonRendererBase<
   }
 
   /**
+   * Returns the tint color for one of an object's tiled images
+   *
+   * Returns `undefined` here, i.e. the tiled images of an object are rendered in
+   * the colors of their own tiles; subclasses override this to tint them per
+   * channel. Only the tiled images of an object's channels are tinted, never its
+   * backdrop, so this is always called with a channel index.
+   *
+   * @param _ref - The object reference for which to compute the color
+   * @param _c - The index of the channel rendered by the tiled image
+   * @returns The color to tint the tiled image with, or `undefined` for no tint.
+   * Defaults to `undefined`.
+   */
+  protected getTiledImageColor(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _ref: ObjectRef<TObject, TObjectData>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _c: number,
+  ): Color | undefined {
+    return undefined;
+  }
+
+  /**
    * Computes the effective opacity for one of an object's tiled images
    *
    * Returns `0` when either the layer or the object is invisible; otherwise
@@ -648,7 +679,7 @@ export abstract class OpenSeadragonRendererBase<
    * `undefined` for the object's backdrop
    * @returns The effective opacity for the tiled image
    */
-  protected getOpacity(
+  protected getTiledImageOpacity(
     ref: ObjectRef<TObject, TObjectData>,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _c?: number,
@@ -672,7 +703,7 @@ export abstract class OpenSeadragonRendererBase<
    * @param contentSize - The size of the content (image or labels) in pixels
    * @returns An object containing the computed flip, width, rotation, and position for the tiled image
    */
-  protected static getTransform<
+  protected static getTiledImageTransform<
     TObject extends Image | Labels,
     TObjectData extends ImageData | LabelsData,
   >(

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonRendererBase.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonRendererBase.ts
@@ -24,7 +24,8 @@ import type { OpenSeadragonContext } from "./OpenSeadragonContext";
  * renderer contributes to the world (see
  * {@link OpenSeadragonContext.updateBounds}). Renderers share a viewer, so the
  * anchor also marks where the renderer's own tiled images belong: they directly
- * follow the anchor, in the order of {@link renderedObjects}.
+ * follow the anchor, in the order of {@link renderedObjects}, with one tiled
+ * image per channel of each object.
  *
  * Tiled images are inserted behind the anchor when they are added, rather than
  * moved there afterwards, as OpenSeadragon's navigator cannot keep up with
@@ -87,7 +88,7 @@ export abstract class OpenSeadragonRendererBase<
   /**
    * Resizes the anchor to the bounding box of all tiled images and extra bounds
    *
-   * Rendered objects whose tiled image has not been added to the world yet are
+   * Rendered objects whose tiled images have not been added to the world yet are
    * ignored; they update the anchor themselves upon arrival (see
    * {@link createRenderedObject}). Does nothing once the renderer has been
    * destroyed, as there is no anchor to resize anymore.
@@ -103,8 +104,10 @@ export abstract class OpenSeadragonRendererBase<
       signal?.throwIfAborted();
       const tiledImageBounds = [];
       for (const renderedObject of this.renderedObjects) {
-        if (renderedObject.tiledImage !== undefined) {
-          tiledImageBounds.push(renderedObject.tiledImage.getBounds());
+        if (renderedObject.tiledImages !== undefined) {
+          for (const tiledImage of renderedObject.tiledImages) {
+            tiledImageBounds.push(tiledImage.getBounds());
+          }
         }
       }
       const bounds =
@@ -120,7 +123,7 @@ export abstract class OpenSeadragonRendererBase<
   /**
    * Destroys the renderer by removing the anchor tiled image and all rendered objects from the OpenSeadragon viewer
    *
-   * Rendered objects whose tiled image has not been added to the world yet are
+   * Rendered objects whose tiled images have not been added to the world yet are
    * only marked for deletion, and are removed as soon as they arrive.
    *
    * The renderer is unusable afterwards: it has no anchor anymore, so
@@ -201,11 +204,12 @@ export abstract class OpenSeadragonRendererBase<
    * Retains the rendered objects that can be reused for the new object references, and deletes the rest
    *
    * A rendered object is reusable if it references the same object on the same
-   * layer with an unchanged data source, and if its tiled image already sits at
-   * the world index expected for its position among the reusable references,
-   * counted from the anchor. All other rendered objects are deleted, and are
-   * expected to be recreated by the caller via {@link createRenderedObject},
-   * which is also how the world is reordered.
+   * layer with an unchanged data source, and if all of its tiled images already
+   * sit at the consecutive world indices expected for its position among the
+   * reusable references, counted from the anchor. A partially misplaced object
+   * is not reusable. All other rendered objects are deleted, and are expected to
+   * be recreated by the caller via {@link createRenderedObject}, which is also
+   * how the world is reordered.
    *
    * @param newRefs - The new object references, in the intended world order
    * @param options - Optional abort signal
@@ -233,7 +237,7 @@ export abstract class OpenSeadragonRendererBase<
       RenderedObject<TObject, TObjectData>
     >();
     const survivors = new Set<RenderedObject<TObject, TObjectData>>();
-    let nextOffset = 1;
+    let offset = 1;
     for (const newRef of newRefs) {
       const renderedObject = this.renderedObjects.find(
         (renderedObject) =>
@@ -246,14 +250,17 @@ export abstract class OpenSeadragonRendererBase<
       );
       if (renderedObject !== undefined) {
         if (
-          renderedObject.tiledImage !== undefined &&
-          this.context.getTiledImageIndex(renderedObject.tiledImage) ===
-            anchorIndex + nextOffset
+          renderedObject.tiledImages !== undefined &&
+          renderedObject.tiledImages.every(
+            (tiledImage, c) =>
+              this.context.getTiledImageIndex(tiledImage) ===
+              anchorIndex + offset + c,
+          )
         ) {
           renderedObjectsByNewRef.set(newRef, renderedObject);
           survivors.add(renderedObject);
         }
-        nextOffset++;
+        offset += renderedObject.tiledImageCount;
       }
     }
     for (const renderedObject of this.renderedObjects) {
@@ -267,23 +274,30 @@ export abstract class OpenSeadragonRendererBase<
   }
 
   /**
-   * Creates a new rendered object for the given object reference and adds its TiledImage to the world
+   * Creates a new rendered object for the given object reference and adds one TiledImage per channel to the world
    *
-   * The TiledImage is inserted `offset` places after the anchor, which
-   * establishes the world layout that {@link cleanRenderedObjects} expects. Its
-   * index is resolved once the addition is executed, as the anchor may have been
-   * replaced, and world indices may have shifted, while it was enqueued.
+   * The TiledImages are inserted at consecutive indices, starting `offset` places
+   * after the anchor, which establishes the world layout that
+   * {@link cleanRenderedObjects} expects. `offset` therefore counts TiledImages,
+   * not objects, and callers have to advance it by
+   * {@link RenderedObject.tiledImageCount}. The indices are resolved once each
+   * addition is executed, as the anchor may have been replaced, and world indices
+   * may have shifted, while it was enqueued.
    *
-   * Returns before the TiledImage exists: it is added asynchronously and only
-   * then assigned to the rendered object, transformed, and included in the
-   * anchor bounds. If the rendered object is deleted or the operation is aborted
-   * in the meantime, the TiledImage is removed again immediately after it was
-   * added; if the context is destroyed, nothing is done at all.
+   * Returns before the TiledImages exist: they are added asynchronously and only
+   * then assigned to the rendered object, transformed, and included in the anchor
+   * bounds, which is when {@link RenderedObject.tiledImagesPromise} resolves. The
+   * TiledImages are removed again immediately after they were added if the
+   * rendered object is deleted or the operation is aborted in the meantime, or if
+   * any of them could not be added at all - a partially added object would shift
+   * the world indices of every object after it. If the context is destroyed,
+   * nothing is done at all, as the viewer tears down its world itself.
    *
-   * @param offset - The position after the anchor at which to insert the new TiledImage
+   * @param offset - The number of TiledImages between the anchor and the first new TiledImage
    * @param newRef - The object reference for which to create a rendered object
    * @param options - Optional abort signal
-   * @returns The newly created rendered object, which does not have a TiledImage yet
+   * @returns The newly created rendered object, which does not have TiledImages yet
+   * @throws Error if the object data provides no tile sources
    */
   protected createRenderedObject(
     offset: number,
@@ -291,107 +305,141 @@ export abstract class OpenSeadragonRendererBase<
     options?: { signal?: AbortSignal },
   ): RenderedObject<TObject, TObjectData> {
     const { signal } = options ?? {};
+    const tileSources = this.getTileSources(newRef.data);
+    if (tileSources.length === 0) {
+      throw new Error(
+        `Object with ID '${newRef.object.id}' has no tile sources`,
+      );
+    }
     const {
-      promise: tiledImagePromise,
-      resolve: resolveTiledImagePromise,
-      reject: rejectTiledImagePromise,
-    } = Promise.withResolvers<OpenSeadragon.TiledImage>();
-    tiledImagePromise.catch(() => {}); // prevent unhandled rejections in console
+      promise: tiledImagesPromise,
+      resolve: resolveTiledImagesPromise,
+      reject: rejectTiledImagesPromise,
+    } = Promise.withResolvers<OpenSeadragon.TiledImage[]>();
+    tiledImagesPromise.catch(() => {}); // prevent unhandled rejections in console
     const newRenderedObject: RenderedObject<TObject, TObjectData> = {
       ref: newRef,
       state: {
         object: { dataSource: structuredClone(newRef.object.dataSource) },
       },
-      tiledImagePromise,
+      tiledImageCount: tileSources.length,
+      tiledImagesPromise,
     };
-    this.context
-      .addTiledImage(
-        { tileSource: this.getTileSource(newRef.data) },
+    const tiledImagePromises: Promise<OpenSeadragon.TiledImage>[] = [];
+    for (let c = 0; c < tileSources.length; c++) {
+      const tiledImagePromise = this.context.addTiledImage(
+        { tileSource: tileSources[c]! },
         {
           signal,
           getIndex: () => {
             if (this._anchor !== undefined) {
               const anchorIndex = this.context.getTiledImageIndex(this._anchor);
               if (anchorIndex !== -1) {
-                return anchorIndex + 1 + offset;
+                return anchorIndex + 1 + offset + c;
               }
             }
             return undefined;
           },
         },
-      )
-      .then(async (tiledImage) => {
-        signal?.throwIfAborted();
-        if (!this.context.isDestroyed()) {
-          if (
-            newRenderedObject.pendingDelete ||
-            signal?.aborted ||
-            this._destroyed
-          ) {
-            await this.context.removeTiledImage(tiledImage);
-            signal?.throwIfAborted();
-          } else {
-            newRenderedObject.tiledImage = tiledImage;
-            this.updateRenderedObject(newRenderedObject);
-            await this.updateBounds({ signal });
-          }
+      );
+      tiledImagePromise.catch(() => {}); // prevent unhandled rejections in console
+      tiledImagePromises.push(tiledImagePromise);
+    }
+    Promise.allSettled(tiledImagePromises)
+      .then(async (results) => {
+        const tiledImages = results
+          .filter((result) => result.status === "fulfilled")
+          .map((result) => result.value);
+        if (this.context.isDestroyed()) {
+          return tiledImages; // the viewer tears down its world itself
         }
-        return tiledImage;
+        const failure = results.find((result) => result.status === "rejected");
+        if (
+          signal?.aborted ||
+          failure !== undefined ||
+          newRenderedObject.pendingDelete ||
+          this._destroyed
+        ) {
+          for (const tiledImage of tiledImages) {
+            await this.context.removeTiledImage(tiledImage);
+          }
+          signal?.throwIfAborted();
+          if (failure !== undefined) {
+            console.error(
+              `Failed to add ${results.length - tiledImages.length} of ${results.length} tiled images for object with ID '${newRef.object.id}'`,
+              failure.reason,
+            );
+            throw new Error("Failed to add tiled images", {
+              cause: failure.reason,
+            });
+          }
+        } else {
+          newRenderedObject.tiledImages = tiledImages;
+          this.updateRenderedObject(newRenderedObject);
+          await this.updateBounds({ signal });
+        }
+        return tiledImages;
       })
-      .then(resolveTiledImagePromise, rejectTiledImagePromise);
+      .then(resolveTiledImagesPromise, rejectTiledImagesPromise);
     return newRenderedObject;
   }
 
   /**
-   * Applies the transform, flip, visibility, and opacity of an object reference to the rendered object's TiledImage
+   * Applies the transform, flip, visibility, and opacity of an object reference to each of the rendered object's TiledImages
    *
    * Only properties whose value actually changed are written, as each write
-   * triggers a redraw. The applied data source is recorded in the rendered
-   * object's state, where {@link cleanRenderedObjects} picks it up to detect
-   * TiledImages that have to be recreated.
+   * triggers a redraw. The opacity is computed per TiledImage via
+   * {@link getOpacity}, so that subclasses can vary it by channel; all other
+   * properties are shared by all TiledImages of an object. The applied data
+   * source is recorded in the rendered object's state, where
+   * {@link cleanRenderedObjects} picks it up to detect TiledImages that have to
+   * be recreated.
    *
    * @param renderedObject - The rendered object to update
    * @param newRef - The new object reference to update the rendered object with. If not provided, the existing reference will be used.
-   * @throws Error if the TiledImage has not been created yet
+   * @throws Error if the TiledImages have not been created yet
    */
   protected updateRenderedObject(
     renderedObject: RenderedObject<TObject, TObjectData>,
     newRef: ObjectRef<TObject, TObjectData> = renderedObject.ref,
   ): void {
-    if (renderedObject.tiledImage === undefined) {
+    if (renderedObject.tiledImages === undefined) {
       throw new Error("Rendered object not loaded");
     }
     renderedObject.ref = newRef;
-    // transform --> flip, width, rotation, position
-    const bounds = renderedObject.tiledImage.getBounds();
-    const transform = OpenSeadragonRendererBase.getTransform(
-      newRef,
-      renderedObject.tiledImage.getContentSize(),
-    );
-    if (renderedObject.tiledImage.getFlip() !== transform.flip) {
-      renderedObject.tiledImage.setFlip(transform.flip);
-    }
-    if (bounds.width !== transform.width) {
-      renderedObject.tiledImage.setWidth(transform.width, true); // implicitly updates height to maintain aspect ratio
-    }
-    if (renderedObject.tiledImage.getRotation() !== transform.rotation) {
-      renderedObject.tiledImage.setRotation(transform.rotation, true);
-    }
-    if (
-      bounds.x !== transform.position.x ||
-      bounds.y !== transform.position.y
-    ) {
-      renderedObject.tiledImage.setPosition(transform.position, true);
-    }
-    // visibility & opacity --> opacity
-    const oldOpacity = renderedObject.tiledImage.getOpacity();
-    const newOpacity = OpenSeadragonRendererBase.getOpacity(newRef);
-    if (oldOpacity !== newOpacity) {
-      renderedObject.tiledImage.setOpacity(newOpacity);
-      if (oldOpacity === 0 && newOpacity > 0) {
-        // OpenSeadragon does not load tiles for invisible images,
-        // so we need to trigger a reload when an image becomes visible
-        renderedObject.tiledImage.update(true);
+    for (let c = 0; c < renderedObject.tiledImages.length; c++) {
+      const tiledImage = renderedObject.tiledImages[c]!;
+      // transform --> flip, width, rotation, position
+      const bounds = tiledImage.getBounds();
+      const transform = OpenSeadragonRendererBase.getTransform(
+        newRef,
+        tiledImage.getContentSize(),
+      );
+      if (tiledImage.getFlip() !== transform.flip) {
+        tiledImage.setFlip(transform.flip);
+      }
+      if (bounds.width !== transform.width) {
+        tiledImage.setWidth(transform.width, true); // implicitly updates height to maintain aspect ratio
+      }
+      if (tiledImage.getRotation() !== transform.rotation) {
+        tiledImage.setRotation(transform.rotation, true);
+      }
+      if (
+        bounds.x !== transform.position.x ||
+        bounds.y !== transform.position.y
+      ) {
+        tiledImage.setPosition(transform.position, true);
+      }
+      // visibility & opacity --> opacity
+      const oldOpacity = tiledImage.getOpacity();
+      const newOpacity = this.getOpacity(newRef, c);
+      if (oldOpacity !== newOpacity) {
+        tiledImage.setOpacity(newOpacity);
+        if (oldOpacity === 0 && newOpacity > 0) {
+          // OpenSeadragon does not load tiles for invisible images,
+          // so we need to trigger a reload when an image becomes visible
+          tiledImage.update(true);
+        }
       }
     }
     renderedObject.state = {
@@ -402,37 +450,41 @@ export abstract class OpenSeadragonRendererBase<
   }
 
   /**
-   * Deletes the rendered object by removing its TiledImage from the OpenSeadragon viewer, or marking it for deletion if the TiledImage has not yet been created
+   * Deletes the rendered object by removing its TiledImages from the OpenSeadragon viewer, or marking it for deletion if the TiledImages have not yet been created
    *
-   * The removal is queued by the context (see
+   * The removals are queued by the context (see
    * {@link OpenSeadragonContext.removeTiledImage}) and applied before any tiled
-   * image requested after it, so a caller that deletes before it creates still
+   * image requested after them, so a caller that deletes before it creates still
    * gets the world indices it expects.
    *
    * Deleting a rendered object does not remove it from {@link renderedObjects}.
    *
    * @param renderedObject - The rendered object to delete
-   * @param options - Optional abort signal
+   * @returns A promise that resolves once all of its TiledImages have been removed
    */
   protected deleteRenderedObject(
     renderedObject: RenderedObject<TObject, TObjectData>,
   ): Promise<void> {
-    if (renderedObject.tiledImage === undefined) {
+    if (renderedObject.tiledImages === undefined) {
       renderedObject.pendingDelete = true;
       return Promise.resolve();
     }
-    return this.context.removeTiledImage(renderedObject.tiledImage);
+    return Promise.all(
+      renderedObject.tiledImages.map((tiledImage) =>
+        this.context.removeTiledImage(tiledImage),
+      ),
+    ).then(() => {});
   }
 
   /**
-   * Returns the tile source for the given object data
+   * Returns the tile sources for the given object data
    *
-   * @param data - The object data (image or labels) for which to retrieve the tile source
-   * @returns The tile source, which can be a URL string, a TileSourceConfig object, or a CustomTileSource object
+   * @param data - The object data (image or labels) for which to retrieve the tile sources
+   * @returns The tile sources, which can be a URL string, a TileSourceConfig object, or a CustomTileSource object
    */
-  protected abstract getTileSource(
+  protected abstract getTileSources(
     data: TObjectData,
-  ): string | TileSourceConfig | CustomTileSource;
+  ): (string | TileSourceConfig | CustomTileSource)[];
 
   /**
    * Appends a task to the anchor task queue
@@ -457,18 +509,23 @@ export abstract class OpenSeadragonRendererBase<
   }
 
   /**
-   * Computes the effective opacity for a tiled image
+   * Computes the effective opacity for one of an object's tiled images
    *
-   * Returns `0` when either the layer or object is invisible; otherwise
-   * multiplies layer and object opacities.
+   * Returns `0` when either the layer or the object is invisible; otherwise
+   * multiplies layer and object opacities. The channel index is ignored here,
+   * i.e. all tiled images of an object share the same opacity; subclasses
+   * override this to additionally apply per-channel visibility and opacity.
    *
    * @param ref - The object reference for which to compute the opacity
+   * @param _c - The index of the tiled image among the object's tiled images,
+   * i.e. the index of the channel it renders
    * @returns The effective opacity for the tiled image
    */
-  protected static getOpacity<
-    TObject extends Image | Labels,
-    TObjectData extends ImageData | LabelsData,
-  >(ref: ObjectRef<TObject, TObjectData>): number {
+  protected getOpacity(
+    ref: ObjectRef<TObject, TObjectData>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _c: number,
+  ): number {
     const visibility = ref.layer.visibility && ref.object.visibility;
     const opacity = ref.layer.opacity * ref.object.opacity;
     return visibility ? opacity : 0;
@@ -536,7 +593,13 @@ export type ObjectRef<
 };
 
 /**
- * Mutable state for a single tiled image in the viewer
+ * Mutable state for the tiled images of a single object in the viewer
+ *
+ * An object occupies `tiledImageCount` consecutive world indices, one tiled
+ * image per channel, in the order of its tile sources. The count is known as
+ * soon as the rendered object is created, whereas `tiledImages` is assigned only
+ * once all of them have been added to the world, which is also when
+ * `tiledImagesPromise` resolves.
  */
 export type RenderedObject<
   TObject extends Image | Labels,
@@ -544,7 +607,8 @@ export type RenderedObject<
 > = {
   ref: ObjectRef<TObject, TObjectData>;
   state: { object: Pick<TObject, "dataSource"> };
-  tiledImagePromise: Promise<OpenSeadragon.TiledImage>;
-  tiledImage?: OpenSeadragon.TiledImage;
+  tiledImageCount: number;
+  tiledImagesPromise: Promise<OpenSeadragon.TiledImage[]>;
+  tiledImages?: OpenSeadragon.TiledImage[];
   pendingDelete?: boolean;
 };

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonRendererBase.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonRendererBase.ts
@@ -16,6 +16,7 @@ import {
 } from "@tissuumaps/core";
 
 import type { OpenSeadragonContext } from "./OpenSeadragonContext";
+import { OpenSeadragonUtils } from "./OpenSeadragonUtils";
 
 /**
  * Base class for OpenSeadragon renderers that manage tiled images for objects (images or labels)
@@ -26,6 +27,9 @@ import type { OpenSeadragonContext } from "./OpenSeadragonContext";
  * anchor also marks where the renderer's own tiled images belong: they directly
  * follow the anchor, in the order of {@link renderedObjects}, with one tiled
  * image per channel of each object.
+ *
+ * The tiled images of an object that uses additive blending are preceded by one
+ * more tiled image, its backdrop (see {@link usesAdditiveBlending}).
  *
  * Tiled images are inserted behind the anchor when they are added, rather than
  * moved there afterwards, as OpenSeadragon's navigator cannot keep up with
@@ -104,6 +108,9 @@ export abstract class OpenSeadragonRendererBase<
       signal?.throwIfAborted();
       const tiledImageBounds = [];
       for (const renderedObject of this.renderedObjects) {
+        if (renderedObject.backdrop !== undefined) {
+          tiledImageBounds.push(renderedObject.backdrop.getBounds());
+        }
         if (renderedObject.tiledImages !== undefined) {
           for (const tiledImage of renderedObject.tiledImages) {
             tiledImageBounds.push(tiledImage.getBounds());
@@ -204,12 +211,12 @@ export abstract class OpenSeadragonRendererBase<
    * Retains the rendered objects that can be reused for the new object references, and deletes the rest
    *
    * A rendered object is reusable if it references the same object on the same
-   * layer with an unchanged data source, and if all of its tiled images already
-   * sit at the consecutive world indices expected for its position among the
-   * reusable references, counted from the anchor. A partially misplaced object
-   * is not reusable. All other rendered objects are deleted, and are expected to
-   * be recreated by the caller via {@link createRenderedObject}, which is also
-   * how the world is reordered.
+   * layer with an unchanged data source, and if its backdrop, if any, and all of
+   * its tiled images already sit at the consecutive world indices expected for
+   * its position among the reusable references, counted from the anchor. A
+   * partially misplaced object is not reusable. All other rendered objects are
+   * deleted, and are expected to be recreated by the caller via
+   * {@link createRenderedObject}, which is also how the world is reordered.
    *
    * @param newRefs - The new object references, in the intended world order
    * @param options - Optional abort signal
@@ -249,18 +256,25 @@ export abstract class OpenSeadragonRendererBase<
           ),
       );
       if (renderedObject !== undefined) {
+        const useBackdrop = this.usesAdditiveBlending(newRef.data);
         if (
+          // not using a backdrop or backdrop exists and is at the expected index
+          (!useBackdrop ||
+            (renderedObject.backdrop !== undefined &&
+              this.context.getTiledImageIndex(renderedObject.backdrop) ===
+                anchorIndex + offset)) &&
+          // tiled images exist and are at the expected indices
           renderedObject.tiledImages !== undefined &&
           renderedObject.tiledImages.every(
             (tiledImage, c) =>
               this.context.getTiledImageIndex(tiledImage) ===
-              anchorIndex + offset + c,
+              anchorIndex + offset + (useBackdrop ? 1 : 0) + c,
           )
         ) {
           renderedObjectsByNewRef.set(newRef, renderedObject);
           survivors.add(renderedObject);
         }
-        offset += renderedObject.tiledImageCount;
+        offset += (useBackdrop ? 1 : 0) + renderedObject.tileSourceCount;
       }
     }
     for (const renderedObject of this.renderedObjects) {
@@ -274,26 +288,34 @@ export abstract class OpenSeadragonRendererBase<
   }
 
   /**
-   * Creates a new rendered object for the given object reference and adds one TiledImage per channel to the world
+   * Creates a new rendered object for the given object reference and adds one TiledImage per channel, preceded by a backdrop where required, to the world
    *
    * The TiledImages are inserted at consecutive indices, starting `offset` places
    * after the anchor, which establishes the world layout that
    * {@link cleanRenderedObjects} expects. `offset` therefore counts TiledImages,
    * not objects, and callers have to advance it by
-   * {@link RenderedObject.tiledImageCount}. The indices are resolved once each
-   * addition is executed, as the anchor may have been replaced, and world indices
-   * may have shifted, while it was enqueued.
+   * {@link RenderedObject.tileSourceCount} plus the object's backdrop, if it has
+   * one. The indices are resolved once each addition is executed, as the anchor
+   * may have been replaced, and world indices may have shifted, while it was
+   * enqueued.
+   *
+   * The tile sources are opened here, rather than by the additions themselves,
+   * so that the backdrop can be sized like the object's content, which is only
+   * known once one of them has been opened. The additions are all requested
+   * before this function returns, and in world order, so that the TiledImages of
+   * the object that the caller creates next end up behind them.
    *
    * Returns before the TiledImages exist: they are added asynchronously and only
    * then assigned to the rendered object, transformed, and included in the anchor
    * bounds, which is when {@link RenderedObject.tiledImagesPromise} resolves. The
-   * TiledImages are removed again immediately after they were added if the
-   * rendered object is deleted or the operation is aborted in the meantime, or if
-   * any of them could not be added at all - a partially added object would shift
-   * the world indices of every object after it. If the context is destroyed,
-   * nothing is done at all, as the viewer tears down its world itself.
+   * backdrop and TiledImages are removed again immediately after they were added
+   * if the rendered object is deleted or the operation is aborted in the
+   * meantime, or if any of them could not be added at all - a partially added
+   * object would shift the world indices of every object after it. If the context
+   * is destroyed, nothing is done at all, as the viewer tears down its world
+   * itself.
    *
-   * @param offset - The number of TiledImages between the anchor and the first new TiledImage
+   * @param offset - The number of TiledImages between the anchor and the object's first new TiledImage
    * @param newRef - The object reference for which to create a rendered object
    * @param options - Optional abort signal
    * @returns The newly created rendered object, which does not have TiledImages yet
@@ -311,6 +333,21 @@ export abstract class OpenSeadragonRendererBase<
         `Object with ID '${newRef.object.id}' has no tile sources`,
       );
     }
+    const useBackdrop = this.usesAdditiveBlending(newRef.data);
+    const tileSourcePromises = tileSources.map((tileSource) =>
+      this.context.openTileSource({ tileSource }, { signal }),
+    );
+    const backdropTileSourcePromise = useBackdrop
+      ? tileSourcePromises[0]!.then((firstTileSource) =>
+          OpenSeadragonUtils.createPixelTileSource(
+            {
+              width: firstTileSource.dimensions.x,
+              height: firstTileSource.dimensions.y,
+            },
+            OpenSeadragonUtils.blackPixelUrl,
+          ),
+        )
+      : undefined;
     const {
       promise: tiledImagesPromise,
       resolve: resolveTiledImagesPromise,
@@ -322,32 +359,68 @@ export abstract class OpenSeadragonRendererBase<
       state: {
         object: { dataSource: structuredClone(newRef.object.dataSource) },
       },
-      tiledImageCount: tileSources.length,
+      tileSourceCount: tileSources.length,
       tiledImagesPromise,
     };
-    const tiledImagePromises: Promise<OpenSeadragon.TiledImage>[] = [];
-    for (let c = 0; c < tileSources.length; c++) {
-      const tiledImagePromise = this.context.addTiledImage(
-        { tileSource: tileSources[c]! },
+    let backdropPromise: Promise<OpenSeadragon.TiledImage> | undefined;
+    if (useBackdrop && backdropTileSourcePromise !== undefined) {
+      backdropPromise = this.context.addTiledImage(
+        {
+          tileSource: backdropTileSourcePromise,
+          opacity: 0, // only make visible once transformed
+          // OBS: explicitly setting this would exclude the backdrop from the WebGL drawer's batched path!
+          // compositeOperation: "source-over",
+        },
         {
           signal,
           getIndex: () => {
             if (this._anchor !== undefined) {
               const anchorIndex = this.context.getTiledImageIndex(this._anchor);
               if (anchorIndex !== -1) {
-                return anchorIndex + 1 + offset + c;
+                return anchorIndex + 1 + offset;
               }
             }
             return undefined;
           },
         },
       );
-      tiledImagePromise.catch(() => {}); // prevent unhandled rejections in console
-      tiledImagePromises.push(tiledImagePromise);
+      backdropPromise.catch(() => {}); // prevent unhandled rejections in console
     }
-    Promise.allSettled(tiledImagePromises)
+    const tiledImagePromises = tileSourcePromises.map(
+      (tileSourcePromise, c) => {
+        const tiledImagePromise = this.context.addTiledImage(
+          {
+            tileSource: tileSourcePromise,
+            opacity: 0, // only make visible once transformed
+            ...(useBackdrop && { compositeOperation: "lighter" }),
+          },
+          {
+            signal,
+            getIndex: () => {
+              if (this._anchor !== undefined) {
+                const anchorIndex = this.context.getTiledImageIndex(
+                  this._anchor,
+                );
+                if (anchorIndex !== -1) {
+                  return anchorIndex + 1 + offset + (useBackdrop ? 1 : 0) + c;
+                }
+              }
+              return undefined;
+            },
+          },
+        );
+        tiledImagePromise.catch(() => {}); // prevent unhandled rejections in console
+        return tiledImagePromise;
+      },
+    );
+    Promise.allSettled([backdropPromise, ...tiledImagePromises])
       .then(async (results) => {
-        const tiledImages = results
+        const [backdropResult, ...tiledImageResults] = results;
+        const backdrop =
+          backdropResult?.status === "fulfilled"
+            ? backdropResult.value
+            : undefined;
+        const tiledImages = tiledImageResults
           .filter((result) => result.status === "fulfilled")
           .map((result) => result.value);
         if (this.context.isDestroyed()) {
@@ -360,13 +433,16 @@ export abstract class OpenSeadragonRendererBase<
           newRenderedObject.pendingDelete ||
           this._destroyed
         ) {
+          if (backdrop !== undefined) {
+            await this.context.removeTiledImage(backdrop);
+          }
           for (const tiledImage of tiledImages) {
             await this.context.removeTiledImage(tiledImage);
           }
           signal?.throwIfAborted();
           if (failure !== undefined) {
             console.error(
-              `Failed to add ${results.length - tiledImages.length} of ${results.length} tiled images for object with ID '${newRef.object.id}'`,
+              `Failed to add tiled images for object with ID '${newRef.object.id}'`,
               failure.reason,
             );
             throw new Error("Failed to add tiled images", {
@@ -374,6 +450,7 @@ export abstract class OpenSeadragonRendererBase<
             });
           }
         } else {
+          newRenderedObject.backdrop = backdrop;
           newRenderedObject.tiledImages = tiledImages;
           this.updateRenderedObject(newRenderedObject);
           await this.updateBounds({ signal });
@@ -385,13 +462,13 @@ export abstract class OpenSeadragonRendererBase<
   }
 
   /**
-   * Applies the transform, flip, visibility, and opacity of an object reference to each of the rendered object's TiledImages
+   * Applies the transform, flip, visibility, and opacity of an object reference to the rendered object's backdrop and TiledImages
    *
-   * Only properties whose value actually changed are written, as each write
-   * triggers a redraw. The opacity is computed per TiledImage via
-   * {@link getOpacity}, so that subclasses can vary it by channel; all other
-   * properties are shared by all TiledImages of an object. The applied data
-   * source is recorded in the rendered object's state, where
+   * The opacity is computed per TiledImage via {@link getOpacity}, so that
+   * subclasses can vary it by channel; all other properties are shared by all
+   * TiledImages of an object, and by its backdrop. The backdrop is opaque where
+   * the object is, so it gets {@link getOpacity} without a channel index. The
+   * applied data source is recorded in the rendered object's state, where
    * {@link cleanRenderedObjects} picks it up to detect TiledImages that have to
    * be recreated.
    *
@@ -407,40 +484,19 @@ export abstract class OpenSeadragonRendererBase<
       throw new Error("Rendered object not loaded");
     }
     renderedObject.ref = newRef;
-    for (let c = 0; c < renderedObject.tiledImages.length; c++) {
-      const tiledImage = renderedObject.tiledImages[c]!;
-      // transform --> flip, width, rotation, position
-      const bounds = tiledImage.getBounds();
-      const transform = OpenSeadragonRendererBase.getTransform(
+    if (renderedObject.backdrop !== undefined) {
+      this._updateTiledImage(
+        renderedObject.backdrop,
         newRef,
-        tiledImage.getContentSize(),
+        this.getOpacity(newRef),
       );
-      if (tiledImage.getFlip() !== transform.flip) {
-        tiledImage.setFlip(transform.flip);
-      }
-      if (bounds.width !== transform.width) {
-        tiledImage.setWidth(transform.width, true); // implicitly updates height to maintain aspect ratio
-      }
-      if (tiledImage.getRotation() !== transform.rotation) {
-        tiledImage.setRotation(transform.rotation, true);
-      }
-      if (
-        bounds.x !== transform.position.x ||
-        bounds.y !== transform.position.y
-      ) {
-        tiledImage.setPosition(transform.position, true);
-      }
-      // visibility & opacity --> opacity
-      const oldOpacity = tiledImage.getOpacity();
-      const newOpacity = this.getOpacity(newRef, c);
-      if (oldOpacity !== newOpacity) {
-        tiledImage.setOpacity(newOpacity);
-        if (oldOpacity === 0 && newOpacity > 0) {
-          // OpenSeadragon does not load tiles for invisible images,
-          // so we need to trigger a reload when an image becomes visible
-          tiledImage.update(true);
-        }
-      }
+    }
+    for (let c = 0; c < renderedObject.tiledImages.length; c++) {
+      this._updateTiledImage(
+        renderedObject.tiledImages[c]!,
+        newRef,
+        this.getOpacity(newRef, c),
+      );
     }
     renderedObject.state = {
       object: {
@@ -450,7 +506,7 @@ export abstract class OpenSeadragonRendererBase<
   }
 
   /**
-   * Deletes the rendered object by removing its TiledImages from the OpenSeadragon viewer, or marking it for deletion if the TiledImages have not yet been created
+   * Deletes the rendered object by removing its backdrop and TiledImages from the OpenSeadragon viewer, or marking it for deletion if the TiledImages have not yet been created
    *
    * The removals are queued by the context (see
    * {@link OpenSeadragonContext.removeTiledImage}) and applied before any tiled
@@ -460,7 +516,7 @@ export abstract class OpenSeadragonRendererBase<
    * Deleting a rendered object does not remove it from {@link renderedObjects}.
    *
    * @param renderedObject - The rendered object to delete
-   * @returns A promise that resolves once all of its TiledImages have been removed
+   * @returns A promise that resolves once its backdrop and all of its TiledImages have been removed
    */
   protected deleteRenderedObject(
     renderedObject: RenderedObject<TObject, TObjectData>,
@@ -469,11 +525,13 @@ export abstract class OpenSeadragonRendererBase<
       renderedObject.pendingDelete = true;
       return Promise.resolve();
     }
-    return Promise.all(
-      renderedObject.tiledImages.map((tiledImage) =>
-        this.context.removeTiledImage(tiledImage),
-      ),
-    ).then(() => {});
+    const promises = renderedObject.tiledImages.map((tiledImage) =>
+      this.context.removeTiledImage(tiledImage),
+    );
+    if (renderedObject.backdrop !== undefined) {
+      promises.push(this.context.removeTiledImage(renderedObject.backdrop));
+    }
+    return Promise.all(promises).then(() => {});
   }
 
   /**
@@ -485,6 +543,73 @@ export abstract class OpenSeadragonRendererBase<
   protected abstract getTileSources(
     data: TObjectData,
   ): (string | TileSourceConfig | CustomTileSource)[];
+
+  /**
+   * Returns whether the channels of the given object data are blended additively
+   *
+   * The channels of an object that blends additively are composited with
+   * OpenSeadragon's "lighter" operation onto an opaque black backdrop below
+   * them, so that they add up among themselves while the backdrop hides
+   * whatever is below the object, thereby compositing the object as a whole over
+   * it. Objects that do not blend additively have no backdrop and keep
+   * OpenSeadragon's default composite operation, i.e. each of their channels is
+   * composited over the one below it.
+   *
+   * @param _data - The object data (image or labels) to check
+   * @returns Whether the object's channels are blended additively. Defaults to `false`.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  protected usesAdditiveBlending(_data: TObjectData): boolean {
+    return false;
+  }
+
+  /**
+   * Applies the transform of an object reference and the given opacity to a single TiledImage
+   *
+   * Only properties whose value actually changed are written, as each write
+   * triggers a redraw.
+   *
+   * @param tiledImage - The TiledImage to update
+   * @param ref - The object reference whose transform to apply
+   * @param opacity - The effective opacity to apply
+   */
+  private _updateTiledImage(
+    tiledImage: OpenSeadragon.TiledImage,
+    ref: ObjectRef<TObject, TObjectData>,
+    opacity: number,
+  ): void {
+    // transform --> flip, width, rotation, position
+    const bounds = tiledImage.getBounds();
+    const transform = OpenSeadragonRendererBase.getTransform(
+      ref,
+      tiledImage.getContentSize(),
+    );
+    if (tiledImage.getFlip() !== transform.flip) {
+      tiledImage.setFlip(transform.flip);
+    }
+    if (bounds.width !== transform.width) {
+      tiledImage.setWidth(transform.width, true); // implicitly updates height to maintain aspect ratio
+    }
+    if (tiledImage.getRotation() !== transform.rotation) {
+      tiledImage.setRotation(transform.rotation, true);
+    }
+    if (
+      bounds.x !== transform.position.x ||
+      bounds.y !== transform.position.y
+    ) {
+      tiledImage.setPosition(transform.position, true);
+    }
+    // visibility & opacity --> opacity
+    const oldOpacity = tiledImage.getOpacity();
+    if (oldOpacity !== opacity) {
+      tiledImage.setOpacity(opacity);
+      if (oldOpacity === 0 && opacity > 0) {
+        // OpenSeadragon does not load tiles for invisible images,
+        // so we need to trigger a reload when an image becomes visible
+        tiledImage.update(true);
+      }
+    }
+  }
 
   /**
    * Appends a task to the anchor task queue
@@ -514,17 +639,19 @@ export abstract class OpenSeadragonRendererBase<
    * Returns `0` when either the layer or the object is invisible; otherwise
    * multiplies layer and object opacities. The channel index is ignored here,
    * i.e. all tiled images of an object share the same opacity; subclasses
-   * override this to additionally apply per-channel visibility and opacity.
+   * override this to additionally apply per-channel visibility and opacity. The
+   * channel index is omitted for an object's backdrop, which carries the opacity
+   * of the object itself.
    *
    * @param ref - The object reference for which to compute the opacity
-   * @param _c - The index of the tiled image among the object's tiled images,
-   * i.e. the index of the channel it renders
+   * @param _c - The index of the channel rendered by the tiled image, or
+   * `undefined` for the object's backdrop
    * @returns The effective opacity for the tiled image
    */
   protected getOpacity(
     ref: ObjectRef<TObject, TObjectData>,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _c: number,
+    _c?: number,
   ): number {
     const visibility = ref.layer.visibility && ref.object.visibility;
     const opacity = ref.layer.opacity * ref.object.opacity;
@@ -595,11 +722,14 @@ export type ObjectRef<
 /**
  * Mutable state for the tiled images of a single object in the viewer
  *
- * An object occupies `tiledImageCount` consecutive world indices, one tiled
- * image per channel, in the order of its tile sources. The count is known as
- * soon as the rendered object is created, whereas `tiledImages` is assigned only
- * once all of them have been added to the world, which is also when
- * `tiledImagesPromise` resolves.
+ * An object occupies `tileSourceCount` consecutive world indices, one tiled
+ * image per channel, in the order of its tile sources, preceded by that of its
+ * `backdrop`: the opaque black tiled image that the channels of an additively
+ * blended object add up on (see
+ * {@link OpenSeadragonRendererBase.usesAdditiveBlending}). The count is known as
+ * soon as the rendered object is created, whereas `backdrop` and `tiledImages`
+ * are assigned only once all of them have been added to the world, which is also
+ * when `tiledImagesPromise` resolves, with `tiledImages` alone.
  */
 export type RenderedObject<
   TObject extends Image | Labels,
@@ -607,8 +737,9 @@ export type RenderedObject<
 > = {
   ref: ObjectRef<TObject, TObjectData>;
   state: { object: Pick<TObject, "dataSource"> };
-  tiledImageCount: number;
+  tileSourceCount: number;
   tiledImagesPromise: Promise<OpenSeadragon.TiledImage[]>;
   tiledImages?: OpenSeadragon.TiledImage[];
+  backdrop?: OpenSeadragon.TiledImage;
   pendingDelete?: boolean;
 };

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonUtils.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonUtils.ts
@@ -1,0 +1,37 @@
+import type { Dims, TileSourceConfig } from "@tissuumaps/core";
+
+/**
+ * Helpers for constructing OpenSeadragon tile sources
+ */
+export class OpenSeadragonUtils {
+  /** A single fully transparent pixel, as a PNG data URL */
+  static readonly transparentPixelUrl =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAEElEQVR4AQEFAPr/AAAAAAAABQABZHiVOAAAAABJRU5ErkJggg==";
+
+  /** A single opaque black pixel, as a PNG data URL */
+  static readonly blackPixelUrl =
+    "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNgYGD4DwABBAEAcCBlCwAAAABJRU5ErkJggg==";
+
+  /**
+   * Creates a tile source that fills the given size with a single tile
+   *
+   * The tile source has a single level holding a single tile, which OpenSeadragon
+   * scales to the declared size, so a single-pixel URL fills an area of arbitrary
+   * size. The declared size is the content size of the resulting tiled image, and
+   * therefore determines its aspect ratio in the world.
+   *
+   * @param size - The size of the tile source, in pixels
+   * @param pixelUrl - URL of the image to fill the tile source with
+   * @returns The tile source configuration
+   */
+  static createPixelTileSource(size: Dims, pixelUrl: string): TileSourceConfig {
+    return {
+      width: size.width,
+      height: size.height,
+      tileSize: Math.max(size.width, size.height),
+      minLevel: 0,
+      maxLevel: 0,
+      getTileUrl: () => pixelUrl,
+    };
+  }
+}

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageData.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageData.ts
@@ -9,27 +9,20 @@ import type {
 export class OMEZarrImageData implements ImageData {
   private readonly _tileSource: OMEZarrTileSource | undefined;
   private readonly _tileSources: OMEZarrTileSource[] | undefined;
-  private readonly _channelNames: string[] | undefined;
   private readonly _objectUrl?: string;
 
   constructor(
     tileSource: OMEZarrTileSource | undefined,
     tileSources: OMEZarrTileSource[] | undefined,
-    channelNames: string[] | undefined,
     objectUrl?: string,
   ) {
     this._tileSource = tileSource;
     this._tileSources = tileSources;
-    this._channelNames = channelNames;
     this._objectUrl = objectUrl;
   }
 
   getSizeC(): number | undefined {
     return this._tileSources?.length;
-  }
-
-  getChannelNames(): string[] | undefined {
-    return this._tileSources !== undefined ? this._channelNames : undefined;
   }
 
   getTileSource(c?: number): string | TileSourceConfig | CustomTileSource {

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageData.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageData.ts
@@ -7,33 +7,45 @@ import type {
 } from "@tissuumaps/core";
 
 export class OMEZarrImageData implements ImageData {
-  private readonly _tileSources: OMEZarrTileSource[];
+  private readonly _tileSource: OMEZarrTileSource | undefined;
+  private readonly _tileSources: OMEZarrTileSource[] | undefined;
+  private readonly _channelNames: string[] | undefined;
   private readonly _objectUrl?: string;
 
-  constructor(tileSources: OMEZarrTileSource[], objectUrl?: string) {
+  constructor(
+    tileSource: OMEZarrTileSource | undefined,
+    tileSources: OMEZarrTileSource[] | undefined,
+    channelNames: string[] | undefined,
+    objectUrl?: string,
+  ) {
+    this._tileSource = tileSource;
     this._tileSources = tileSources;
+    this._channelNames = channelNames;
     this._objectUrl = objectUrl;
   }
 
   getSizeC(): number | undefined {
-    throw new Error("Method not implemented.");
+    return this._tileSources?.length;
   }
 
   getChannelNames(): string[] | undefined {
-    throw new Error("Method not implemented.");
+    return this._tileSources !== undefined ? this._channelNames : undefined;
   }
 
   getTileSource(c?: number): string | TileSourceConfig | CustomTileSource {
-    if (c === undefined) {
-      if (this._tileSources.length !== 1) {
-        throw new Error("Multi-channel images require a channel index");
+    if (c !== undefined) {
+      if (this._tileSources === undefined) {
+        throw new Error("Not a multi-channel image");
       }
-      return this._tileSources[0]!;
+      if (c < 0 || c >= this._tileSources.length) {
+        throw new Error(`Channel index ${c} is out of bounds`);
+      }
+      return this._tileSources[c]!;
     }
-    if (c < 0 || c >= this._tileSources.length) {
-      throw new Error(`Channel index ${c} is out of bounds`);
+    if (this._tileSource === undefined) {
+      throw new Error("Not a single-channel image");
     }
-    return this._tileSources[c]!;
+    return this._tileSource;
   }
 
   close(): void {

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageData.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageData.ts
@@ -7,20 +7,37 @@ import type {
 } from "@tissuumaps/core";
 
 export class OMEZarrImageData implements ImageData {
-  private readonly _tileSource: OMEZarrTileSource;
+  private readonly _tileSources: OMEZarrTileSource[];
   private readonly _objectUrl?: string;
 
-  constructor(tileSource: OMEZarrTileSource, objectUrl?: string) {
-    this._tileSource = tileSource;
+  constructor(tileSources: OMEZarrTileSource[], objectUrl?: string) {
+    this._tileSources = tileSources;
     this._objectUrl = objectUrl;
   }
 
-  getTileSource(): string | TileSourceConfig | CustomTileSource {
-    return this._tileSource;
+  getSizeC(): number | undefined {
+    throw new Error("Method not implemented.");
+  }
+
+  getChannelNames(): string[] | undefined {
+    throw new Error("Method not implemented.");
+  }
+
+  getTileSource(c?: number): string | TileSourceConfig | CustomTileSource {
+    if (c === undefined) {
+      if (this._tileSources.length !== 1) {
+        throw new Error("Multi-channel images require a channel index");
+      }
+      return this._tileSources[0]!;
+    }
+    if (c < 0 || c >= this._tileSources.length) {
+      throw new Error(`Channel index ${c} is out of bounds`);
+    }
+    return this._tileSources[c]!;
   }
 
   close(): void {
-    if (this._objectUrl) {
+    if (this._objectUrl !== undefined) {
       URL.revokeObjectURL(this._objectUrl);
     }
   }

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
@@ -25,7 +25,7 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
         type: "string",
       },
       // TODO path
-      c: {
+      sizeC: {
         type: "integer",
       },
       z: {
@@ -47,6 +47,11 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
         label: "URL",
       },
       // TODO path
+      {
+        type: "Control",
+        scope: "#/properties/sizeC",
+        label: "Number of channels",
+      },
       {
         type: "Control",
         scope: "#/properties/z",

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
@@ -95,17 +95,24 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
     } else {
       throw new Error("A URL or workspace path is required to load data.");
     }
-    const tileSources = [];
+    let tileSource: OMEZarrTileSource | undefined;
+    let tileSources: OMEZarrTileSource[] | undefined;
+    let channelNames: string[] | undefined;
     const { sizeC, z, t } = normalizedDataSource;
-    if (sizeC !== undefined) {
-      for (let c = 0; c < sizeC; c++) {
-        const tileSource = new OMEZarrTileSource({ url, c, z, t });
-        tileSources.push(tileSource);
-      }
+    if (sizeC === undefined) {
+      tileSource = new OMEZarrTileSource({ url, z, t });
     } else {
-      const tileSource = new OMEZarrTileSource({ url, z, t });
-      tileSources.push(tileSource);
+      tileSources = [];
+      for (let c = 0; c < sizeC; c++) {
+        tileSources.push(new OMEZarrTileSource({ url, c, z, t }));
+      }
+      channelNames = undefined; // TODO channel names
     }
-    return new OMEZarrImageData(tileSources, objectUrl);
+    return new OMEZarrImageData(
+      tileSource,
+      tileSources,
+      channelNames,
+      objectUrl,
+    );
   }
 }

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
@@ -105,6 +105,8 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
     const { sizeC, z, t } = normalizedDataSource;
     if (sizeC === undefined) {
       tileSource = new OMEZarrTileSource({ url, z, t });
+    } else if (sizeC <= 0) {
+      throw new Error("Number of channels must be a positive integer.");
     } else {
       tileSources = [];
       for (let c = 0; c < sizeC; c++) {

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
@@ -102,7 +102,6 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
     }
     let tileSource: OMEZarrTileSource | undefined;
     let tileSources: OMEZarrTileSource[] | undefined;
-    let channelNames: string[] | undefined;
     const { sizeC, z, t } = normalizedDataSource;
     if (sizeC === undefined) {
       tileSource = new OMEZarrTileSource({ url, z, t });
@@ -111,13 +110,7 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
       for (let c = 0; c < sizeC; c++) {
         tileSources.push(new OMEZarrTileSource({ url, c, z, t }));
       }
-      channelNames = undefined; // TODO channel names
     }
-    return new OMEZarrImageData(
-      tileSource,
-      tileSources,
-      channelNames,
-      objectUrl,
-    );
+    return new OMEZarrImageData(tileSource, tileSources, objectUrl);
   }
 }

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
@@ -49,11 +49,6 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
       // TODO path
       {
         type: "Control",
-        scope: "#/properties/c",
-        label: "Channel",
-      },
-      {
-        type: "Control",
         scope: "#/properties/z",
         label: "Z-slice",
       },
@@ -84,35 +79,33 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
 
     const normalizedDataSource = this.normalizeDataSource(dataSource);
 
+    let url: string;
+    let objectUrl: string | undefined = undefined;
     if (normalizedDataSource.path !== undefined && workspace !== null) {
       const fh = await workspace.getFileHandle(normalizedDataSource.path);
       signal?.throwIfAborted(); // getFileHandle() does not throw on abort
       const file = await fh.getFile();
       signal?.throwIfAborted(); // getFile() does not throw on abort
-      const objectUrl = URL.createObjectURL(file);
-      const tileSource = new OMEZarrTileSource({
-        url: objectUrl,
-        c: normalizedDataSource.c,
-        z: normalizedDataSource.z,
-        t: normalizedDataSource.t,
-      });
-      return new OMEZarrImageData(tileSource, objectUrl);
-    }
-
-    if (normalizedDataSource.url !== undefined) {
-      const tileSource = new OMEZarrTileSource({
-        url: normalizedDataSource.url,
-        c: normalizedDataSource.c,
-        z: normalizedDataSource.z,
-        t: normalizedDataSource.t,
-      });
-      return new OMEZarrImageData(tileSource, undefined);
-    }
-
-    if (normalizedDataSource.path !== undefined) {
+      objectUrl = URL.createObjectURL(file);
+      url = objectUrl;
+    } else if (normalizedDataSource.url !== undefined) {
+      url = normalizedDataSource.url;
+    } else if (normalizedDataSource.path !== undefined) {
       throw new Error("An open workspace is required to open local-only data.");
+    } else {
+      throw new Error("A URL or workspace path is required to load data.");
     }
-
-    throw new Error("A URL or workspace path is required to load data.");
+    const tileSources = [];
+    const { sizeC, z, t } = normalizedDataSource;
+    if (sizeC !== undefined) {
+      for (let c = 0; c < sizeC; c++) {
+        const tileSource = new OMEZarrTileSource({ url, c, z, t });
+        tileSources.push(tileSource);
+      }
+    } else {
+      const tileSource = new OMEZarrTileSource({ url, z, t });
+      tileSources.push(tileSource);
+    }
+    return new OMEZarrImageData(tileSources, objectUrl);
   }
 }

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataProvider.ts
@@ -84,6 +84,12 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
 
     const normalizedDataSource = this.normalizeDataSource(dataSource);
 
+    const { sizeC, z, t } = normalizedDataSource;
+    // validate before any file handling, so that no object URL is leaked
+    if (sizeC !== undefined && sizeC <= 0) {
+      throw new Error("Number of channels must be a positive integer.");
+    }
+
     let url: string;
     let objectUrl: string | undefined = undefined;
     if (normalizedDataSource.path !== undefined && workspace !== null) {
@@ -102,11 +108,8 @@ export class OMEZarrImageDataProvider implements ImageDataProvider<
     }
     let tileSource: OMEZarrTileSource | undefined;
     let tileSources: OMEZarrTileSource[] | undefined;
-    const { sizeC, z, t } = normalizedDataSource;
     if (sizeC === undefined) {
       tileSource = new OMEZarrTileSource({ url, z, t });
-    } else if (sizeC <= 0) {
-      throw new Error("Number of channels must be a positive integer.");
     } else {
       tileSources = [];
       for (let c = 0; c < sizeC; c++) {

--- a/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataSource.ts
+++ b/packages/@tissuumaps-storage/src/ome-zarr/OMEZarrImageDataSource.ts
@@ -8,8 +8,8 @@ export interface OMEZarrImageDataSource extends ImageDataSource<
   typeof omeZarrImageDataSourceType
 > {
   t?: number;
-  c?: number;
   z?: number;
+  sizeC?: number;
 }
 
 export type DefaultOMEZarrImageDataSource = Required<

--- a/packages/@tissuumaps-storage/src/openseadragon/OpenSeadragonImageData.ts
+++ b/packages/@tissuumaps-storage/src/openseadragon/OpenSeadragonImageData.ts
@@ -13,7 +13,18 @@ export class OpenSeadragonImageData implements ImageData {
     this._objectUrl = objectUrl;
   }
 
-  getTileSource(): string | TileSourceConfig | CustomTileSource {
+  getSizeC(): number | undefined {
+    return undefined;
+  }
+
+  getChannelNames(): string[] | undefined {
+    return undefined;
+  }
+
+  getTileSource(c?: number): string | TileSourceConfig | CustomTileSource {
+    if (c !== undefined) {
+      throw new Error("Multi-channel images are not supported");
+    }
     return this._tileSource;
   }
 

--- a/packages/@tissuumaps-storage/src/openseadragon/OpenSeadragonImageData.ts
+++ b/packages/@tissuumaps-storage/src/openseadragon/OpenSeadragonImageData.ts
@@ -17,10 +17,6 @@ export class OpenSeadragonImageData implements ImageData {
     return undefined;
   }
 
-  getChannelNames(): string[] | undefined {
-    return undefined;
-  }
-
   getTileSource(c?: number): string | TileSourceConfig | CustomTileSource {
     if (c !== undefined) {
       throw new Error("Multi-channel images are not supported");


### PR DESCRIPTION
# References and relevant issues

[TMAP-162](https://scilifelab.atlassian.net/browse/TMAP-162) — Add multi-channel image support.

Builds on the incremental renderer synchronization from #167. **No UI is wired up yet** (see *Further comments*).

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

Renders multi-channel images as one OpenSeadragon TiledImage per channel, additively blended onto an opaque backdrop, with a per-channel color, visibility and opacity taken from the model.

**Model (`@tissuumaps/core`)**

- New `Channel` type in `model/image.ts` (`name?`, `visibility?`, `opacity?`, `color?`), and `RawImage.channels?: Channel[]`, indexed by channel. Channels beyond the end of the array, and images whose data is not multi-channel, fall back to the defaults (visible, opacity 1, no tint). `RawImage` is no longer an empty interface, so the `no-empty-object-type` suppression is gone.
- `ImageData` (`storage/image.ts`) becomes explicitly two-shaped: it either provides one tile source *per channel*, or a single unaddressed one. `getSizeC()` returns `undefined` in the latter case; `getTileSource(c?)` takes a channel index that is required for multi-channel data, must be omitted otherwise, and throws when it is out of bounds. Channel metadata is exposed through four *optional* per-channel accessors — `getChannelName?(c)`, `getChannelVisibility?(c)`, `getChannelOpacity?(c)` and `getChannelColor?(c)` — replacing the whole-image `getChannelNames()`, so a data provider can report what a format already knows (OME-Zarr `omero` rendering settings, for instance) without every implementation having to grow four methods.
- `OpenSeadragonViewerOptions` now also omits `compositeOperation` — viewer options are applied to *every* tiled image in the world, which would overwrite the per-tiled-image composite operations the renderers now set.
- `ColorUtils.colorsEqual()` (exact component comparison, no tolerance) plus 4 tests, used to skip redundant tint invalidations.

**Tinting (`OpenSeadragonContext`)**

- New `setTiledImageTint(tiledImage, tint | undefined)`. OpenSeadragon has no per-image color, so the tint is applied to the *tiles*, in a `tile-invalidated` handler: the tile is composited over opaque black (`destination-over`, which turns transparency into intensity), then `multiply`-ed with the tint.
- Tints are stored in a `WeakMap` keyed by **tile source**, not tiled image, because that is the granularity at which OSD keys its tile caches — and it also covers the navigator, whose tiled images mirror the world but share its tile sources. Consequence, documented on the method: tiled images sharing a tile source share a tint, last write wins.
- The tint is only written and the tiles only invalidated when the color actually changed; `requestInvalidate(restoreTiles: true, viewportOnly: false)` re-runs the tinting from the original tile data on every loaded tile.
- `_openTileSource()` is now public `openTileSource()` and additionally awaits a *promised* tile source. This lets a caller derive one tile source from another that is still opening without losing its place in the addition queue (and therefore its world index) — which is exactly what the backdrop needs.

**Per-channel tiled images (`OpenSeadragonRendererBase`)**

- `RenderedObject` holds `tiledImages: TiledImage[]` and an optional `backdrop` instead of a single `tiledImage`; `tiledImagePromise` → `tiledImagesPromise`. `tileSourceCount` is recorded up front, at creation time, because the world layout has to be computable before the images exist.
- An object now occupies `tileSourceCount` consecutive world indices after the anchor, optionally preceded by its backdrop. `createRenderedObject(offset, …)`'s `offset` therefore counts **TiledImages, not objects**; callers advance it by `tileSourceCount` (+1 for a backdrop). `cleanRenderedObjects()` checks that the backdrop *and* every tiled image sit at their expected consecutive index — a partially misplaced object is not reusable.
- All additions for an object are requested before `createRenderedObject()` returns and in world order, then joined with `Promise.allSettled`. If any one of them fails, the whole object is torn down again: a partially added object would shift the world indices of everything behind it. Deletion removes tiled images and backdrop together.
- New overridable `usesAdditiveBlending(data)` (default `false`), `getTiledImageColor(ref, c)` (default `undefined`) and `getTiledImageOpacity(ref, c?)` (default: the old layer × object opacity, `0` when either is invisible). `getOpacity`/`getTransform` were renamed to `getTiledImageOpacity`/`getTiledImageTransform`; the former stops being `static` since subclasses now override it. The per-image write logic moved into a private `_updateTiledImage()`, still writing only properties whose value actually changed.
- The backdrop is an opaque-black single-pixel tile source sized to the *first opened* channel's dimensions, added with `opacity: 0` (made visible only once transformed) and, deliberately, **no explicit `compositeOperation`** — setting it, even to `"source-over"`, would exclude the backdrop from the WebGL drawer's batched path. The channels themselves get `compositeOperation: "lighter"`, so they add up among themselves while the backdrop hides what is below, compositing the object as a whole over the rest of the world.

**Image renderer (`OpenSeadragonImageRenderer`)**

- `getTileSource` → `getTileSources`, returning one tile source per channel for multi-channel data and a single one otherwise (`OpenSeadragonLabelsRenderer` follows the renamed signature; it still throws).
- Overrides `usesAdditiveBlending` (true iff `getSizeC() !== undefined`), `getTiledImageColor` (the channel's color; `undefined` leaves the tiles in their own colors) and `getTiledImageOpacity` (multiplies the base opacity by the channel's visibility and opacity; the backdrop, called without `c`, keeps the plain layer × object opacity). Each of the three channel properties is resolved model first, data second, default last: an explicit value on `Image.channels[c]` wins, otherwise the data's optional accessor is consulted, otherwise the default (visible, opacity 1, no tint) applies.
- `synchronize()` now walks `newRefs` with a running TiledImage offset instead of using the loop index, and images whose tiled images cannot be created — e.g. data that yields no tile sources — are logged and skipped, like images whose data failed to load.

**Storage providers**

- `OMEZarrImageDataSource.c` (a single channel to show) is replaced by `sizeC` (the number of channels to open). `OMEZarrImageDataProvider` builds one `OMEZarrTileSource` per channel when `sizeC` is set and a single one otherwise, and the URL/object-URL resolution was flattened into one `if`/`else if` chain so both paths share the tile-source construction. The "Channel" control is gone from the uischema.
- `OpenSeadragonImageData` reports "not multi-channel" (`getSizeC()` → `undefined`) and throws if a channel index is passed. `ImageDataWrapper` forwards `getSizeC()`, the channel-indexed `getTileSource()` and the four optional per-channel accessors.

**Misc**

- `OpenSeadragonUtils` (new) holds `transparentPixelUrl`, the new `blackPixelUrl`, and `createPixelTileSource(size, pixelUrl)`, extracted from the anchor tile source in `OpenSeadragonContext` and now shared with the backdrop.
- `tiledImage.update(true)` on a 0 → visible opacity transition became `update(/* viewportChanged */ false)`; the argument is `viewportChanged`, and the viewport has not changed here.

# Screenshot of the fix

N/A for now — nothing in the UI exposes channels yet, so there is no user-visible change to screenshot (see *Further comments*).

# Use of AI

Yes. As with the rest of `development`, the code was written with the assistance of Claude Code (Opus 5) and manually reviewed; Claude Code also drafted this description and ran the verification below.

# Testing

- Instructions on how to test

`pnpm run build`, `eslint .`, `prettier --check .` and `pnpm test` (439 passed / 18 files) all pass on this branch. Only the 4 new `ColorUtils.colorsEqual` tests are new — the OpenSeadragon renderers have no test coverage, so the rendering itself has to be exercised by hand.

To do that, an OME-Zarr image data source with `sizeC` set has to be put into a project file directly, together with `channels` on the image (see *Further comments*). Worth checking: channels adding up rather than occluding each other; toggling a channel's `visibility`/`opacity`/`color`; single-channel and non-OME-Zarr (DZI/IIIF) images still rendering unchanged with their transparency intact; the navigator showing the same tints; and reordering/removing images, which is where the consecutive world indices are easy to get wrong.

# Further comments

**No UI, and no channel discovery.** `Image.channels` and the `ImageData` channel accessors are model and storage plumbing only — nothing reads `channels` outside the renderer, and nothing writes it, so channels can currently only be configured by hand in a project file. No data provider implements the optional accessors yet either: `OMEZarrImageDataProvider` does not read channel metadata at all, `sizeC` has to be supplied by the caller, and channel names are left `undefined` (`// TODO channel names`). Both are follow-up work.

**Tinting drops tile transparency.** Compositing over black is what makes `"lighter"` blending behave, but it means a tinted tiled image *must* sit on the backdrop; this is why only multi-channel image data is tinted, and why `getTiledImageColor()` returns `undefined` for everything else.

