### PR TITLE
refactor(core): pivot-based similarity matrix decomposition

### DIFF
--- a/packages/@tissuumaps-core/src/utils/TransformUtils.test.ts
+++ b/packages/@tissuumaps-core/src/utils/TransformUtils.test.ts
@@ -1,4 +1,4 @@
-import { mat3 } from "gl-matrix";
+import { mat3, vec2 } from "gl-matrix";
 import { describe, expect, it } from "vitest";
 
 import type { SimilarityTransform } from "../model/primitives";
@@ -82,6 +82,146 @@ describe("TransformUtils", () => {
       const tf = TransformUtils.fromSimilarityMatrix(m);
       expect(tf.flip).toBe(false);
     });
+  });
+
+  describe("fromSimilarityMatrix with pivot", () => {
+    const pivot = { x: 50, y: 25 };
+
+    it("matches the pivot-free result for a pivot at the origin", () => {
+      const m = mat3.create();
+      mat3.translate(m, m, [5, 7]);
+      mat3.rotate(m, m, Math.PI / 6);
+      mat3.scale(m, m, [2, 2]);
+      mat3.scale(m, m, [-1, 1]);
+      const tf = TransformUtils.fromSimilarityMatrix(m, { x: 0, y: 0 });
+      const ref = TransformUtils.fromSimilarityMatrix(m);
+      expect(tf).toEqual(ref);
+    });
+
+    it("leaves the identity matrix untouched", () => {
+      const tf = TransformUtils.fromSimilarityMatrix(mat3.create(), pivot);
+      expect(tf.flip).toBe(false);
+      expect(tf.scale).toBeCloseTo(1);
+      expect(tf.rotation).toBeCloseTo(0);
+      expect(tf.translation.x).toBeCloseTo(0);
+      expect(tf.translation.y).toBeCloseTo(0);
+    });
+
+    it("does not pivot scale", () => {
+      const m = mat3.create();
+      mat3.translate(m, m, [5, 7]);
+      mat3.scale(m, m, [3, 3]);
+      const tf = TransformUtils.fromSimilarityMatrix(m, pivot);
+      expect(tf.scale).toBeCloseTo(3);
+      expect(tf.translation.x).toBeCloseTo(5);
+      expect(tf.translation.y).toBeCloseTo(7);
+    });
+
+    it("shifts a flip about the origin to a flip about the pivot", () => {
+      const m = mat3.create();
+      mat3.scale(m, m, [-1, 1]);
+      const tf = TransformUtils.fromSimilarityMatrix(m, pivot);
+      expect(tf.flip).toBe(true);
+      // Flipping about x = 0 equals flipping about x = pivot.x, then
+      // translating by -2 * pivot.x
+      expect(tf.translation.x).toBeCloseTo(-2 * pivot.x);
+      expect(tf.translation.y).toBeCloseTo(0);
+    });
+
+    it("shifts a rotation about the origin to a rotation about the pivot", () => {
+      const m = mat3.create();
+      mat3.rotate(m, m, Math.PI / 2);
+      const tf = TransformUtils.fromSimilarityMatrix(m, pivot);
+      expect(tf.rotation).toBeCloseTo(90);
+      // A 90° rotation maps the pivot (x, y) to (-y, x); the translation is
+      // that image minus the (unscaled) pivot
+      expect(tf.translation.x).toBeCloseTo(-pivot.y - pivot.x);
+      expect(tf.translation.y).toBeCloseTo(pivot.x - pivot.y);
+    });
+
+    it("keeps flip, scale, and rotation", () => {
+      const m = mat3.create();
+      mat3.translate(m, m, [5, 7]);
+      mat3.rotate(m, m, Math.PI / 6);
+      mat3.scale(m, m, [2, 2]);
+      mat3.scale(m, m, [-1, 1]);
+      const tf = TransformUtils.fromSimilarityMatrix(m, pivot);
+      const ref = TransformUtils.fromSimilarityMatrix(m);
+      expect(tf.flip).toBe(ref.flip);
+      expect(tf.scale).toBeCloseTo(ref.scale);
+      expect(tf.rotation).toBeCloseTo(ref.rotation);
+    });
+
+    it("places the pivot where the matrix maps it", () => {
+      const m = mat3.create();
+      mat3.translate(m, m, [5, 7]);
+      mat3.rotate(m, m, Math.PI / 4);
+      mat3.scale(m, m, [2, 2]);
+      mat3.scale(m, m, [-1, 1]);
+      const tf = TransformUtils.fromSimilarityMatrix(m, pivot);
+      const mapped = vec2.transformMat3(vec2.create(), [pivot.x, pivot.y], m);
+      // Flip and rotation fix the scaled pivot, so the mapped pivot is the
+      // translation plus the scaled pivot
+      expect(tf.translation.x + tf.scale * pivot.x).toBeCloseTo(mapped[0]);
+      expect(tf.translation.y + tf.scale * pivot.y).toBeCloseTo(mapped[1]);
+    });
+
+    it.each([
+      { flip: false, scale: 1, rotation: 0, translation: { x: 0, y: 0 } },
+      {
+        flip: false,
+        scale: 2.5,
+        rotation: 60,
+        translation: { x: -10, y: 20 },
+      },
+      {
+        flip: false,
+        scale: 0.5,
+        rotation: -45,
+        translation: { x: 100, y: 100 },
+      },
+      { flip: true, scale: 1, rotation: 0, translation: { x: 0, y: 0 } },
+      {
+        flip: true,
+        scale: 2.5,
+        rotation: 60,
+        translation: { x: -10, y: 20 },
+      },
+      {
+        flip: true,
+        scale: 0.5,
+        rotation: -45,
+        translation: { x: 100, y: 100 },
+      },
+    ])(
+      "rebuilds %j from translate, flip/rotate about the scaled pivot, scale",
+      (tf) => {
+        const m = TransformUtils.toSimilarityMatrix(tf);
+        const result = TransformUtils.fromSimilarityMatrix(m, pivot);
+        const rebuilt = mat3.create();
+        mat3.translate(rebuilt, rebuilt, [
+          result.translation.x,
+          result.translation.y,
+        ]);
+        // Flip and rotate about the scaled pivot
+        mat3.translate(rebuilt, rebuilt, [
+          result.scale * pivot.x,
+          result.scale * pivot.y,
+        ]);
+        mat3.rotate(rebuilt, rebuilt, (Math.PI * result.rotation) / 180);
+        if (result.flip) {
+          mat3.scale(rebuilt, rebuilt, [-1, 1]);
+        }
+        mat3.translate(rebuilt, rebuilt, [
+          -result.scale * pivot.x,
+          -result.scale * pivot.y,
+        ]);
+        mat3.scale(rebuilt, rebuilt, [result.scale, result.scale]);
+        for (let i = 0; i < 9; i++) {
+          expect(rebuilt[i]).toBeCloseTo(m[i]!);
+        }
+      },
+    );
   });
 
   describe("toSimilarityMatrix", () => {

--- a/packages/@tissuumaps-core/src/utils/TransformUtils.test.ts
+++ b/packages/@tissuumaps-core/src/utils/TransformUtils.test.ts
@@ -165,63 +165,6 @@ describe("TransformUtils", () => {
       expect(tf.translation.x + tf.scale * pivot.x).toBeCloseTo(mapped[0]);
       expect(tf.translation.y + tf.scale * pivot.y).toBeCloseTo(mapped[1]);
     });
-
-    it.each([
-      { flip: false, scale: 1, rotation: 0, translation: { x: 0, y: 0 } },
-      {
-        flip: false,
-        scale: 2.5,
-        rotation: 60,
-        translation: { x: -10, y: 20 },
-      },
-      {
-        flip: false,
-        scale: 0.5,
-        rotation: -45,
-        translation: { x: 100, y: 100 },
-      },
-      { flip: true, scale: 1, rotation: 0, translation: { x: 0, y: 0 } },
-      {
-        flip: true,
-        scale: 2.5,
-        rotation: 60,
-        translation: { x: -10, y: 20 },
-      },
-      {
-        flip: true,
-        scale: 0.5,
-        rotation: -45,
-        translation: { x: 100, y: 100 },
-      },
-    ])(
-      "rebuilds %j from translate, flip/rotate about the scaled pivot, scale",
-      (tf) => {
-        const m = TransformUtils.toSimilarityMatrix(tf);
-        const result = TransformUtils.fromSimilarityMatrix(m, pivot);
-        const rebuilt = mat3.create();
-        mat3.translate(rebuilt, rebuilt, [
-          result.translation.x,
-          result.translation.y,
-        ]);
-        // Flip and rotate about the scaled pivot
-        mat3.translate(rebuilt, rebuilt, [
-          result.scale * pivot.x,
-          result.scale * pivot.y,
-        ]);
-        mat3.rotate(rebuilt, rebuilt, (Math.PI * result.rotation) / 180);
-        if (result.flip) {
-          mat3.scale(rebuilt, rebuilt, [-1, 1]);
-        }
-        mat3.translate(rebuilt, rebuilt, [
-          -result.scale * pivot.x,
-          -result.scale * pivot.y,
-        ]);
-        mat3.scale(rebuilt, rebuilt, [result.scale, result.scale]);
-        for (let i = 0; i < 9; i++) {
-          expect(rebuilt[i]).toBeCloseTo(m[i]!);
-        }
-      },
-    );
   });
 
   describe("toSimilarityMatrix", () => {
@@ -292,6 +235,61 @@ describe("TransformUtils", () => {
     });
   });
 
