### PR TITLE
feat: let plugins contribute a user interface panel

### DIFF
--- a/apps/docs/docs/development/plugins.md
+++ b/apps/docs/docs/development/plugins.md
@@ -57,16 +57,20 @@ A plugin is unregistered again — tearing it down — using
 - `id` (required): a unique identifier for the plugin. Registering a plugin whose
   `id` is already in use unregisters the previous plugin first.
 - `name` (required): a human-readable name for the plugin.
-- `setup` (required): called once, immediately upon registration, with a reference
+- `setup` (optional): called once, immediately upon registration, with a reference
   to each of the application's Zustand stores (see below). Errors thrown by
   `setup` are caught and logged; they do not abort application startup. The
   plugin is then not registered, and its `teardown` is _not_ called - a
   `teardown` never has to cope with a half-initialized plugin. A `setup` that can
   fail part-way through is responsible for releasing what it had already set up
-  before it rethrows.
+  before it rethrows. A plugin that only adds a user interface does not need a
+  `setup`, because its panel's `mount` receives the same stores.
+- `panel` (optional): mounts a user interface panel shown for as long as the
+  plugin is registered, see [User interface plugins](#user-interface-plugins).
 - `teardown` (optional): called when the plugin is unregistered, and when the
-  application shuts down. Only ever called for a plugin whose `setup` returned
-  successfully. Errors thrown by `teardown` are caught and logged.
+  application shuts down. Only ever called for a plugin that was registered
+  successfully, i.e. one whose `setup` did not throw. Errors thrown by `teardown`
+  are caught and logged. It is called _before_ the plugin's `panel` is unmounted.
 
 ## Stores
 
@@ -107,8 +111,88 @@ data loading by changing the project instead, for example
 
 ## User interface plugins
 
-TODO
+A plugin adds a panel to the TissUUmaps user interface by declaring a `panel`.
+The panel appears as a tab titled with the plugin's `name`, next to the built-in
+Project, Images, Labels, Points, Shapes and Tables panels:
 
-## Data provider plugins
+```javascript
+window.tissuumaps.registerPlugin({
+  id: "my-plugin",
+  name: "My plugin",
+  panel: (container, { projectStore }) => {
+    const paragraph = document.createElement("p");
+    const update = (state) => {
+      paragraph.textContent = `${state.images.length} images`;
+    };
+    update(projectStore.getState());
+    container.append(paragraph);
+    return projectStore.subscribe(update);
+  },
+});
+```
 
-TODO
+Because `panel` receives the stores itself, a plugin that only adds a user
+interface needs neither `setup` nor `teardown`.
+
+`panel` is called with an empty `HTMLElement` owned by the panel, into which the
+plugin renders its user interface, and with the same four stores that `setup`
+would receive. It may return a callback that unmounts that user interface again.
+TissUUmaps empties the container after the callback has run, so the callback only
+has to release what is not plain DOM, such as store subscriptions, listeners on
+`window`, or a React root.
+
+### Panel lifetime
+
+The panel is shown for exactly as long as the plugin is registered:
+
+- `panel` is called once the plugin's `setup` has returned successfully, if there
+  is one, so anything `setup` prepares is available to it.
+- The panel stays mounted while other tabs of its group are active — switching
+  tabs does not remount it.
+- Unregistering the plugin calls `teardown` and then the callback returned by
+  `panel`. Because `teardown` runs first, cleaning up the user interface belongs
+  in the unmount callback rather than in `teardown`.
+
+:::caution
+
+Closing the panel unregisters the plugin. There is no user interface for adding a
+plugin back, so a closed plugin has to be registered again — by reloading the
+page, or by calling `registerPlugin` again.
+
+:::
+
+In development, React's [Strict Mode](https://react.dev/reference/react/StrictMode)
+deliberately mounts every component twice, so `panel` is called, unmounted and
+called again. This is not a bug: it checks that the unmount callback really
+undoes everything `panel` did.
+
+### Bringing your own framework
+
+`panel` is a plain DOM contract, so a plugin can use whichever framework it
+likes — or none at all. With React, for example:
+
+```javascript
+panel: (container, stores) => {
+  const element = document.createElement("div");
+  container.append(element);
+  const root = ReactDOM.createRoot(element);
+  root.render(React.createElement(MyPanel, { stores }));
+  return () => queueMicrotask(() => root.unmount());
+};
+```
+
+Note the two details: the root is created on an element of the plugin's own
+rather than on `container` itself, and it is unmounted in a microtask.
+TissUUmaps unmounts panels from within its own rendering, where unmounting a
+React root synchronously makes React warn; deferring it avoids that, and by then
+TissUUmaps has emptied `container` — which detaches the plugin's element with the
+React root's content intact inside it, rather than pulling that content out from
+under React.
+
+:::caution
+
+The registry keeps the plugin object in an Immer store, which deep-freezes it.
+Keep mutable plugin state in closures rather than in properties of the plugin
+object.
+
+:::

--- a/apps/docs/docs/development/plugins.md
+++ b/apps/docs/docs/development/plugins.md
@@ -11,8 +11,9 @@ Once the application has started up, TissUUmaps exposes its plugin registry as
 window.tissuumaps.registerPlugin({
   id: "my-plugin",
   name: "My plugin",
-  setup: ({ appStore, dataStore, projectStore, settingsStore }) => {},
-  teardown: () => {},
+  setup: ({ appStore, dataStore, projectStore, settingsStore }) => {
+    return () => {}; // teardown
+  },
 });
 ```
 
@@ -31,8 +32,9 @@ function registerMyPlugin() {
   window.tissuumaps.registerPlugin({
     id: "my-plugin",
     name: "My plugin",
-    setup: ({ appStore, dataStore, projectStore, settingsStore }) => {},
-    teardown: () => {},
+    setup: ({ appStore, dataStore, projectStore, settingsStore }) => {
+      return () => {}; // teardown
+    },
   });
 }
 
@@ -49,7 +51,7 @@ Note that the project is not yet loaded when `tissuumaps-loaded` fires — loadi
 is only started during startup. A plugin that depends on project contents should
 subscribe to `projectStore` in `setup` instead of reading it once.
 
-A plugin is unregistered again — tearing it down — using
+A plugin is unregistered again — unmounting and tearing it down — using
 `window.tissuumaps.unregisterPlugin(pluginId)`.
 
 ## Plugin properties
@@ -58,23 +60,40 @@ A plugin is unregistered again — tearing it down — using
   `id` is already in use unregisters the previous plugin first.
 - `name` (required): a human-readable name for the plugin.
 - `setup` (optional): called once, immediately upon registration, with a reference
-  to each of the application's Zustand stores (see below). Errors thrown by
+  to each of the application's Zustand stores (see below). It may return a
+  teardown callback, see [Plugin lifecycle](#plugin-lifecycle). Errors thrown by
   `setup` are caught and logged; they do not abort application startup. The
-  plugin is then not registered, and its `teardown` is _not_ called - a
-  `teardown` never has to cope with a half-initialized plugin. A `setup` that can
-  fail part-way through is responsible for releasing what it had already set up
-  before it rethrows. A plugin that only adds a user interface does not need a
-  `setup`, because its panel's `mount` receives the same stores.
-- `panel` (optional): mounts a user interface panel shown for as long as the
-  plugin is registered, see [User interface plugins](#user-interface-plugins).
-- `teardown` (optional): called when the plugin is unregistered, and when the
-  application shuts down. Only ever called for a plugin that was registered
-  successfully, i.e. one whose `setup` did not throw. Errors thrown by `teardown`
-  are caught and logged. It is called _before_ the plugin's `panel` is unmounted.
+  plugin is then not registered, and no teardown happens - a teardown never has
+  to cope with a half-initialized plugin. A `setup` that can fail part-way
+  through is responsible for releasing what it had already set up before it
+  rethrows. A plugin that only adds a user interface does not need a `setup`,
+  because its `mount` receives the same stores.
+- `mount` (optional): mounts a user interface panel shown for as long as the
+  plugin is registered, and may return an unmount callback, see
+  [User interface plugins](#user-interface-plugins).
+
+## Plugin lifecycle
+
+A plugin goes through four steps, all of them optional:
+
+1. `setup` is called when the plugin is registered.
+2. `mount` is called once `setup` has returned successfully, so anything `setup`
+   prepares is available to it.
+3. The unmount callback returned by `mount` is called when the plugin is
+   unregistered.
+4. The teardown callback returned by `setup` is called last, once the user
+   interface has been unmounted.
+
+Unregistering happens through `window.tissuumaps.unregisterPlugin(pluginId)`, by
+closing the plugin's panel, by registering another plugin with the same `id`, and
+when the application shuts down. The unmount and teardown callbacks are only ever
+called for a plugin that was registered successfully; errors they throw are
+caught and logged. If `mount` throws, the plugin is not registered either, but
+since `setup` did succeed, its teardown callback _is_ called.
 
 ## Stores
 
-The `setup` function receives the application's four Zustand stores:
+`setup` and `mount` receive the application's four Zustand stores:
 
 | Store           | Contents                                                                     |
 | --------------- | ---------------------------------------------------------------------------- |
@@ -111,7 +130,7 @@ data loading by changing the project instead, for example
 
 ## User interface plugins
 
-A plugin adds a panel to the TissUUmaps user interface by declaring a `panel`.
+A plugin adds a panel to the TissUUmaps user interface by declaring a `mount`.
 The panel appears as a tab titled with the plugin's `name`, next to the built-in
 Project, Images, Labels, Points, Shapes and Tables panels:
 
@@ -119,39 +138,42 @@ Project, Images, Labels, Points, Shapes and Tables panels:
 window.tissuumaps.registerPlugin({
   id: "my-plugin",
   name: "My plugin",
-  panel: (container, { projectStore }) => {
+  mount: (container, { projectStore }) => {
     const paragraph = document.createElement("p");
     const update = (state) => {
       paragraph.textContent = `${state.images.length} images`;
     };
     update(projectStore.getState());
     container.append(paragraph);
-    return projectStore.subscribe(update);
+    return projectStore.subscribe(update); // unmount
   },
 });
 ```
 
-Because `panel` receives the stores itself, a plugin that only adds a user
-interface needs neither `setup` nor `teardown`.
+Because `mount` receives the stores itself, a plugin that only adds a user
+interface does not need a `setup`.
 
-`panel` is called with an empty `HTMLElement` owned by the panel, into which the
+`mount` is called with an empty `HTMLElement` owned by TissUUmaps, into which the
 plugin renders its user interface, and with the same four stores that `setup`
-would receive. It may return a callback that unmounts that user interface again.
-TissUUmaps empties the container after the callback has run, so the callback only
-has to release what is not plain DOM, such as store subscriptions, listeners on
-`window`, or a React root.
+receives. It may return a callback that unmounts that user interface again.
+The container is discarded together with the plugin, so the callback only has to
+release what is not plain DOM, such as store subscriptions, listeners on `window`,
+or a React root.
 
 ### Panel lifetime
 
 The panel is shown for exactly as long as the plugin is registered:
 
-- `panel` is called once the plugin's `setup` has returned successfully, if there
-  is one, so anything `setup` prepares is available to it.
-- The panel stays mounted while other tabs of its group are active — switching
-  tabs does not remount it.
-- Unregistering the plugin calls `teardown` and then the callback returned by
-  `panel`. Because `teardown` runs first, cleaning up the user interface belongs
-  in the unmount callback rather than in `teardown`.
+- `mount` is called immediately upon registration, right after `setup`. The
+  container is not part of the document at that point: TissUUmaps attaches it to
+  the panel once the panel is shown. Measure the container's size with a
+  `ResizeObserver` rather than once in `mount`.
+- The user interface stays mounted while other tabs of its group are active, and
+  when the panel is dragged elsewhere — neither remounts it.
+- Unregistering the plugin calls the callback returned by `mount` first and the
+  callback returned by `setup` afterwards, so an unmount callback may still rely
+  on whatever `setup` set up. The container is discarded afterwards; registering
+  the plugin again gives it a fresh one.
 
 :::caution
 
@@ -161,38 +183,23 @@ page, or by calling `registerPlugin` again.
 
 :::
 
-In development, React's [Strict Mode](https://react.dev/reference/react/StrictMode)
-deliberately mounts every component twice, so `panel` is called, unmounted and
-called again. This is not a bug: it checks that the unmount callback really
-undoes everything `panel` did.
-
 ### Bringing your own framework
 
-`panel` is a plain DOM contract, so a plugin can use whichever framework it
+`mount` is a plain DOM contract, so a plugin can use whichever framework it
 likes — or none at all. With React, for example:
 
 ```javascript
-panel: (container, stores) => {
-  const element = document.createElement("div");
-  container.append(element);
-  const root = ReactDOM.createRoot(element);
+mount: (container, stores) => {
+  const root = ReactDOM.createRoot(container);
   root.render(React.createElement(MyPanel, { stores }));
-  return () => queueMicrotask(() => root.unmount());
+  return () => root.unmount();
 };
 ```
 
-Note the two details: the root is created on an element of the plugin's own
-rather than on `container` itself, and it is unmounted in a microtask.
-TissUUmaps unmounts panels from within its own rendering, where unmounting a
-React root synchronously makes React warn; deferring it avoids that, and by then
-TissUUmaps has emptied `container` — which detaches the plugin's element with the
-React root's content intact inside it, rather than pulling that content out from
-under React.
-
 :::caution
 
-The registry keeps the plugin object in an Immer store, which deep-freezes it.
-Keep mutable plugin state in closures rather than in properties of the plugin
-object.
+The registry keeps a copy of the plugin object in an Immer store, which
+deep-freezes it together with any objects the plugin object references. Keep
+mutable plugin state in closures rather than in properties of the plugin object.
 
 :::

--- a/apps/docs/docs/development/plugins.md
+++ b/apps/docs/docs/development/plugins.md
@@ -195,11 +195,3 @@ mount: (container, stores) => {
   return () => root.unmount();
 };
 ```
-
-:::caution
-
-The registry keeps a copy of the plugin object in an Immer store, which
-deep-freezes it together with any objects the plugin object references. Keep
-mutable plugin state in closures rather than in properties of the plugin object.
-
-:::

--- a/apps/tissuumaps/src/App.tsx
+++ b/apps/tissuumaps/src/App.tsx
@@ -1,23 +1,29 @@
 import {
+  type DockviewApi,
   DockviewDefaultTab,
   DockviewReact,
   type DockviewReadyEvent,
   type DockviewTheme,
   type IDockviewPanelHeaderProps,
+  type IDockviewPanelProps,
 } from "dockview-react";
 import { Moon, Sun } from "lucide-react";
+import { useState } from "react";
 
 import { Button } from "@/components/ui/button";
+import { usePluginPanels } from "@/hooks/usePluginPanels";
 
 import "./App.css";
 import { DialogProvider } from "./components/dialogs/DialogProvider";
 import { ImagesPanel } from "./components/panels/ImagesPanel";
 import { LabelsPanel } from "./components/panels/LabelsPanel";
+import { PluginPanel } from "./components/panels/PluginPanel";
 import { PointsPanel } from "./components/panels/PointsPanel";
 import { ProjectPanel } from "./components/panels/ProjectPanel";
 import { ShapesPanel } from "./components/panels/ShapesPanel";
 import { TablesPanel } from "./components/panels/TablesPanel";
 import { ViewerPanel } from "./components/panels/ViewerPanel";
+import { appStore } from "./stores/app";
 import { useSettingsStore } from "./stores/settings";
 
 /** The Tailwind CSS-styled dockview theme defined in `dockview.css` */
@@ -25,6 +31,12 @@ const dockviewTheme: DockviewTheme = {
   name: "tailwindcss",
   className: "dockview-theme-tailwindcss",
 };
+
+/**
+ * The ID of the project panel, into whose group the panels contributed by
+ * plugins are added
+ */
+const projectPanelId = "projectPanel";
 
 /** The panels that can be shown in the dockview layout, by component name */
 const dockviewComponents = {
@@ -35,11 +47,15 @@ const dockviewComponents = {
   PointsPanel: () => <PointsPanel className="m-2" />,
   ShapesPanel: () => <ShapesPanel className="m-2" />,
   TablesPanel: () => <TablesPanel className="m-2" />,
+  PluginPanel: (props: IDockviewPanelProps<{ pluginId: string }>) => (
+    <PluginPanel pluginId={props.params.pluginId} className="m-2" />
+  ),
 };
 
 /**
  * The tab headers available to panels, by component name: one that lets the
- * user close the panel, and one for panels that are always shown
+ * user close the panel, one for panels that are always shown, and one for the
+ * panels contributed by plugins, whose close button unregisters the plugin
  */
 const dockviewTabComponents = {
   ClosablePanelHeader: (props: IDockviewPanelHeaderProps) => {
@@ -47,6 +63,19 @@ const dockviewTabComponents = {
   },
   PersistentPanelHeader: (props: IDockviewPanelHeaderProps) => {
     return <DockviewDefaultTab hideClose={true} {...props} />;
+  },
+  PluginPanelHeader: (
+    props: IDockviewPanelHeaderProps<{ pluginId: string }>,
+  ) => {
+    return (
+      <DockviewDefaultTab
+        {...props}
+        hideClose={false}
+        closeActionOverride={() =>
+          appStore.getState().unregisterPlugin(props.params.pluginId)
+        }
+      />
+    );
   },
 };
 
@@ -79,7 +108,7 @@ const onDockviewReady = (event: DockviewReadyEvent) => {
   viewerPanel.group.header.hidden = true;
   viewerPanel.group.locked = true;
   const projectPanel = event.api.addPanel({
-    id: "projectPanel",
+    id: projectPanelId,
     title: "Project",
     component: "ProjectPanel",
     tabComponent: "PersistentPanelHeader",
@@ -135,6 +164,9 @@ const onDockviewReady = (event: DockviewReadyEvent) => {
  */
 export function App() {
   const dark = useSettingsStore((state) => state.dark);
+  const [dockviewApi, setDockviewApi] = useState<DockviewApi | null>(null);
+
+  usePluginPanels(dockviewApi, projectPanelId);
 
   return (
     <DialogProvider>
@@ -147,7 +179,10 @@ export function App() {
           components={dockviewComponents}
           tabComponents={dockviewTabComponents}
           rightHeaderActionsComponent={DockviewRightHeaderActionsComponent}
-          onReady={onDockviewReady}
+          onReady={(event) => {
+            onDockviewReady(event);
+            setDockviewApi(event.api);
+          }}
         />
       </div>
     </DialogProvider>

--- a/apps/tissuumaps/src/App.tsx
+++ b/apps/tissuumaps/src/App.tsx
@@ -23,7 +23,7 @@ import { ProjectPanel } from "./components/panels/ProjectPanel";
 import { ShapesPanel } from "./components/panels/ShapesPanel";
 import { TablesPanel } from "./components/panels/TablesPanel";
 import { ViewerPanel } from "./components/panels/ViewerPanel";
-import { appStore } from "./stores/app";
+import { pluginRegistry } from "./plugins";
 import { useSettingsStore } from "./stores/settings";
 
 /** The Tailwind CSS-styled dockview theme defined in `dockview.css` */
@@ -72,7 +72,7 @@ const dockviewTabComponents = {
         {...props}
         hideClose={false}
         closeActionOverride={() =>
-          appStore.getState().unregisterPlugin(props.params.pluginId)
+          pluginRegistry.unregisterPlugin(props.params.pluginId)
         }
       />
     );

--- a/apps/tissuumaps/src/components/panels/PluginPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/PluginPanel/index.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useRef } from "react";
+
+import { pluginStores, useAppStore } from "@/stores/app";
+
+export type PluginPanelProps = {
+  pluginId: string;
+  className?: string;
+};
+
+/**
+ * The panel of a registered plugin
+ *
+ * Hands the plugin an empty container element to mount its user interface into,
+ * and unmounts that user interface again when the plugin is unregistered, or
+ * re-registered with a different `panel`. The container is emptied afterwards, so
+ * a plugin only has to release what is not plain DOM.
+ *
+ * Errors thrown while mounting and unmounting are caught and logged, as they
+ * are for a plugin's `setup` and `teardown`: a failing plugin must not take the
+ * application down with it.
+ */
+export function PluginPanel({ pluginId, className }: PluginPanelProps) {
+  const panel = useAppStore((state) => state.plugins.get(pluginId)?.panel);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (panel === undefined || container === null) {
+      return;
+    }
+    let unmount: (() => void) | void = undefined;
+    try {
+      unmount = panel(container, pluginStores);
+    } catch (error) {
+      console.error(`Error while mounting panel of plugin ${pluginId}:`, error);
+    }
+    return () => {
+      try {
+        unmount?.();
+      } catch (error) {
+        console.error(
+          `Error while unmounting panel of plugin ${pluginId}:`,
+          error,
+        );
+      } finally {
+        container.replaceChildren();
+      }
+    };
+  }, [panel, pluginId]);
+
+  return <div ref={containerRef} className={className} />;
+}

--- a/apps/tissuumaps/src/components/panels/PluginPanel/index.tsx
+++ b/apps/tissuumaps/src/components/panels/PluginPanel/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from "react";
 
-import { pluginStores, useAppStore } from "@/stores/app";
+import { useAppStore } from "@/stores/app";
 
 export type PluginPanelProps = {
   pluginId: string;
@@ -10,43 +10,32 @@ export type PluginPanelProps = {
 /**
  * The panel of a registered plugin
  *
- * Hands the plugin an empty container element to mount its user interface into,
- * and unmounts that user interface again when the plugin is unregistered, or
- * re-registered with a different `panel`. The container is emptied afterwards, so
- * a plugin only has to release what is not plain DOM.
+ * Shows the element into which the plugin registry mounted the plugin's user
+ * interface when the plugin was registered, as held by the app store. The panel
+ * only attaches that element; mounting and unmounting are the registry's
+ * business, so that the user interface is unmounted before the plugin is torn
+ * down, and so that it survives the panel being hidden, moved or remounted.
  *
- * Errors thrown while mounting and unmounting are caught and logged, as they
- * are for a plugin's `setup` and `teardown`: a failing plugin must not take the
- * application down with it.
+ * Re-registering the plugin swaps in the new element.
  */
 export function PluginPanel({ pluginId, className }: PluginPanelProps) {
-  const panel = useAppStore((state) => state.plugins.get(pluginId)?.panel);
-  const containerRef = useRef<HTMLDivElement>(null);
+  const ref = useRef<HTMLDivElement>(null);
+
+  const container = useAppStore(
+    (state) => state.plugins.get(pluginId)?.container,
+  );
 
   useEffect(() => {
-    const container = containerRef.current;
-    if (panel === undefined || container === null) {
+    const element = ref.current;
+    if (element === null) {
       return;
     }
-    let unmount: (() => void) | void = undefined;
-    try {
-      unmount = panel(container, pluginStores);
-    } catch (error) {
-      console.error(`Error while mounting panel of plugin ${pluginId}:`, error);
+    if (container === undefined) {
+      element.replaceChildren();
+    } else if (container.parentElement !== element) {
+      element.replaceChildren(container);
     }
-    return () => {
-      try {
-        unmount?.();
-      } catch (error) {
-        console.error(
-          `Error while unmounting panel of plugin ${pluginId}:`,
-          error,
-        );
-      } finally {
-        container.replaceChildren();
-      }
-    };
-  }, [panel, pluginId]);
+  }, [container]);
 
-  return <div ref={containerRef} className={className} />;
+  return <div ref={ref} className={className} />;
 }

--- a/apps/tissuumaps/src/hooks/usePluginPanels.ts
+++ b/apps/tissuumaps/src/hooks/usePluginPanels.ts
@@ -1,0 +1,82 @@
+import type { DockviewApi } from "dockview-react";
+import { useEffect } from "react";
+
+import type { Plugin } from "@tissuumaps/core";
+
+import { useAppStore } from "@/stores/app";
+
+/**
+ * The prefix of the dockview panel ID of a plugin's panel, followed by the
+ * plugin's ID
+ *
+ * The prefix identifies the plugin panels among the dockview panels, so that
+ * {@link usePluginPanels} only ever adds and removes its own.
+ */
+const pluginPanelIdPrefix = "plugin:";
+
+/**
+ * Keeps the plugin panels in the dockview layout in sync with the plugins
+ * registered with the app store
+ *
+ * A plugin's panel is shown for exactly as long as the plugin is registered:
+ * registering a plugin that has a panel adds the panel to the dockview layout,
+ * and unregistering the plugin removes it again. A panel is not made active
+ * when it is added, so that a plugin registering during startup does not take
+ * the group it is added to over.
+ *
+ * The panels are shown using the `PluginPanel` component and the
+ * `PluginPanelHeader` tab component, both of which the application registers
+ * with dockview.
+ *
+ * @param dockviewApi - The API of the ready dockview, or `null` while it is not
+ * ready yet
+ * @param referencePanelId - The ID of the panel into whose group the plugin
+ * panels are added
+ */
+export function usePluginPanels(
+  dockviewApi: DockviewApi | null,
+  referencePanelId: string,
+): void {
+  const plugins = useAppStore((state) => state.plugins);
+
+  useEffect(() => {
+    if (dockviewApi === null) {
+      return;
+    }
+    const pluginPanels = new Map<string, Plugin>();
+    for (const plugin of plugins.values()) {
+      if (plugin.panel !== undefined) {
+        pluginPanels.set(pluginPanelIdPrefix + plugin.id, plugin);
+      }
+    }
+    for (const dockviewPanel of dockviewApi.panels) {
+      if (
+        dockviewPanel.id.startsWith(pluginPanelIdPrefix) &&
+        !pluginPanels.has(dockviewPanel.id)
+      ) {
+        dockviewApi.removePanel(dockviewPanel);
+      }
+    }
+    const referenceGroup = dockviewApi.getPanel(referencePanelId)?.group;
+    for (const [id, plugin] of pluginPanels) {
+      const dockviewPanel = dockviewApi.getPanel(id);
+      if (dockviewPanel === undefined) {
+        dockviewApi.addPanel<{ pluginId: string }>({
+          id,
+          title: plugin.name,
+          component: "PluginPanel",
+          tabComponent: "PluginPanelHeader",
+          // keep the panel mounted while another tab of its group is active
+          renderer: "always",
+          // do not steal the active tab from whatever the user is looking at
+          inactive: true,
+          params: { pluginId: plugin.id },
+          position:
+            referenceGroup !== undefined ? { referenceGroup } : undefined,
+        });
+      } else if (dockviewPanel.title !== plugin.name) {
+        dockviewPanel.api.setTitle(plugin.name);
+      }
+    }
+  }, [dockviewApi, plugins, referencePanelId]);
+}

--- a/apps/tissuumaps/src/hooks/usePluginPanels.ts
+++ b/apps/tissuumaps/src/hooks/usePluginPanels.ts
@@ -1,8 +1,6 @@
 import type { DockviewApi } from "dockview-react";
 import { useEffect } from "react";
 
-import type { Plugin } from "@tissuumaps/core";
-
 import { useAppStore } from "@/stores/app";
 
 /**
@@ -43,10 +41,13 @@ export function usePluginPanels(
     if (dockviewApi === null) {
       return;
     }
-    const pluginPanels = new Map<string, Plugin>();
-    for (const plugin of plugins.values()) {
-      if (plugin.mount !== undefined) {
-        pluginPanels.set(pluginPanelIdPrefix + plugin.id, plugin);
+    const pluginPanels = new Map<string, { id: string; name: string }>();
+    for (const [pluginId, plugin] of plugins) {
+      if (plugin.container !== undefined) {
+        pluginPanels.set(pluginPanelIdPrefix + pluginId, {
+          id: pluginId,
+          name: plugin.name,
+        });
       }
     }
     for (const dockviewPanel of dockviewApi.panels) {

--- a/apps/tissuumaps/src/hooks/usePluginPanels.ts
+++ b/apps/tissuumaps/src/hooks/usePluginPanels.ts
@@ -19,7 +19,7 @@ const pluginPanelIdPrefix = "plugin:";
  * registered with the app store
  *
  * A plugin's panel is shown for exactly as long as the plugin is registered:
- * registering a plugin that has a panel adds the panel to the dockview layout,
+ * registering a plugin that has a `mount` adds a panel to the dockview layout,
  * and unregistering the plugin removes it again. A panel is not made active
  * when it is added, so that a plugin registering during startup does not take
  * the group it is added to over.
@@ -45,7 +45,7 @@ export function usePluginPanels(
     }
     const pluginPanels = new Map<string, Plugin>();
     for (const plugin of plugins.values()) {
-      if (plugin.panel !== undefined) {
+      if (plugin.mount !== undefined) {
         pluginPanels.set(pluginPanelIdPrefix + plugin.id, plugin);
       }
     }

--- a/apps/tissuumaps/src/plugins.ts
+++ b/apps/tissuumaps/src/plugins.ts
@@ -1,6 +1,11 @@
-import type { PluginRegistry } from "@tissuumaps/core";
+import { castDraft } from "immer";
+
+import type { PluginRegistry, PluginStores } from "@tissuumaps/core";
 
 import { appStore } from "./stores/app";
+import { dataStore } from "./stores/data";
+import { projectStore } from "./stores/project";
+import { settingsStore } from "./stores/settings";
 
 declare global {
   interface Window {
@@ -10,27 +15,120 @@ declare global {
 }
 
 /**
- * Exposes the plugin registry to plugins as `window.tissuumaps`
+ * The stores handed to a plugin, both when it is set up and when it is mounted
+ */
+const pluginStores: PluginStores = {
+  appStore,
+  dataStore,
+  projectStore,
+  settingsStore,
+};
+
+/**
+ * The callbacks that unmount the user interface and tear the plugin down again,
+ * for each registered plugin, by plugin ID
  *
- * The registry forwards to the app store, which sets a plugin up when it is
- * registered and tears it down when it is unregistered.
+ * Kept outside of the app store, whose state holds the plugins themselves and
+ * their containers, since the callbacks are the registry's business alone.
+ */
+const pluginRegistrations = new Map<
+  string,
+  { unmount: (() => void) | void; teardown: (() => void) | void }
+>();
+
+/**
+ * The plugin registry, which owns the plugin lifecycle
+ *
+ * Registering a plugin calls its `setup` and then its `mount`, and adds the
+ * plugin to the app store once both have succeeded, together with the element
+ * its user interface is mounted into; unregistering it removes the plugin from
+ * the app store first, and then calls the unmount callback returned by `mount`
+ * and the teardown callback returned by `setup`. The registry is the only
+ * writer of the app store's `plugins`.
+ *
+ * Errors thrown by a plugin are caught and logged, so that a failing plugin
+ * does not take the application down with it. A plugin whose `setup` throws is
+ * not registered, and neither is one whose `mount` throws, but the latter's
+ * teardown callback is called, since its `setup` did succeed.
+ */
+export const pluginRegistry: PluginRegistry = {
+  registerPlugin: (plugin) => {
+    pluginRegistry.unregisterPlugin(plugin.id);
+    let teardown: (() => void) | void = undefined;
+    if (plugin.setup !== undefined) {
+      try {
+        teardown = plugin.setup(pluginStores);
+      } catch (setupError) {
+        console.error(`Error during setup of plugin ${plugin.id}:`, setupError);
+        return;
+      }
+    }
+    let container: HTMLElement | undefined = undefined;
+    let unmount: (() => void) | void = undefined;
+    if (plugin.mount !== undefined) {
+      container = document.createElement("div");
+      try {
+        unmount = plugin.mount(container, pluginStores);
+      } catch (mountError) {
+        console.error(`Error during mount of plugin ${plugin.id}:`, mountError);
+        try {
+          teardown?.();
+        } catch (teardownError) {
+          console.error(
+            `Error during teardown of plugin ${plugin.id}:`,
+            teardownError,
+          );
+        }
+        return;
+      }
+    }
+    pluginRegistrations.set(plugin.id, { unmount, teardown });
+    appStore.setState((draft) => {
+      // the element is opaque to Immer, which its draft type cannot express
+      draft.plugins.set(plugin.id, castDraft({ ...plugin, container }));
+    });
+  },
+  unregisterPlugin: (pluginId) => {
+    const registration = pluginRegistrations.get(pluginId);
+    if (registration !== undefined) {
+      pluginRegistrations.delete(pluginId);
+      appStore.setState((draft) => {
+        draft.plugins.delete(pluginId);
+      });
+      try {
+        registration.unmount?.();
+      } catch (unmountError) {
+        console.error(
+          `Error during unmount of plugin ${pluginId}:`,
+          unmountError,
+        );
+      }
+      try {
+        registration.teardown?.();
+      } catch (teardownError) {
+        console.error(
+          `Error during teardown of plugin ${pluginId}:`,
+          teardownError,
+        );
+      }
+    }
+  },
+};
+
+/**
+ * Exposes the {@link pluginRegistry} to plugins as `window.tissuumaps`
  *
  * @returns A callback that removes the registry from `window` again, unless it
  * has been replaced in the meantime, and unregisters all plugins that are still
  * registered
  */
 export function startPluginRegistry(): () => void {
-  const pluginRegistry: PluginRegistry = {
-    registerPlugin: (plugin) => appStore.getState().registerPlugin(plugin),
-    unregisterPlugin: (pluginId) =>
-      appStore.getState().unregisterPlugin(pluginId),
-  };
   window.tissuumaps = pluginRegistry;
   return () => {
     if (window.tissuumaps === pluginRegistry) {
       delete window.tissuumaps;
     }
-    for (const pluginId of [...appStore.getState().plugins.keys()]) {
+    for (const pluginId of [...pluginRegistrations.keys()]) {
       pluginRegistry.unregisterPlugin(pluginId);
     }
   };

--- a/apps/tissuumaps/src/plugins.ts
+++ b/apps/tissuumaps/src/plugins.ts
@@ -28,8 +28,8 @@ const pluginStores: PluginStores = {
  * The callbacks that unmount the user interface and tear the plugin down again,
  * for each registered plugin, by plugin ID
  *
- * Kept outside of the app store, whose state holds the plugins themselves and
- * their containers, since the callbacks are the registry's business alone.
+ * Kept outside of the app store, whose state holds the plugins' names and
+ * containers, since the callbacks are the registry's business alone.
  */
 const pluginRegistrations = new Map<
   string,
@@ -40,11 +40,14 @@ const pluginRegistrations = new Map<
  * The plugin registry, which owns the plugin lifecycle
  *
  * Registering a plugin calls its `setup` and then its `mount`, and adds the
- * plugin to the app store once both have succeeded, together with the element
- * its user interface is mounted into; unregistering it removes the plugin from
- * the app store first, and then calls the unmount callback returned by `mount`
- * and the teardown callback returned by `setup`. The registry is the only
- * writer of the app store's `plugins`.
+ * plugin to the app store once both have succeeded, as its name together with
+ * the element its user interface is mounted into; unregistering it removes the
+ * plugin from the app store first, and then calls the unmount callback returned
+ * by `mount` and the teardown callback returned by `setup`. The registry is the
+ * only writer of the app store's `plugins`.
+ *
+ * The plugin object itself is not kept: the app store only holds what the user
+ * interface renders, so that Immer does not freeze anything the plugin owns.
  *
  * Errors thrown by a plugin are caught and logged, so that a failing plugin
  * does not take the application down with it. A plugin whose `setup` throws is
@@ -85,7 +88,7 @@ export const pluginRegistry: PluginRegistry = {
     pluginRegistrations.set(plugin.id, { unmount, teardown });
     appStore.setState((draft) => {
       // the element is opaque to Immer, which its draft type cannot express
-      draft.plugins.set(plugin.id, castDraft({ ...plugin, container }));
+      draft.plugins.set(plugin.id, castDraft({ name: plugin.name, container }));
     });
   },
   unregisterPlugin: (pluginId) => {

--- a/apps/tissuumaps/src/stores/app.ts
+++ b/apps/tissuumaps/src/stores/app.ts
@@ -2,7 +2,12 @@ import { createStore, useStore } from "zustand";
 import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
-import type { AppStore, AppStoreApi, AppStoreState } from "@tissuumaps/core";
+import type {
+  AppStore,
+  AppStoreApi,
+  AppStoreState,
+  PluginStores,
+} from "@tissuumaps/core";
 
 import { dataStore } from "./data";
 import { projectStore } from "./project";
@@ -43,11 +48,13 @@ export const appStore: AppStoreApi = createStore<AppStore>()(
         }),
       registerPlugin: (plugin) => {
         get().unregisterPlugin(plugin.id);
-        try {
-          plugin.setup({ appStore, dataStore, projectStore, settingsStore });
-        } catch (error) {
-          console.error(`Error during setup of plugin ${plugin.id}:`, error);
-          return;
+        if (plugin.setup !== undefined) {
+          try {
+            plugin.setup(pluginStores);
+          } catch (error) {
+            console.error(`Error during setup of plugin ${plugin.id}:`, error);
+            return;
+          }
         }
         set((draft) => {
           draft.plugins.set(plugin.id, plugin);
@@ -102,3 +109,14 @@ function createInitialAppStoreState(): AppStoreState {
     plugins: new Map(),
   };
 }
+
+/**
+ * The stores handed to a plugin, both when it is set up and when its panel is
+ * mounted
+ */
+export const pluginStores: PluginStores = {
+  appStore,
+  dataStore,
+  projectStore,
+  settingsStore,
+};

--- a/apps/tissuumaps/src/stores/app.ts
+++ b/apps/tissuumaps/src/stores/app.ts
@@ -2,27 +2,21 @@ import { createStore, useStore } from "zustand";
 import { devtools } from "zustand/middleware";
 import { immer } from "zustand/middleware/immer";
 
-import type {
-  AppStore,
-  AppStoreApi,
-  AppStoreState,
-  PluginStores,
-} from "@tissuumaps/core";
+import type { AppStore, AppStoreApi, AppStoreState } from "@tissuumaps/core";
 
-import { dataStore } from "./data";
-import { projectStore } from "./project";
-import { settingsStore } from "./settings";
 import "./zustand";
 
 /**
  * The store holding application state that is not part of the project
  *
  * This comprises the open workspace, the current interaction mode, the
- * registered data providers, and the registered plugins.
+ * registered data providers, and the registered plugins. The plugins are
+ * written by the plugin registry, which owns their lifecycle, rather than
+ * through an action.
  */
 export const appStore: AppStoreApi = createStore<AppStore>()(
   devtools(
-    immer((set, get) => ({
+    immer((set) => ({
       ...createInitialAppStoreState(),
       setWorkspace: (workspace) => set({ workspace }),
       setInteractionMode: (interactionMode) => set({ interactionMode }),
@@ -46,38 +40,6 @@ export const appStore: AppStoreApi = createStore<AppStore>()(
         set((draft) => {
           draft.tableDataProviders.set(type, dataProvider);
         }),
-      registerPlugin: (plugin) => {
-        get().unregisterPlugin(plugin.id);
-        if (plugin.setup !== undefined) {
-          try {
-            plugin.setup(pluginStores);
-          } catch (error) {
-            console.error(`Error during setup of plugin ${plugin.id}:`, error);
-            return;
-          }
-        }
-        set((draft) => {
-          draft.plugins.set(plugin.id, plugin);
-        });
-      },
-      unregisterPlugin: (pluginId) => {
-        const plugin = get().plugins.get(pluginId);
-        if (plugin !== undefined) {
-          set((draft) => {
-            draft.plugins.delete(pluginId);
-          });
-          if (plugin.teardown !== undefined) {
-            try {
-              plugin.teardown();
-            } catch (error) {
-              console.error(
-                `Error during teardown of plugin ${plugin.id}:`,
-                error,
-              );
-            }
-          }
-        }
-      },
     })),
     { name: "app", enabled: import.meta.env.DEV },
   ),
@@ -109,14 +71,3 @@ function createInitialAppStoreState(): AppStoreState {
     plugins: new Map(),
   };
 }
-
-/**
- * The stores handed to a plugin, both when it is set up and when its panel is
- * mounted
- */
-export const pluginStores: PluginStores = {
-  appStore,
-  dataStore,
-  projectStore,
-  settingsStore,
-};

--- a/packages/@tissuumaps-core/src/index.ts
+++ b/packages/@tissuumaps-core/src/index.ts
@@ -176,7 +176,11 @@ export {
   type Vertex,
 } from "./types/geometry";
 export { type InteractionMode } from "./types/interaction";
-export { type Plugin, type PluginRegistry } from "./types/plugins";
+export {
+  type Plugin,
+  type PluginRegistry,
+  type PluginStores,
+} from "./types/plugins";
 export {
   type OpenSeadragonOptions,
   type OpenSeadragonViewerOptions,

--- a/packages/@tissuumaps-core/src/types/plugins.ts
+++ b/packages/@tissuumaps-core/src/types/plugins.ts
@@ -15,6 +15,11 @@ export type PluginStores = {
 
 /**
  * A plugin that can be registered with the application
+ *
+ * A plugin's lifecycle is `setup`, `mount`, `unmount`, `teardown`: registering
+ * the plugin calls {@link setup} and then {@link mount}, and unregistering it
+ * calls the callback returned by `mount` and then the callback returned by
+ * `setup`. All four steps are optional.
  */
 export type Plugin = {
   /** The unique ID of the plugin */
@@ -24,48 +29,50 @@ export type Plugin = {
   name: string;
 
   /**
-   * Mounts the plugin's panel, through which it shows a user interface, if any
+   * Sets up the plugin and registers any necessary event listeners or other resources
    *
-   * The panel is shown as a tab titled with the plugin's {@link name}, for
-   * exactly as long as the plugin is registered: it is mounted once
-   * {@link setup} has returned successfully, if there is one, and unmounted when
-   * the plugin is unregistered. Closing the panel unregisters the plugin; a
-   * plugin without a panel can only be unregistered through the registry.
+   * Called first when the plugin is registered. A plugin whose `setup` throws is
+   * not registered, and the teardown callback is not called: releasing whatever
+   * `setup` had already acquired before it throws is `setup`'s own
+   * responsibility.
    *
-   * Called with an empty element owned by the panel. The application empties the
-   * container again after the returned callback has run, so the callback only
-   * has to release what is not plain DOM, such as store subscriptions, listeners
-   * on `window`, or a React root.
+   * A plugin that only contributes a user interface does not need a `setup`:
+   * its {@link mount} receives the same stores.
+   *
+   * @param stores - The stores provided by the application for the plugin to interact with
+   * @returns A teardown callback that unregisters the event listeners and
+   * releases the other resources again, if any. It is called last when the
+   * plugin is unregistered, after the user interface has been unmounted, and
+   * only for a plugin that was registered successfully.
+   */
+  setup?: (stores: PluginStores) => (() => void) | void;
+
+  /**
+   * Mounts the plugin's user interface, if any
+   *
+   * A plugin with a `mount` is shown as a panel titled with the plugin's
+   * {@link name}, for exactly as long as the plugin is registered. Closing the
+   * panel unregisters the plugin; a plugin without a `mount` can only be
+   * unregistered through the registry.
+   *
+   * Called once {@link setup} has returned successfully, with an empty element
+   * owned by the application. The element is not part of the document yet: the
+   * application attaches it to the panel once that is shown, and keeps the user
+   * interface mounted while the panel is hidden behind other tabs or moved.
+   * A plugin whose `mount` throws is not registered, and the teardown callback
+   * returned by `setup` is called.
+   *
+   * The container is discarded together with the plugin, so the returned
+   * callback only has to release what is not plain DOM, such as store
+   * subscriptions, listeners on `window`, or a React root.
    *
    * @param container - The element to mount the user interface into
    * @param stores - The stores provided by the application for the plugin to interact with
-   * @returns A callback that unmounts the user interface again, if any
+   * @returns An unmount callback that unmounts the user interface again, if
+   * any. It is called first when the plugin is unregistered, before the
+   * teardown callback returned by {@link setup}.
    */
-  panel?: (container: HTMLElement, stores: PluginStores) => (() => void) | void;
-
-  /**
-   * Sets up the plugin and registers any necessary event listeners or other resources
-   *
-   * A plugin whose `setup` throws is not registered, and its {@link teardown} is
-   * not called: releasing whatever `setup` had already acquired before it throws
-   * is `setup`'s own responsibility.
-   *
-   * A plugin that only contributes a {@link panel} does not need a `setup`: its
-   * `panel` receives the same stores.
-   *
-   * @param stores - The stores provided by the application for the plugin to interact with
-   */
-  setup?: (stores: PluginStores) => void;
-
-  /**
-   * Tears down the plugin and unregisters any event listeners or other resources
-   *
-   * Only called for a plugin that was registered successfully, i.e. one whose
-   * {@link setup} did not throw. It is called before the plugin's {@link panel}
-   * is unmounted, so cleaning up the user interface belongs in the callback
-   * returned by {@link panel} rather than here.
-   */
-  teardown?: () => void;
+  mount?: (container: HTMLElement, stores: PluginStores) => (() => void) | void;
 };
 
 /**
@@ -73,7 +80,7 @@ export type Plugin = {
  */
 export type PluginRegistry = {
   /**
-   * Registers a plugin and calls its `setup` function, if it has one
+   * Registers a plugin, calling its `setup` and then its `mount`, if it has them
    *
    * Registering a plugin whose ID is already in use unregisters the previously
    * registered plugin first.
@@ -83,7 +90,8 @@ export type PluginRegistry = {
   registerPlugin: (plugin: Plugin) => void;
 
   /**
-   * Calls a registered plugin's `teardown` function and unregisters it
+   * Unregisters a registered plugin, calling the unmount callback returned by
+   * its `mount` and then the teardown callback returned by its `setup`
    *
    * @param pluginId - The ID of the plugin to unregister
    */

--- a/packages/@tissuumaps-core/src/types/plugins.ts
+++ b/packages/@tissuumaps-core/src/types/plugins.ts
@@ -4,6 +4,16 @@ import type { ProjectStoreApi } from "./stores/project";
 import type { SettingsStoreApi } from "./stores/settings";
 
 /**
+ * The stores provided by the application for a plugin to interact with
+ */
+export type PluginStores = {
+  appStore: AppStoreApi;
+  dataStore: DataStoreApi;
+  projectStore: ProjectStoreApi;
+  settingsStore: SettingsStoreApi;
+};
+
+/**
  * A plugin that can be registered with the application
  */
 export type Plugin = {
@@ -14,25 +24,46 @@ export type Plugin = {
   name: string;
 
   /**
+   * Mounts the plugin's panel, through which it shows a user interface, if any
+   *
+   * The panel is shown as a tab titled with the plugin's {@link name}, for
+   * exactly as long as the plugin is registered: it is mounted once
+   * {@link setup} has returned successfully, if there is one, and unmounted when
+   * the plugin is unregistered. Closing the panel unregisters the plugin; a
+   * plugin without a panel can only be unregistered through the registry.
+   *
+   * Called with an empty element owned by the panel. The application empties the
+   * container again after the returned callback has run, so the callback only
+   * has to release what is not plain DOM, such as store subscriptions, listeners
+   * on `window`, or a React root.
+   *
+   * @param container - The element to mount the user interface into
+   * @param stores - The stores provided by the application for the plugin to interact with
+   * @returns A callback that unmounts the user interface again, if any
+   */
+  panel?: (container: HTMLElement, stores: PluginStores) => (() => void) | void;
+
+  /**
    * Sets up the plugin and registers any necessary event listeners or other resources
    *
    * A plugin whose `setup` throws is not registered, and its {@link teardown} is
    * not called: releasing whatever `setup` had already acquired before it throws
    * is `setup`'s own responsibility.
    *
+   * A plugin that only contributes a {@link panel} does not need a `setup`: its
+   * `panel` receives the same stores.
+   *
    * @param stores - The stores provided by the application for the plugin to interact with
    */
-  setup: (stores: {
-    appStore: AppStoreApi;
-    dataStore: DataStoreApi;
-    projectStore: ProjectStoreApi;
-    settingsStore: SettingsStoreApi;
-  }) => void;
+  setup?: (stores: PluginStores) => void;
 
   /**
    * Tears down the plugin and unregisters any event listeners or other resources
    *
-   * Only called for a plugin whose {@link setup} returned successfully.
+   * Only called for a plugin that was registered successfully, i.e. one whose
+   * {@link setup} did not throw. It is called before the plugin's {@link panel}
+   * is unmounted, so cleaning up the user interface belongs in the callback
+   * returned by {@link panel} rather than here.
    */
   teardown?: () => void;
 };
@@ -42,7 +73,7 @@ export type Plugin = {
  */
 export type PluginRegistry = {
   /**
-   * Registers a plugin and calls its `setup` function
+   * Registers a plugin and calls its `setup` function, if it has one
    *
    * Registering a plugin whose ID is already in use unregisters the previously
    * registered plugin first.

--- a/packages/@tissuumaps-core/src/types/stores/app.ts
+++ b/packages/@tissuumaps-core/src/types/stores/app.ts
@@ -11,7 +11,6 @@ import type { PointsData, PointsDataProvider } from "../../storage/points";
 import type { ShapesData, ShapesDataProvider } from "../../storage/shapes";
 import type { TableData, TableDataProvider } from "../../storage/table";
 import type { InteractionMode } from "../interaction";
-import type { Plugin } from "../plugins";
 
 /**
  * The state of the app store, holding what is not part of the project
@@ -54,12 +53,14 @@ export type AppStoreState = {
   >;
 
   /**
-   * The registered plugins, by plugin ID, each together with the element its
-   * user interface is mounted into, if it has one
+   * The registered plugins, by plugin ID, each as its human-readable name
+   * together with the element its user interface is mounted into, if it has one
    *
-   * Written by the plugin registry, which owns the plugin lifecycle.
+   * Written by the plugin registry, which owns the plugin lifecycle and keeps
+   * the plugin objects themselves to itself, so that nothing a plugin owns ends
+   * up frozen in the store.
    */
-  plugins: Map<string, Plugin & { container?: HTMLElement }>;
+  plugins: Map<string, { name: string; container?: HTMLElement }>;
 };
 
 /**

--- a/packages/@tissuumaps-core/src/types/stores/app.ts
+++ b/packages/@tissuumaps-core/src/types/stores/app.ts
@@ -53,8 +53,13 @@ export type AppStoreState = {
     TableDataProvider<TableDataSource, TableData>
   >;
 
-  /** The registered plugins, by plugin ID */
-  plugins: Map<string, Plugin>;
+  /**
+   * The registered plugins, by plugin ID, each together with the element its
+   * user interface is mounted into, if it has one
+   *
+   * Written by the plugin registry, which owns the plugin lifecycle.
+   */
+  plugins: Map<string, Plugin & { container?: HTMLElement }>;
 };
 
 /**
@@ -134,22 +139,6 @@ export type AppStoreActions = {
     type: string,
     dataProvider: TableDataProvider<TableDataSource, TableData>,
   ) => void;
-
-  /**
-   * Registers a plugin and calls its `setup` function, if it has one, see
-   * {@link PluginRegistry.registerPlugin}
-   *
-   * @param plugin - The plugin to register
-   */
-  registerPlugin: (plugin: Plugin) => void;
-
-  /**
-   * Calls a registered plugin's `teardown` function and unregisters it, see
-   * {@link PluginRegistry.unregisterPlugin}
-   *
-   * @param pluginId - The ID of the plugin to unregister
-   */
-  unregisterPlugin: (pluginId: string) => void;
 };
 
 /**

--- a/packages/@tissuumaps-core/src/types/stores/app.ts
+++ b/packages/@tissuumaps-core/src/types/stores/app.ts
@@ -136,7 +136,7 @@ export type AppStoreActions = {
   ) => void;
 
   /**
-   * Registers a plugin and calls its `setup` function, see
+   * Registers a plugin and calls its `setup` function, if it has one, see
    * {@link PluginRegistry.registerPlugin}
    *
    * @param plugin - The plugin to register


### PR DESCRIPTION
# References and relevant issues

Jira: [TMAP-199](https://scilifelab.atlassian.net/browse/TMAP-199)

Fills in the `## User interface plugins` TODO in `apps/docs/docs/development/plugins.md`.

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

Plugins could read and write all state, but had no way to show anything: the dockview layout was a static component map and a one-shot `onDockviewReady`.

- **Plugin interface** (`@tissuumaps/core`): `id`, `name`, `setup?` and `mount?`. `setup(stores)` may return a teardown callback; `mount(container, stores)` may return an unmount callback. The explicit `teardown` property is gone (breaking), and `setup` is optional — a plugin that only adds a user interface needs no `setup`, since `mount` receives the same stores. `mount` is a plain DOM contract, so plugins keep working as `<script>`s and core stays React-free.
- **Lifecycle**: `setup`, `mount`, `unmount`, `teardown`, all optional. If `setup` throws, the plugin is not registered and nothing is torn down; if `mount` throws, the teardown callback returned by `setup` is still called. Errors from plugin code are caught and logged everywhere.
- **The plugin registry owns the lifecycle** (`apps/tissuumaps/src/plugins.ts`). It creates the container element, calls `setup` and `mount`, keeps the unmount and teardown callbacks, and writes `appStore.plugins` directly via `setState` — the `registerPlugin`/`unregisterPlugin` store actions are removed. A plugin lands in the store, together with its `container`, only after `setup` and `mount` succeeded, and is removed before `unmount` and `teardown` run. Since the registry writes `HTMLElement`s into the Immer store, the entry is wrapped in `castDraft`; Immer leaves DOM nodes alone at runtime.
- **Panels are derived from `appStore.plugins`**. `usePluginPanels` reconciles `plugin:<id>` dockview panels against the registered plugins that have a `mount` (add / remove / rename), and a single `PluginPanel` bridge component attaches the plugin's container element. Mounting happens at registration, not when the panel is shown, so the user interface survives tab switches, drags and panel remounts.
- Closing the panel unregisters the plugin, via `DockviewDefaultTab`'s `closeActionOverride`. Intercepting the click rather than observing `onDidRemovePanel` matters: the latter also fires when dockview disposes its panels (StrictMode's dev double-mount, HMR) and would silently unregister every plugin.
- Panels are added with `renderer: "always"` so switching tabs does not remount them, and `inactive: true` so a plugin registering during startup does not steal the active tab.

# Screenshot of the fix

<!-- Attach screenshot if relevant. -->

# Use of AI

Claude Code was used for the design, implementation, documentation and a review pass over the diff.

# Testing

Instructions on how to test — with `pnpm dev` running, paste into the browser console:

```js
window.tissuumaps.registerPlugin({
  id: "demo",
  name: "Demo",
  setup: () => {
    console.log("setup");
    return () => console.log("teardown");
  },
  mount: (container, { projectStore }) => {
    container.textContent = `${projectStore.getState().images.length} images`;
    return () => console.log("unmount");
  },
});
```

`setup` should log immediately, a "Demo" tab should appear in the sidebar group without stealing focus from Project, survive tab switching and dragging without remounting, and disappear — logging `unmount` and then `teardown`, in that order — both on `window.tissuumaps.unregisterPlugin("demo")` and when its close button is clicked.

# Further comments

`mount` is called with a container that is not yet part of the document; TissUUmaps attaches it to the panel once that is shown. Plugins that need their size should use a `ResizeObserver` rather than measuring once in `mount`. Re-registering a plugin under the same `id` unregisters the previous one first and mounts the new one into a fresh container.
