### PR TITLE
Fix/viewport sync draw

### DIFF
--- a/packages/@tissuumaps-render/src/SVGController.ts
+++ b/packages/@tissuumaps-render/src/SVGController.ts
@@ -68,6 +68,9 @@ export class SVGController {
   }
 
   /**
+   * Creates the transform node inside the given container and registers the
+   * shape drawing event handlers
+   *
    * The viewport starts out as the unit square; {@link setViewport} is the only
    * way to change it.
    *

--- a/packages/@tissuumaps-render/src/SVGController.ts
+++ b/packages/@tissuumaps-render/src/SVGController.ts
@@ -68,13 +68,14 @@ export class SVGController {
   }
 
   /**
+   * The viewport starts out as the unit square; {@link setViewport} is the only
+   * way to change it.
+   *
    * @param container - The `<svg>` element to draw on (typically created by {@link createContainer})
-   * @param initialViewport - Initial world-space viewport rectangle
    * @param options - Optional shape drawing event handlers
    */
   constructor(
     container: SVGSVGElement,
-    initialViewport: Rect | null,
     options?: { onShapeComplete?: (shape: MultiPolygon) => void },
   ) {
     this.container = container;
@@ -82,7 +83,7 @@ export class SVGController {
     this.shapeCompleteHandler = options?.onShapeComplete;
     container.replaceChildren(this.transformNode);
     this._containerSize = container.getBoundingClientRect();
-    this._viewport = initialViewport ?? { x: 0, y: 0, width: 1, height: 1 };
+    this._viewport = { x: 0, y: 0, width: 1, height: 1 };
     this._updateTransformNode();
 
     this._registerEventHandlers();

--- a/packages/@tissuumaps-render/src/webgl/WebGLPointsRenderer.ts
+++ b/packages/@tissuumaps-render/src/webgl/WebGLPointsRenderer.ts
@@ -107,7 +107,7 @@ export class WebGLPointsRenderer extends WebGLRendererBase<
    * @param context - The WebGL context to use for rendering
    * @param onInitialized - Called once the marker atlas texture has been loaded
    * @param onError - Called if the marker atlas texture could not be loaded
-   * @param options - Optional abort signal, viewport, and render options
+   * @param options - Optional abort signal and render options
    */
   constructor(
     context: WebGLContext,
@@ -115,11 +115,10 @@ export class WebGLPointsRenderer extends WebGLRendererBase<
     onError: (error: Error) => void,
     options?: {
       signal?: AbortSignal;
-      viewport?: Rect;
       renderOptions?: WebGLPointsRenderOptions;
     },
   ) {
-    super(context, options);
+    super(context);
     const { signal, renderOptions } = options ?? {};
     const { globalPointSizeFactor } = renderOptions ?? {};
     this._globalPointSizeFactor = globalPointSizeFactor ?? 1.0;

--- a/packages/@tissuumaps-render/src/webgl/WebGLRendererBase.ts
+++ b/packages/@tissuumaps-render/src/webgl/WebGLRendererBase.ts
@@ -53,13 +53,14 @@ export abstract class WebGLRendererBase<
   /**
    * Creates a new WebGLRendererBase instance
    *
+   * The viewport starts out as the unit square; {@link setViewport} is the only
+   * way to change it.
+   *
    * @param context - The WebGL context to use for rendering
-   * @param options - Optional initial viewport, defaulting to the unit square
    */
-  constructor(context: WebGLContext, options?: { viewport?: Rect }) {
-    const { viewport } = options ?? {};
+  constructor(context: WebGLContext) {
     this.context = context;
-    this.viewport = viewport ?? { x: 0, y: 0, width: 1, height: 1 };
+    this.viewport = { x: 0, y: 0, width: 1, height: 1 };
   }
 
   /**

--- a/packages/@tissuumaps-render/src/webgl/WebGLShapesRenderer.ts
+++ b/packages/@tissuumaps-render/src/webgl/WebGLShapesRenderer.ts
@@ -76,13 +76,13 @@ export class WebGLShapesRenderer extends WebGLRendererBase<
    * Creates the shader program and retrieves uniform locations
    *
    * @param context - The WebGL context to use for rendering
-   * @param options - Optional viewport and render options
+   * @param options - Optional render options
    */
   constructor(
     context: WebGLContext,
-    options?: { viewport?: Rect; renderOptions?: WebGLShapesRenderOptions },
+    options?: { renderOptions?: WebGLShapesRenderOptions },
   ) {
-    super(context, options);
+    super(context);
     const { renderOptions } = options ?? {};
     const { strokeWidth, numScanlines } = renderOptions ?? {};
     this._strokeWidth = strokeWidth ?? 1.0;

--- a/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
+++ b/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
@@ -18,15 +18,6 @@ export type ViewerProps = {
 export function Viewer({ adapter, children, className }: ViewerProps) {
   const [osContext, setOSContext] = useState<OpenSeadragonContext | null>(null);
 
-  const [viewport, setViewport] = useState<Rect | null>(null);
-  const updateViewport = useCallback((newViewport: Rect) => {
-    setViewport((oldViewport) =>
-      oldViewport !== null && GeometryUtils.rectEquals(oldViewport, newViewport)
-        ? oldViewport
-        : newViewport,
-    );
-  }, []);
-
   const [containerSize, setContainerSize] = useState<{
     width: number;
     height: number;
@@ -45,12 +36,11 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
 
   const { initOS, osRef, osReady, updateOSExternalBounds } =
     useOpenSeadragon(adapter);
-  const { initGL, glPointsBounds, glShapesBounds } = useWebGL(
+  const { initGL, setGLViewport, glPointsBounds, glShapesBounds } = useWebGL(
     adapter,
-    viewport,
     containerSize,
   );
-  const { initSVG } = useSVG(adapter, viewport, containerSize);
+  const { initSVG, setSVGViewport } = useSVG(adapter, containerSize);
 
   useEffect(() => {
     const os = osRef.current;
@@ -58,6 +48,15 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
       return;
     }
     setOSContext(os.context);
+    // Push the viewport straight into the renderers instead of through React
+    // state: a passive useEffect runs after paint, so the overlay would lag
+    // one frame behind the OSD canvas. With the default animationTime of 0,
+    // OSD applies the viewport synchronously, so drawing here lands in the
+    // same paint.
+    const updateViewport = (viewport: Rect) => {
+      setGLViewport(viewport);
+      setSVGViewport(viewport);
+    };
     updateViewport(os.context.getViewport());
     updateContainerSize(os.context.getContainerSize());
     const onViewportChanged = (event: OpenSeadragon.ViewerEvent) => {
@@ -78,11 +77,18 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
       destroySVG();
       os.context.viewer.removeHandler("resize", onContainerResized);
       os.context.viewer.removeHandler("viewport-change", onViewportChanged);
-      setViewport(null);
       setContainerSize(null);
       setOSContext(null);
     };
-  }, [osReady, osRef, initGL, initSVG, updateViewport, updateContainerSize]);
+  }, [
+    osReady,
+    osRef,
+    initGL,
+    initSVG,
+    setGLViewport,
+    setSVGViewport,
+    updateContainerSize,
+  ]);
 
   useEffect(() => {
     const osExternalBounds = [];

--- a/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
+++ b/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
@@ -49,10 +49,11 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
     }
     setOSContext(os.context);
     // Push the viewport straight into the renderers instead of through React
-    // state: a passive useEffect runs after paint, so the overlay would lag
-    // one frame behind the OSD canvas. With the default animationTime of 0,
-    // OSD applies the viewport synchronously, so drawing here lands in the
-    // same paint.
+    // state. OSD raises "viewport-change" from its animation-frame update, after
+    // the springs advanced and before it draws the world, and getBounds(true)
+    // returns the bounds it is about to paint. Drawing here therefore lands in
+    // the same frame, whereas a passive useEffect runs after paint and would
+    // leave the overlay one frame behind the OSD canvas.
     const updateViewport = (viewport: Rect) => {
       setGLViewport(viewport);
       setSVGViewport(viewport);
@@ -81,6 +82,8 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
       setOSContext(null);
     };
   }, [
+    // all callbacks have a stable identity; a new one would tear down and
+    // recreate the whole overlay
     osReady,
     osRef,
     initGL,

--- a/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
+++ b/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
@@ -1,6 +1,6 @@
-import { type ReactNode, useCallback, useEffect, useState } from "react";
+import { type ReactNode, useEffect, useState } from "react";
 
-import { GeometryUtils, type Rect } from "@tissuumaps/core";
+import type { Dims, Rect } from "@tissuumaps/core";
 import type { OpenSeadragonContext } from "@tissuumaps/render";
 
 import type { ViewerAdapter } from "../../adapter";
@@ -18,29 +18,16 @@ export type ViewerProps = {
 export function Viewer({ adapter, children, className }: ViewerProps) {
   const [osContext, setOSContext] = useState<OpenSeadragonContext | null>(null);
 
-  const [containerSize, setContainerSize] = useState<{
-    width: number;
-    height: number;
-  } | null>(null);
-  const updateContainerSize = useCallback(
-    (newContainerSize: { width: number; height: number }) => {
-      setContainerSize((oldContainerSize) =>
-        oldContainerSize !== null &&
-        GeometryUtils.dimsEquals(oldContainerSize, newContainerSize)
-          ? oldContainerSize
-          : newContainerSize,
-      );
-    },
-    [],
-  );
-
   const { initOS, osRef, osReady, updateOSExternalBounds } =
     useOpenSeadragon(adapter);
-  const { initGL, setGLViewport, glPointsBounds, glShapesBounds } = useWebGL(
-    adapter,
-    containerSize,
-  );
-  const { initSVG, setSVGViewport } = useSVG(adapter, containerSize);
+  const {
+    initGL,
+    setGLViewport,
+    setGLContainerSize,
+    glPointsBounds,
+    glShapesBounds,
+  } = useWebGL(adapter);
+  const { initSVG, setSVGViewport, setSVGContainerSize } = useSVG(adapter);
 
   // the setters and init callbacks are memoized; a new identity tears down and
   // recreates the whole overlay
@@ -50,15 +37,20 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
       return;
     }
     setOSContext(os.context);
-    // Push the viewport straight into the renderers instead of through React
-    // state. OSD raises "viewport-change" from its animation-frame update, after
-    // the springs advanced and before it draws the world, and getBounds(true)
-    // returns the bounds it is about to paint. Drawing here therefore lands in
-    // the same frame, whereas a passive useEffect runs after paint and would
-    // leave the overlay one frame behind the OSD canvas.
+    // Push the viewport and container size straight into the renderers instead
+    // of through React state. OSD raises "viewport-change" and "resize" from its
+    // animation-frame update, after the springs advanced and before it draws the
+    // world, and getBounds(true) returns the bounds it is about to paint.
+    // Drawing here therefore lands in the same frame, whereas a passive
+    // useEffect runs after paint and would leave the overlay one frame behind
+    // the OSD canvas.
     const updateViewport = (viewport: Rect) => {
       setGLViewport(viewport);
       setSVGViewport(viewport);
+    };
+    const updateContainerSize = (containerSize: Dims) => {
+      setGLContainerSize(containerSize);
+      setSVGContainerSize(containerSize);
     };
     updateViewport(os.context.getViewport());
     updateContainerSize(os.context.getContainerSize());
@@ -80,7 +72,6 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
       destroySVG();
       os.context.viewer.removeHandler("resize", onContainerResized);
       os.context.viewer.removeHandler("viewport-change", onViewportChanged);
-      setContainerSize(null);
       setOSContext(null);
     };
   }, [
@@ -90,7 +81,8 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
     initSVG,
     setGLViewport,
     setSVGViewport,
-    updateContainerSize,
+    setGLContainerSize,
+    setSVGContainerSize,
   ]);
 
   useEffect(() => {

--- a/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
+++ b/packages/@tissuumaps-viewer/src/components/Viewer/index.tsx
@@ -42,6 +42,8 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
   );
   const { initSVG, setSVGViewport } = useSVG(adapter, containerSize);
 
+  // the setters and init callbacks are memoized; a new identity tears down and
+  // recreates the whole overlay
   useEffect(() => {
     const os = osRef.current;
     if (!osReady || os === null) {
@@ -82,8 +84,6 @@ export function Viewer({ adapter, children, className }: ViewerProps) {
       setOSContext(null);
     };
   }, [
-    // all callbacks have a stable identity; a new one would tear down and
-    // recreate the whole overlay
     osReady,
     osRef,
     initGL,

--- a/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
@@ -18,7 +18,6 @@ export function useSVG(
   const viewportRef = useRef<Rect | null>(null);
   const containerSizeRef = useRef(containerSize);
 
-  // called synchronously from the viewport-change handler in Viewer (see there)
   const setSVGViewport = useCallback((viewport: Rect) => {
     viewportRef.current = viewport;
     if (svgRef.current !== null) {

--- a/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
@@ -18,7 +18,9 @@ export function useSVG(
   const viewportRef = useRef<Rect | null>(null);
   const containerSizeRef = useRef(containerSize);
 
-  // called synchronously from the viewport-change handler in Viewer (see there)
+  // called synchronously from the viewport-change handler in Viewer (see there);
+  // stable identity, as Viewer's effect depends on it and would otherwise
+  // recreate the whole overlay on every render
   const setSVGViewport = useCallback((viewport: Rect) => {
     viewportRef.current = viewport;
     if (svgRef.current !== null) {

--- a/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
@@ -32,9 +32,12 @@ export function useSVG(
       }
       const container = SVGController.createContainer();
       parent.appendChild(container);
-      const controller = new SVGController(container, viewportRef.current, {
+      const controller = new SVGController(container, {
         onShapeComplete: addShape,
       });
+      if (viewportRef.current !== null) {
+        controller.setViewport(viewportRef.current);
+      }
       if (containerSizeRef.current !== null) {
         controller.resizeContainer(containerSizeRef.current);
       }

--- a/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
@@ -7,7 +7,6 @@ import type { ViewerAdapter } from "../adapter";
 
 export function useSVG(
   adapter: ViewerAdapter,
-  viewport: Rect | null,
   containerSize: { width: number; height: number } | null,
 ) {
   const { interactionMode, addShape } = adapter;
@@ -16,8 +15,16 @@ export function useSVG(
   const [svgReady, setSVGReady] = useState(false);
 
   const interactionModeRef = useRef(interactionMode);
-  const viewportRef = useRef(viewport);
+  const viewportRef = useRef<Rect | null>(null);
   const containerSizeRef = useRef(containerSize);
+
+  // called synchronously from the viewport-change handler in Viewer (see there)
+  const setSVGViewport = useCallback((viewport: Rect) => {
+    viewportRef.current = viewport;
+    if (svgRef.current !== null) {
+      svgRef.current.controller.setViewport(viewport);
+    }
+  }, []);
 
   const initSVG = useCallback(
     (parent: HTMLElement | null) => {
@@ -55,18 +62,11 @@ export function useSVG(
   }, [svgReady, interactionMode]);
 
   useEffect(() => {
-    viewportRef.current = viewport;
-    if (svgReady && svgRef.current !== null && viewport !== null) {
-      svgRef.current.controller.setViewport(viewport);
-    }
-  }, [svgReady, viewport]);
-
-  useEffect(() => {
     containerSizeRef.current = containerSize;
     if (svgReady && svgRef.current !== null && containerSize !== null) {
       svgRef.current.controller.resizeContainer(containerSize);
     }
   }, [svgReady, containerSize]);
 
-  return { initSVG, svgRef, svgReady };
+  return { initSVG, setSVGViewport, svgRef, svgReady };
 }

--- a/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
@@ -1,14 +1,11 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import type { Rect } from "@tissuumaps/core";
+import type { Dims, Rect } from "@tissuumaps/core";
 import { SVGController } from "@tissuumaps/render";
 
 import type { ViewerAdapter } from "../adapter";
 
-export function useSVG(
-  adapter: ViewerAdapter,
-  containerSize: { width: number; height: number } | null,
-) {
+export function useSVG(adapter: ViewerAdapter) {
   const { interactionMode, addShape } = adapter;
 
   const svgRef = useRef<{ controller: SVGController } | null>(null);
@@ -16,12 +13,19 @@ export function useSVG(
 
   const interactionModeRef = useRef(interactionMode);
   const viewportRef = useRef<Rect | null>(null);
-  const containerSizeRef = useRef(containerSize);
+  const containerSizeRef = useRef<Dims | null>(null);
 
   const setSVGViewport = useCallback((viewport: Rect) => {
     viewportRef.current = viewport;
     if (svgRef.current !== null) {
       svgRef.current.controller.setViewport(viewport);
+    }
+  }, []);
+
+  const setSVGContainerSize = useCallback((containerSize: Dims) => {
+    containerSizeRef.current = containerSize;
+    if (svgRef.current !== null) {
+      svgRef.current.controller.resizeContainer(containerSize);
     }
   }, []);
 
@@ -63,12 +67,5 @@ export function useSVG(
     }
   }, [svgReady, interactionMode]);
 
-  useEffect(() => {
-    containerSizeRef.current = containerSize;
-    if (svgReady && svgRef.current !== null && containerSize !== null) {
-      svgRef.current.controller.resizeContainer(containerSize);
-    }
-  }, [svgReady, containerSize]);
-
-  return { initSVG, setSVGViewport, svgRef, svgReady };
+  return { initSVG, setSVGViewport, setSVGContainerSize, svgRef, svgReady };
 }

--- a/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useSVG.ts
@@ -18,9 +18,7 @@ export function useSVG(
   const viewportRef = useRef<Rect | null>(null);
   const containerSizeRef = useRef(containerSize);
 
-  // called synchronously from the viewport-change handler in Viewer (see there);
-  // stable identity, as Viewer's effect depends on it and would otherwise
-  // recreate the whole overlay on every render
+  // called synchronously from the viewport-change handler in Viewer (see there)
   const setSVGViewport = useCallback((viewport: Rect) => {
     viewportRef.current = viewport;
     if (svgRef.current !== null) {

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -16,6 +16,14 @@ type GL = {
   shapesRenderer: WebGLShapesRenderer;
 };
 
+/**
+ * Clears the canvas and redraws both WebGL renderers
+ *
+ * Deliberately a module-level function of the GL object rather than a callback
+ * inside the hook: it keeps one identity for the lifetime of the module, so the
+ * memoized setters below cannot capture a stale copy of it and no hook has to
+ * list it as a dependency.
+ */
 function drawGL(gl: GL | null) {
   if (gl !== null) {
     gl.context.clear();

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -68,9 +68,7 @@ export function useWebGL(
     }
   }
 
-  // called synchronously from the viewport-change handler in Viewer (see there);
-  // stable identity, as Viewer's effect depends on it and would otherwise
-  // recreate the whole overlay on every render
+  // called synchronously from the viewport-change handler in Viewer (see there)
   const setGLViewport = useCallback((viewport: Rect) => {
     viewportRef.current = viewport;
     if (glRef.current !== null) {

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -132,7 +132,6 @@ export function useWebGL(
       let shapesRenderer: WebGLShapesRenderer;
       try {
         shapesRenderer = new WebGLShapesRenderer(context, {
-          viewport: viewportRef.current ?? undefined,
           renderOptions: glOptionsRef.current.shapesRenderOptions,
         });
       } catch (error) {
@@ -144,6 +143,7 @@ export function useWebGL(
       // points renderer
       if (viewportRef.current !== null) {
         pointsRenderer.setViewport(viewportRef.current);
+        shapesRenderer.setViewport(viewportRef.current);
       }
       const gl = { canvas, context, pointsRenderer, shapesRenderer };
       glRef.current = gl;

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -105,7 +105,6 @@ export function useWebGL(
           resolvePointsRendererInitPromise,
           rejectPointsRendererInitPromise,
           {
-            viewport: viewportRef.current ?? undefined,
             renderOptions: glOptionsRef.current.pointsRenderOptions,
             signal: abortController.signal,
           },

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -19,10 +19,10 @@ type GL = {
 /**
  * Clears the canvas and redraws both WebGL renderers
  *
- * Deliberately a module-level function of the GL object rather than a callback
- * inside the hook: it keeps one identity for the lifetime of the module, so the
- * memoized setters below cannot capture a stale copy of it and no hook has to
- * list it as a dependency.
+ * Module-level so it closes over nothing from the render scope: the memoized
+ * setters can call it without listing it as a dependency, however it changes.
+ *
+ * @param gl - The GL object to draw on; nothing is drawn if null
  */
 function drawGL(gl: GL | null) {
   if (gl !== null) {
@@ -91,6 +91,11 @@ export function useWebGL(adapter: ViewerAdapter) {
         glRef.current.canvas,
         containerSize,
       );
+      // OSD raises "resize" before it updates the viewport bounds, so this
+      // draws the old viewport and is superseded by the viewport-change draw
+      // later in the same update - except on a resize that leaves the bounds
+      // unchanged, where it is the only draw that refills the resized, and
+      // therefore blank, canvas.
       if (redraw) {
         drawGL(glRef.current);
       }

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -68,7 +68,6 @@ export function useWebGL(
     }
   }
 
-  // called synchronously from the viewport-change handler in Viewer (see there)
   const setGLViewport = useCallback((viewport: Rect) => {
     viewportRef.current = viewport;
     if (glRef.current !== null) {

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -18,7 +18,6 @@ type GL = {
 
 export function useWebGL(
   adapter: ViewerAdapter,
-  viewport: Rect | null,
   containerSize: { width: number; height: number } | null,
 ) {
   const {
@@ -42,7 +41,7 @@ export function useWebGL(
   const [glReady, setGLReady] = useState(false);
 
   const glOptionsRef = useRef(glOptions);
-  const viewportRef = useRef(viewport);
+  const viewportRef = useRef<Rect | null>(null);
   const containerSizeRef = useRef(containerSize);
 
   const [syncPoints, dispatchSyncPoints] = useReducer((x) => x + 1, 0);
@@ -68,6 +67,18 @@ export function useWebGL(
       glRef.current.shapesRenderer.draw();
     }
   }
+
+  // called synchronously from the viewport-change handler in Viewer (see there)
+  const setGLViewport = useCallback((viewport: Rect) => {
+    viewportRef.current = viewport;
+    if (glRef.current !== null) {
+      const redrawPoints = glRef.current.pointsRenderer.setViewport(viewport);
+      const redrawShapes = glRef.current.shapesRenderer.setViewport(viewport);
+      if (redrawPoints || redrawShapes) {
+        draw();
+      }
+    }
+  }, []);
 
   const initGL = useCallback((parentOrNull: HTMLElement | null) => {
     if (parentOrNull === null) {
@@ -122,6 +133,10 @@ export function useWebGL(
         pointsRenderer.destroy();
         context.destroy();
         throw new Error("Error creating shapes renderer", { cause: error });
+      }
+      // a viewport change may have arrived while awaiting the points renderer
+      if (viewportRef.current !== null) {
+        pointsRenderer.setViewport(viewportRef.current);
       }
       const gl = { canvas, context, pointsRenderer, shapesRenderer };
       glRef.current = gl;
@@ -211,17 +226,6 @@ export function useWebGL(
       }
     }
   }, [glReady, glOptions]);
-
-  useEffect(() => {
-    viewportRef.current = viewport;
-    if (glReady && glRef.current !== null && viewport !== null) {
-      const redrawPoints = glRef.current.pointsRenderer.setViewport(viewport);
-      const redrawShapes = glRef.current.shapesRenderer.setViewport(viewport);
-      if (redrawPoints || redrawShapes) {
-        draw();
-      }
-    }
-  }, [glReady, viewport]);
 
   useEffect(() => {
     containerSizeRef.current = containerSize;
@@ -326,5 +330,12 @@ export function useWebGL(
     syncShapes,
   ]);
 
-  return { initGL, glRef, glReady, glPointsBounds, glShapesBounds };
+  return {
+    initGL,
+    setGLViewport,
+    glRef,
+    glReady,
+    glPointsBounds,
+    glShapesBounds,
+  };
 }

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -68,7 +68,9 @@ export function useWebGL(
     }
   }
 
-  // called synchronously from the viewport-change handler in Viewer (see there)
+  // called synchronously from the viewport-change handler in Viewer (see there);
+  // stable identity, as Viewer's effect depends on it and would otherwise
+  // recreate the whole overlay on every render
   const setGLViewport = useCallback((viewport: Rect) => {
     viewportRef.current = viewport;
     if (glRef.current !== null) {

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
-import type { Rect } from "@tissuumaps/core";
+import type { Dims, Rect } from "@tissuumaps/core";
 import {
   WebGLContext,
   WebGLPointsRenderer,
@@ -32,10 +32,7 @@ function drawGL(gl: GL | null) {
   }
 }
 
-export function useWebGL(
-  adapter: ViewerAdapter,
-  containerSize: { width: number; height: number } | null,
-) {
+export function useWebGL(adapter: ViewerAdapter) {
   const {
     layers,
     points,
@@ -58,7 +55,7 @@ export function useWebGL(
 
   const glOptionsRef = useRef(glOptions);
   const viewportRef = useRef<Rect | null>(null);
-  const containerSizeRef = useRef(containerSize);
+  const containerSizeRef = useRef<Dims | null>(null);
 
   const [syncPoints, dispatchSyncPoints] = useReducer((x) => x + 1, 0);
   const [syncShapes, dispatchSyncShapes] = useReducer((x) => x + 1, 0);
@@ -82,6 +79,19 @@ export function useWebGL(
       const redrawPoints = glRef.current.pointsRenderer.setViewport(viewport);
       const redrawShapes = glRef.current.shapesRenderer.setViewport(viewport);
       if (redrawPoints || redrawShapes) {
+        drawGL(glRef.current);
+      }
+    }
+  }, []);
+
+  const setGLContainerSize = useCallback((containerSize: Dims) => {
+    containerSizeRef.current = containerSize;
+    if (glRef.current !== null) {
+      const redraw = glRef.current.context.resizeCanvas(
+        glRef.current.canvas,
+        containerSize,
+      );
+      if (redraw) {
         drawGL(glRef.current);
       }
     }
@@ -235,19 +245,6 @@ export function useWebGL(
   }, [glReady, glOptions]);
 
   useEffect(() => {
-    containerSizeRef.current = containerSize;
-    if (glReady && glRef.current !== null && containerSize !== null) {
-      const redraw = glRef.current.context.resizeCanvas(
-        glRef.current.canvas,
-        containerSize,
-      );
-      if (redraw) {
-        drawGL(glRef.current);
-      }
-    }
-  }, [glReady, containerSize]);
-
-  useEffect(() => {
     const abortController = new AbortController();
     if (glReady && glRef.current !== null) {
       glRef.current.pointsRenderer
@@ -340,6 +337,7 @@ export function useWebGL(
   return {
     initGL,
     setGLViewport,
+    setGLContainerSize,
     glRef,
     glReady,
     glPointsBounds,

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -16,6 +16,14 @@ type GL = {
   shapesRenderer: WebGLShapesRenderer;
 };
 
+function draw(gl: GL | null) {
+  if (gl !== null) {
+    gl.context.clear();
+    gl.pointsRenderer.draw();
+    gl.shapesRenderer.draw();
+  }
+}
+
 export function useWebGL(
   adapter: ViewerAdapter,
   containerSize: { width: number; height: number } | null,
@@ -60,21 +68,13 @@ export function useWebGL(
     return canvas;
   }
 
-  function draw() {
-    if (glRef.current !== null) {
-      glRef.current.context.clear();
-      glRef.current.pointsRenderer.draw();
-      glRef.current.shapesRenderer.draw();
-    }
-  }
-
   const setGLViewport = useCallback((viewport: Rect) => {
     viewportRef.current = viewport;
     if (glRef.current !== null) {
       const redrawPoints = glRef.current.pointsRenderer.setViewport(viewport);
       const redrawShapes = glRef.current.shapesRenderer.setViewport(viewport);
       if (redrawPoints || redrawShapes) {
-        draw();
+        draw(glRef.current);
       }
     }
   }, []);
@@ -140,7 +140,7 @@ export function useWebGL(
       const gl = { canvas, context, pointsRenderer, shapesRenderer };
       glRef.current = gl;
       setGLReady(true);
-      draw();
+      draw(gl);
       return gl;
     }
 
@@ -215,7 +215,7 @@ export function useWebGL(
           glOptions.shapesRenderOptions,
         );
       if (redrawPoints || redrawShapes) {
-        draw();
+        draw(glRef.current);
       }
       if (resyncPoints) {
         dispatchSyncPoints();
@@ -234,7 +234,7 @@ export function useWebGL(
         containerSize,
       );
       if (redraw) {
-        draw();
+        draw(glRef.current);
       }
     }
   }, [glReady, containerSize]);
@@ -259,7 +259,7 @@ export function useWebGL(
         .then((renderedBounds) => {
           if (!abortController.signal.aborted) {
             setGLPointsBounds(renderedBounds ?? null);
-            draw();
+            draw(glRef.current);
           }
         })
         .catch((error) => {
@@ -304,7 +304,7 @@ export function useWebGL(
         .then((renderedBounds) => {
           if (!abortController.signal.aborted) {
             setGLShapesBounds(renderedBounds ?? null);
-            draw();
+            draw(glRef.current);
           }
         })
         .catch((error) => {

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -16,7 +16,7 @@ type GL = {
   shapesRenderer: WebGLShapesRenderer;
 };
 
-function draw(gl: GL | null) {
+function drawGL(gl: GL | null) {
   if (gl !== null) {
     gl.context.clear();
     gl.pointsRenderer.draw();
@@ -74,7 +74,7 @@ export function useWebGL(
       const redrawPoints = glRef.current.pointsRenderer.setViewport(viewport);
       const redrawShapes = glRef.current.shapesRenderer.setViewport(viewport);
       if (redrawPoints || redrawShapes) {
-        draw(glRef.current);
+        drawGL(glRef.current);
       }
     }
   }, []);
@@ -140,7 +140,7 @@ export function useWebGL(
       const gl = { canvas, context, pointsRenderer, shapesRenderer };
       glRef.current = gl;
       setGLReady(true);
-      draw(gl);
+      drawGL(gl);
       return gl;
     }
 
@@ -215,7 +215,7 @@ export function useWebGL(
           glOptions.shapesRenderOptions,
         );
       if (redrawPoints || redrawShapes) {
-        draw(glRef.current);
+        drawGL(glRef.current);
       }
       if (resyncPoints) {
         dispatchSyncPoints();
@@ -234,7 +234,7 @@ export function useWebGL(
         containerSize,
       );
       if (redraw) {
-        draw(glRef.current);
+        drawGL(glRef.current);
       }
     }
   }, [glReady, containerSize]);
@@ -259,7 +259,7 @@ export function useWebGL(
         .then((renderedBounds) => {
           if (!abortController.signal.aborted) {
             setGLPointsBounds(renderedBounds ?? null);
-            draw(glRef.current);
+            drawGL(glRef.current);
           }
         })
         .catch((error) => {
@@ -304,7 +304,7 @@ export function useWebGL(
         .then((renderedBounds) => {
           if (!abortController.signal.aborted) {
             setGLShapesBounds(renderedBounds ?? null);
-            draw(glRef.current);
+            drawGL(glRef.current);
           }
         })
         .catch((error) => {

--- a/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
+++ b/packages/@tissuumaps-viewer/src/hooks/useWebGL.ts
@@ -132,7 +132,8 @@ export function useWebGL(
         context.destroy();
         throw new Error("Error creating shapes renderer", { cause: error });
       }
-      // a viewport change may have arrived while awaiting the points renderer
+      // set only now, as the viewport may have changed while awaiting the
+      // points renderer
       if (viewportRef.current !== null) {
         pointsRenderer.setViewport(viewportRef.current);
       }


### PR DESCRIPTION
# References and relevant issues

Reintroduced by #162 (`refactor(render)!: extract rendering into a dedicated @tissuumaps/render package`), which rewrote the `viewport-change` handler to store the viewport in React state. Same class of bug as the overlay lag fixed once before.

<!-- Closes #(issue-number) if there is one -->

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

The WebGL (points, shapes) and SVG overlays lagged one frame behind the OpenSeadragon canvas on pan/zoom. The `viewport-change` handler in `Viewer` wrote the viewport into React state; `useWebGL` and `useSVG` picked it up from a passive `useEffect`, which runs after the browser has painted. OSD raises `viewport-change` from its animation-frame update, after the springs advanced and before it draws the world, so a draw issued directly from the handler lands in the same frame.

- `Viewer`: remove the `viewport` state and `updateViewport`; the `viewport-change` handler (and the initial `getViewport()`) call two imperative setters instead. Pan/zoom no longer triggers any React re-render.
- `useWebGL`: drop the `viewport` parameter and its effect; add a stable `setGLViewport` that sets the viewport on both renderers and redraws synchronously if it changed. A viewport arriving during the async points-renderer init is re-applied before the first draw.
- `useSVG`: same treatment with `setSVGViewport`.
- The `rectEquals` dedup removed from `Viewer` is already done inside `WebGLRendererBase.setViewport` and `SVGController.setViewport`.
- Comments explain the mechanism and why the callbacks are memoized (review rounds).

# Screenshot of the fix

Not meaningful as a still image; the lag is only visible while dragging.

# Use of AI

Yes, help of Claude Code (Fable 5.1).

# Testing

- Instructions on how to test: `pnpm run dev`, open a project with points and/or shapes over an image, pan and zoom by dragging and wheel. Before: markers and shapes visibly trail the image by a frame and snap back when the movement stops. After: they move rigidly with the image. Draw a selection with the SVG tools while panning to check the SVG layer too.
- `tsc`, `eslint` and `prettier` pass on the touched packages.

# Further comments

The fix has been re-introduced once already. If the hooks ever grow a viewport parameter again, that is the regression.
