### PR TITLE
fix(widgets): render read-only data source fields through cells so tables show their name

### DIFF
--- a/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/BooleanCell.tsx
+++ b/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/BooleanCell.tsx
@@ -4,6 +4,9 @@ import { withJsonFormsCellProps } from "@jsonforms/react";
 import { Switch } from "@/components/ui/switch";
 
 export const BooleanCell = withJsonFormsCellProps((props: CellProps) => {
+  if (!props.enabled) {
+    return props.data ? "Yes" : "No";
+  }
   const options = {
     ...(props.config as { [key: string]: unknown }),
     ...props.uischema.options,
@@ -13,7 +16,6 @@ export const BooleanCell = withJsonFormsCellProps((props: CellProps) => {
       id={props.id}
       checked={!!props.data}
       onCheckedChange={(checked) => props.handleChange(props.path, checked)}
-      disabled={!props.enabled}
       autoFocus={options.focus as boolean | undefined}
     />
   );

--- a/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/IntegerCell.tsx
+++ b/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/IntegerCell.tsx
@@ -4,6 +4,10 @@ import { withJsonFormsCellProps } from "@jsonforms/react";
 import { Input } from "@/components/ui/input";
 
 export const IntegerCell = withJsonFormsCellProps((props: CellProps) => {
+  const value = (props.data as string | number | undefined | null) ?? "";
+  if (!props.enabled) {
+    return value;
+  }
   const options = {
     ...(props.config as { [key: string]: unknown }),
     ...props.uischema.options,
@@ -13,14 +17,13 @@ export const IntegerCell = withJsonFormsCellProps((props: CellProps) => {
       type="number"
       step="1"
       id={props.id}
-      value={(props.data as string | number | undefined | null) ?? ""}
+      value={value}
       onChange={(event) =>
         props.handleChange(
           props.path,
           event.target.value !== "" ? parseInt(event.target.value) : undefined,
         )
       }
-      disabled={!props.enabled}
       autoFocus={options.focus as boolean | undefined}
     />
   );

--- a/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/NumberCell.tsx
+++ b/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/NumberCell.tsx
@@ -4,6 +4,10 @@ import { withJsonFormsCellProps } from "@jsonforms/react";
 import { Input } from "@/components/ui/input";
 
 export const NumberCell = withJsonFormsCellProps((props: CellProps) => {
+  const value = (props.data as string | number | undefined | null) ?? "";
+  if (!props.enabled) {
+    return value;
+  }
   const options = {
     ...(props.config as { [key: string]: unknown }),
     ...props.uischema.options,
@@ -14,7 +18,7 @@ export const NumberCell = withJsonFormsCellProps((props: CellProps) => {
       inputMode="decimal"
       step="0.1"
       id={props.id}
-      value={(props.data as string | number | undefined | null) ?? ""}
+      value={value}
       onChange={(event) =>
         props.handleChange(
           props.path,
@@ -23,7 +27,6 @@ export const NumberCell = withJsonFormsCellProps((props: CellProps) => {
             : undefined,
         )
       }
-      disabled={!props.enabled}
       autoFocus={options.focus as boolean | undefined}
     />
   );

--- a/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/StringEnumCell.tsx
+++ b/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/StringEnumCell.tsx
@@ -5,15 +5,19 @@ import { SimpleSelect } from "@/components/common/simple-select";
 
 export const StringEnumCell = withJsonFormsEnumCellProps(
   (props: EnumCellProps) => {
+    const value = props.data as string;
+    if (!props.enabled) {
+      const option = props.options?.find((option) => option.value === value);
+      return option?.label ?? value;
+    }
     return (
       <SimpleSelect
         id={props.id}
-        value={props.data as string}
-        onValueChange={(value) => props.handleChange(props.path, value)}
+        value={value}
+        onValueChange={(newValue) => props.handleChange(props.path, newValue)}
         items={props.options || []}
         itemLabel={(option) => option.label}
         itemValue={(option) => option.value as string}
-        disabled={!props.enabled}
       />
     );
   },

--- a/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/TableEnumCell.tsx
+++ b/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/TableEnumCell.tsx
@@ -6,15 +6,19 @@ import { useProjectStore } from "@/stores/project";
 
 export const TableEnumCell = withJsonFormsCellProps((props: CellProps) => {
   const tables = useProjectStore((state) => state.tables);
+  const tableId = props.data as string;
+  if (!props.enabled) {
+    const table = tables.find((table) => table.id === tableId);
+    return table?.name ?? tableId;
+  }
   return (
     <SimpleSelect
       id={props.id}
-      value={props.data as string}
+      value={tableId}
       onValueChange={(value) => props.handleChange(props.path, value)}
       items={tables}
       itemLabel={(item) => item.name}
       itemValue={(item) => item.id}
-      disabled={!props.enabled}
     />
   );
 });

--- a/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/TextCell.tsx
+++ b/apps/tissuumaps/src/components/widgets/DataSourceWidget/cells/TextCell.tsx
@@ -4,6 +4,10 @@ import { withJsonFormsCellProps } from "@jsonforms/react";
 import { Input } from "@/components/ui/input";
 
 export const TextCell = withJsonFormsCellProps((props: CellProps) => {
+  const value = (props.data as string | undefined | null) ?? "";
+  if (!props.enabled) {
+    return value;
+  }
   const options = {
     ...(props.config as { [key: string]: unknown }),
     ...props.uischema.options,
@@ -12,14 +16,13 @@ export const TextCell = withJsonFormsCellProps((props: CellProps) => {
     <Input
       type="text"
       id={props.id}
-      value={(props.data as string | undefined | null) ?? ""}
+      value={value}
       onChange={(event) =>
         props.handleChange(
           props.path,
           event.target.value !== "" ? event.target.value : undefined,
         )
       }
-      disabled={!props.enabled}
       autoFocus={options.focus as boolean | undefined}
       placeholder={options.placeholder as string | undefined}
       maxLength={props.schema.maxLength}

--- a/apps/tissuumaps/src/components/widgets/DataSourceWidget/controls/InputControl.tsx
+++ b/apps/tissuumaps/src/components/widgets/DataSourceWidget/controls/InputControl.tsx
@@ -14,19 +14,26 @@ import {
 } from "@/components/common/field";
 
 export const InputControl = withJsonFormsControlProps((props: ControlProps) => {
+  const [isFocused, setFocused] = useState<boolean>(false);
+
   // readonly mode
-  if (props.enabled === false) {
+  if (!props.enabled) {
     return (
       <Field className="contents">
         <FieldLabel>
           {computeLabel(props.label, props.required ?? false, true)}:
         </FieldLabel>
-        <span className="truncate">{props.data ?? ""}</span>
+        <span className="truncate">
+          <DispatchCell
+            uischema={props.uischema}
+            schema={props.schema}
+            path={props.path}
+            enabled={props.enabled}
+          />
+        </span>
       </Field>
     );
   }
-
-  const [isFocused, setFocused] = useState<boolean>(false);
 
   const options = {
     ...(props.config as { [key: string]: unknown }),

--- a/apps/tissuumaps/src/components/widgets/DataSourceWidget/layouts/VerticalLayout.tsx
+++ b/apps/tissuumaps/src/components/widgets/DataSourceWidget/layouts/VerticalLayout.tsx
@@ -15,7 +15,7 @@ const MemoizedVerticalLayout = memo((props: Omit<LayoutProps, "data">) => {
   const { renderers, cells } = useJsonForms();
 
   // readonly mode
-  if (props.enabled === false) {
+  if (!props.enabled) {
     return (
       <div
         hidden={!props.visible}


### PR DESCRIPTION
# References and relevant issues

No linked issue. Fixes the read-only preview in the data source widget, which showed the table ID instead of the table name.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- In read-only mode, `DataSourceWidget` showed the raw table ID for the `table` field of points and shapes data sources. It now shows the table name.
- `InputControl` no longer renders the read-only value itself. It dispatches to the same cell as in edit mode, wrapped in the truncating span of the read-only grid, so the control stays agnostic of field types.
- Each cell returns plain text when disabled: `TableEnumCell` resolves the ID to the table name (falling back to the ID if the table no longer exists), `StringEnumCell` shows the option label, `BooleanCell` shows "Yes"/"No" (previously rendered nothing, since React renders booleans as empty), and `TextCell`, `IntegerCell`, `NumberCell` show the value.
- The `disabled` props on the cell inputs were dropped, since the disabled state never reaches the inputs anymore.
- All read-only checks in the widget now use `!props.enabled`, matching `ArrayControl`. `VerticalLayout` previously used `=== false`.

# Screenshot of the fix

<!-- Attach: read-only data source widget for a points layer, showing "Table: <name>" instead of the ID. -->

# Use of AI

Claude Code was used to review the initial implementation.

# Testing

- Instructions on how to test:
  1. Load a project with a table and a points (or shapes) layer whose data source references it.
  2. Open the layer panel and look at the data source widget in read-only mode. The "Table" row shows the table name.
  3. Click the edit button. The table select still lists tables by name and saves the ID.
  4. Rename the table in the tables panel. The read-only widget updates to the new name.
  5. Delete the table. The read-only widget falls back to showing the ID.
- `tsc -b tsconfig.src.json`, eslint and prettier pass on the changed files.

# Further comments

No provider schema currently uses enum or boolean fields, so the `StringEnumCell` and `BooleanCell` read-only branches are not reachable from the UI yet. They were added so the read-only path is complete for every registered cell.

The widget treats `enabled=false` as "render as text" at every level (layout, control, cell). JsonForms also sets `enabled=false` for `DISABLE` rules and `readOnly` schema properties, so such a field inside an editable form would render as text rather than a greyed-out input. No provider schema uses those features. Separating read-only from disabled (via JsonForms' `separateReadonlyFromDisabled` config and `props.readonly`) is left for a follow-up.