+  describe("toSimilarityMatrix with pivot", () => {
+    const pivot = { x: 50, y: 25 };
+
+    it("matches the pivot-free result for a pivot at the origin", () => {
+      const tf: SimilarityTransform = {
+        flip: true,
+        scale: 2,
+        rotation: 30,
+        translation: { x: 5, y: 7 },
+      };
+      const m = TransformUtils.toSimilarityMatrix(tf, { x: 0, y: 0 });
+      const ref = TransformUtils.toSimilarityMatrix(tf);
+      for (let i = 0; i < 9; i++) {
+        expect(m[i]).toBeCloseTo(ref[i]!);
+      }
+    });
+
+    it("returns identity for an empty partial transform", () => {
+      const m = TransformUtils.toSimilarityMatrix({}, pivot);
+      const identity = mat3.create();
+      for (let i = 0; i < 9; i++) {
+        expect(m[i]).toBeCloseTo(identity[i]!);
+      }
+    });
+
+    it("flips about the pivot", () => {
+      const m = TransformUtils.toSimilarityMatrix({ flip: true }, pivot);
+      const q = vec2.transformMat3(vec2.create(), [10, 20], m);
+      expect(q[0]).toBeCloseTo(2 * pivot.x - 10);
+      expect(q[1]).toBeCloseTo(20);
+    });
+
+    it("rotates about the pivot", () => {
+      const m = TransformUtils.toSimilarityMatrix({ rotation: 90 }, pivot);
+      const fixed = vec2.transformMat3(vec2.create(), [pivot.x, pivot.y], m);
+      expect(fixed[0]).toBeCloseTo(pivot.x);
+      expect(fixed[1]).toBeCloseTo(pivot.y);
+      // (pivot.x + 1, pivot.y) rotates by 90° about the pivot to (pivot.x, pivot.y + 1)
+      const q = vec2.transformMat3(vec2.create(), [pivot.x + 1, pivot.y], m);
+      expect(q[0]).toBeCloseTo(pivot.x);
+      expect(q[1]).toBeCloseTo(pivot.y + 1);
+    });
+
+    it("scales about the origin and rotates about the scaled pivot", () => {
+      const m = TransformUtils.toSimilarityMatrix(
+        { scale: 2, rotation: 90 },
+        pivot,
+      );
+      // Scale is not pivoted, so the pivot lands at scale * pivot
+      const q = vec2.transformMat3(vec2.create(), [pivot.x, pivot.y], m);
+      expect(q[0]).toBeCloseTo(2 * pivot.x);
+      expect(q[1]).toBeCloseTo(2 * pivot.y);
+    });
+  });
+
   describe("fromSimilarityMatrix / toSimilarityMatrix roundtrip", () => {
     it.each([
       { flip: false, scale: 1, rotation: 0, translation: { x: 0, y: 0 } },
@@ -329,6 +327,75 @@ describe("TransformUtils", () => {
       expect(result.translation.x).toBeCloseTo(tf.translation.x);
       expect(result.translation.y).toBeCloseTo(tf.translation.y);
     });
+  });
+
+  describe("fromSimilarityMatrix / toSimilarityMatrix roundtrip with pivot", () => {
+    const pivot = { x: 50, y: 25 };
+
+    it.each([
+      { flip: false, scale: 1, rotation: 0, translation: { x: 0, y: 0 } },
+      {
+        flip: false,
+        scale: 2.5,
+        rotation: 60,
+        translation: { x: -10, y: 20 },
+      },
+      {
+        flip: false,
+        scale: 0.5,
+        rotation: -45,
+        translation: { x: 100, y: 100 },
+      },
+      { flip: true, scale: 1, rotation: 0, translation: { x: 0, y: 0 } },
+      {
+        flip: true,
+        scale: 2.5,
+        rotation: 60,
+        translation: { x: -10, y: 20 },
+      },
+      {
+        flip: true,
+        scale: 0.5,
+        rotation: -45,
+        translation: { x: 100, y: 100 },
+      },
+    ])("roundtrips %j through the matrix", (tf) => {
+      const m = TransformUtils.toSimilarityMatrix(tf, pivot);
+      const result = TransformUtils.fromSimilarityMatrix(m, pivot);
+      expect(result.flip).toBe(tf.flip);
+      expect(result.scale).toBeCloseTo(tf.scale);
+      expect(result.rotation).toBeCloseTo(tf.rotation);
+      expect(result.translation.x).toBeCloseTo(tf.translation.x);
+      expect(result.translation.y).toBeCloseTo(tf.translation.y);
+    });
+
+    it.each([
+      { flip: false, scale: 1, rotation: 0, translation: { x: 0, y: 0 } },
+      {
+        flip: false,
+        scale: 2.5,
+        rotation: 60,
+        translation: { x: -10, y: 20 },
+      },
+      {
+        flip: true,
+        scale: 0.5,
+        rotation: -45,
+        translation: { x: 100, y: 100 },
+      },
+    ])(
+      "roundtrips the origin-pivoted matrix of %j through the transform",
+      (tf) => {
+        const m = TransformUtils.toSimilarityMatrix(tf);
+        const rebuilt = TransformUtils.toSimilarityMatrix(
+          TransformUtils.fromSimilarityMatrix(m, pivot),
+          pivot,
+        );
+        for (let i = 0; i < 9; i++) {
+          expect(rebuilt[i]).toBeCloseTo(m[i]!);
+        }
+      },
+    );
   });
 
   describe("transformBoundingBox", () => {

--- a/packages/@tissuumaps-core/src/utils/TransformUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/TransformUtils.ts
@@ -50,26 +50,45 @@ export class TransformUtils {
   /**
    * Builds a 3×3 similarity matrix from a (partial) {@link SimilarityTransform}
    *
-   * Applies, in order: flip, scale, rotation, and translation.
+   * Applies, in order: flip/scale, rotation, and translation.
+   *
+   * If `pivot` is given, flip and rotation are applied about `pivot` (in the
+   * source coordinates of the transform) instead of the origin, while scale
+   * stays about the origin. The translation is then the position of the
+   * scaled content before it is flipped and rotated about its (scaled)
+   * pivot. This is the inverse of {@link fromSimilarityMatrix} called with
+   * the same pivot.
    *
    * @param tf - The transform components (all optional)
+   * @param pivot - Optional point about which flip and rotation are applied
    * @returns The composed matrix
    */
-  static toSimilarityMatrix(tf: Partial<SimilarityTransform>): mat3 {
+  static toSimilarityMatrix(
+    tf: Partial<SimilarityTransform>,
+    pivot?: { x: number; y: number },
+  ): mat3 {
     // gl-matrix, like OpenGL, uses pre-multiplied matrices,
     // so we need to apply transformations in reverse order.
     const m = mat3.create();
     if (tf.translation !== undefined) {
       mat3.translate(m, m, [tf.translation.x, tf.translation.y]);
     }
+    if (pivot !== undefined) {
+      const scale = tf.scale ?? 1;
+      mat3.translate(m, m, [scale * pivot.x, scale * pivot.y]);
+    }
     if (tf.rotation !== undefined) {
       mat3.rotate(m, m, (Math.PI * tf.rotation) / 180);
     }
-    if (tf.scale !== undefined) {
-      mat3.scale(m, m, [tf.scale, tf.scale]);
-    }
     if (tf.flip) {
       mat3.scale(m, m, [-1, 1]);
+    }
+    if (pivot !== undefined) {
+      const scale = tf.scale ?? 1;
+      mat3.translate(m, m, [-scale * pivot.x, -scale * pivot.y]);
+    }
+    if (tf.scale !== undefined) {
+      mat3.scale(m, m, [tf.scale, tf.scale]);
     }
     return m;
   }

--- a/packages/@tissuumaps-core/src/utils/TransformUtils.ts
+++ b/packages/@tissuumaps-core/src/utils/TransformUtils.ts
@@ -15,46 +15,36 @@ export class TransformUtils {
    * from a column-major `gl-matrix` {@link mat3}. A negative 2D determinant
    * indicates a horizontal reflection.
    *
-   * When `center` is provided the returned translation is adjusted so that
-   * flip and rotation are expressed around that center instead of the origin.
+   * If `pivot` is given, flip and rotation are expressed about `pivot`
+   * (in the input coordinates of `m`) instead of the origin, while scale
+   * stays about the origin. Flip, scale, and rotation are unaffected; only
+   * the translation changes to `m(pivot) - scale * pivot`, i.e. the position
+   * of the scaled content before it is flipped and rotated about its (scaled)
+   * pivot. This matches viewers that place an image by its top-left corner
+   * and then flip/rotate it about its center.
    *
    * @param m - The source matrix
-   * @param options - Optional center in pre-scaled coordinates
+   * @param pivot - Optional point about which flip and rotation are expressed
    * @returns The decomposed transform
    */
   static fromSimilarityMatrix(
     m: mat3,
-    options?: { center?: { x: number; y: number } },
+    pivot?: { x: number; y: number },
   ): SimilarityTransform {
     // gl-matrix, like OpenGL, uses column-major order.
-    // Detect reflection via the sign of the 2D determinant.
     const det = m[0] * m[4] - m[3] * m[1];
     const flip = det < 0;
     const c0 = flip ? -m[0] : m[0];
     const c1 = flip ? -m[1] : m[1];
-    const scale = Math.sqrt(c0 * c0 + c1 * c1);
-    const angle = Math.atan2(c1, c0);
-    let tx = m[6];
-    let ty = m[7];
-    const { center } = options ?? {};
-    if (center !== undefined) {
-      const cx = center.x * scale;
-      const cy = center.y * scale;
-      const cos = Math.cos(angle);
-      const sin = Math.sin(angle);
-      tx -= cy * sin + cx * (1 - cos);
-      ty -= cy * (1 - cos) - cx * sin;
-      if (flip) {
-        tx -= 2 * cx * cos;
-        ty -= 2 * cx * sin;
-      }
+    const scale = Math.hypot(c0, c1);
+    const rotation = (Math.atan2(c1, c0) * 180) / Math.PI; // in (-180, 180]
+    const translation = { x: m[6], y: m[7] };
+    if (pivot !== undefined) {
+      const { x: cx, y: cy } = pivot;
+      translation.x = m[0] * cx + m[3] * cy + m[6] - scale * cx;
+      translation.y = m[1] * cx + m[4] * cy + m[7] - scale * cy;
     }
-    return {
-      flip,
-      scale,
-      rotation: (angle * 180) / Math.PI,
-      translation: { x: tx, y: ty },
-    };
+    return { flip, scale, rotation, translation };
   }
 
   /**

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonRendererBase.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonRendererBase.ts
@@ -461,7 +461,7 @@ export abstract class OpenSeadragonRendererBase<
   }
 
   /**
-   * Applies the transform, flip, visibility, and opacity of an object reference to the rendered object's backdrop and TiledImages
+   * Applies the transform, visibility, and opacity of an object reference to the rendered object's backdrop and TiledImages
    *
    * The opacity is computed per TiledImage via {@link getTiledImageOpacity}, so that
    * subclasses can vary it by channel; all other properties are shared by all

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonUtils.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonUtils.ts
@@ -47,10 +47,11 @@ export class OpenSeadragonUtils {
   /**
    * Computes the effective flip, width, rotation, and position for a tiled image based on its transforms and content size
    *
-   * Composes the data → layer → world similarity matrices (including flip),
-   * then decomposes the result around the image center to match
-   * OpenSeadragon's flip/rotation-around-image-center convention. The
-   * decomposed translation is then the OpenSeadragon position directly.
+   * Composes the data → layer → world similarity matrices (including flip)
+   * and decomposes the result with flip and rotation pivoted at the image
+   * center, matching OpenSeadragon's flip/rotation-around-image-center
+   * convention. The decomposed translation is then the OpenSeadragon
+   * position directly.
    *
    * @param objectTransform - The data → layer transform of the object
    * @param layerTransform - The layer → world transform of the object's layer
@@ -75,7 +76,8 @@ export class OpenSeadragonUtils {
     );
     const { flip, scale, rotation, translation } =
       TransformUtils.fromSimilarityMatrix(m, {
-        center: { x: contentSize.x / 2, y: contentSize.y / 2 },
+        x: contentSize.x / 2,
+        y: contentSize.y / 2,
       });
     return {
       flip,

--- a/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonUtils.ts
+++ b/packages/@tissuumaps-render/src/openseadragon/OpenSeadragonUtils.ts
@@ -68,17 +68,14 @@ export class OpenSeadragonUtils {
     rotation: number;
     position: OpenSeadragon.Point;
   } {
-    const m = mat3.create();
-    mat3.multiply(
-      m,
+    const m = mat3.multiply(
+      mat3.create(),
       TransformUtils.toSimilarityMatrix(layerTransform),
       TransformUtils.toSimilarityMatrix(objectTransform),
     );
+    const pivot = { x: contentSize.x / 2, y: contentSize.y / 2 };
     const { flip, scale, rotation, translation } =
-      TransformUtils.fromSimilarityMatrix(m, {
-        x: contentSize.x / 2,
-        y: contentSize.y / 2,
-      });
+      TransformUtils.fromSimilarityMatrix(m, pivot);
     return {
       flip,
       width: contentSize.x * scale,

--- a/packages/@tissuumaps-render/src/webgl/WebGLUtils.ts
+++ b/packages/@tissuumaps-render/src/webgl/WebGLUtils.ts
@@ -33,9 +33,7 @@ export class WebGLUtils {
       TransformUtils.toSimilarityMatrix(objectTransform);
     const layerToWorldMatrix =
       TransformUtils.toSimilarityMatrix(layerTransform);
-    const dataToWorldMatrix = mat3.create();
-    mat3.multiply(dataToWorldMatrix, layerToWorldMatrix, dataToLayerMatrix);
-    return dataToWorldMatrix;
+    return mat3.multiply(mat3.create(), layerToWorldMatrix, dataToLayerMatrix);
   }
 
   /**
@@ -51,15 +49,13 @@ export class WebGLUtils {
     objectTransform: SimilarityTransform,
     layerTransform: SimilarityTransform,
   ): mat3 {
-    const worldToDataMatrix = mat3.create();
     const worldToLayerMatrix =
       TransformUtils.toSimilarityMatrix(layerTransform);
     mat3.invert(worldToLayerMatrix, worldToLayerMatrix);
     const layerToDataMatrix =
       TransformUtils.toSimilarityMatrix(objectTransform);
     mat3.invert(layerToDataMatrix, layerToDataMatrix);
-    mat3.multiply(worldToDataMatrix, layerToDataMatrix, worldToLayerMatrix);
-    return worldToDataMatrix;
+    return mat3.multiply(mat3.create(), layerToDataMatrix, worldToLayerMatrix);
   }
 
   /**


### PR DESCRIPTION
# References and relevant issues

Follow-up to `fix-transform`. No associated JIRA issue.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- `TransformUtils.fromSimilarityMatrix`: replace `options.center` with a positional `pivot` and compute the pivoted translation as `m(pivot) - scale * pivot` directly from the matrix columns, dropping the atan2 → cos/sin round trip; use `Math.hypot` for the scale.
- `TransformUtils.toSimilarityMatrix`: add a matching optional `pivot` argument so it is the exact inverse of `fromSimilarityMatrix` for the same pivot; flip/scale are now applied together before rotation.
- Extend `TransformUtils` tests with pivot round-trips and OpenSeadragon-convention cases.
- `render`: adopt the new `pivot` argument in `OpenSeadragonUtils`, simplify `mat3.multiply` usage in `WebGLUtils`, fix TSDoc.

# Screenshot of the fix

N/A

# Use of AI

Claude Code was used in development.

# Testing

- `pnpm test` in `@tissuumaps/core` (TransformUtils tests)

# Further comments

None.
