### PR TITLE
feat(matomo): inject Matomo script into Pages deployment

### DIFF
--- a/.github/pages/custom.html
+++ b/.github/pages/custom.html
@@ -1,10 +1,19 @@
-<!--
-TODO Matomo, for example:
+<!-- Matomo -->
 <script>
-  var _paq = window._paq = window._paq || [];
-  (function() {
-    var u="${MATOMO_URL}";
-    _paq.push(['setSiteId', '${MATOMO_SITE_ID}']);
+  var _paq = (window._paq = window._paq || []);
+  /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["trackPageView"]);
+  _paq.push(["enableLinkTracking"]);
+  (function () {
+    var u = "https://matomo.dc.scilifelab.se/";
+    _paq.push(["setTrackerUrl", u + "matomo.php"]);
+    _paq.push(["setSiteId", "17"]);
+    var d = document,
+      g = d.createElement("script"),
+      s = d.getElementsByTagName("script")[0];
+    g.async = true;
+    g.src = u + "matomo.js";
+    s.parentNode.insertBefore(g, s);
   })();
 </script>
--->
+<!-- End Matomo Code -->

--- a/.github/pages/custom.html
+++ b/.github/pages/custom.html
@@ -1,0 +1,10 @@
+<!--
+TODO Matomo, for example:
+<script>
+  var _paq = window._paq = window._paq || [];
+  (function() {
+    var u="${MATOMO_URL}";
+    _paq.push(['setSiteId', '${MATOMO_SITE_ID}']);
+  })();
+</script>
+-->

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,6 +41,17 @@ jobs:
           cache-dependency-path: |
             production/pnpm-lock.yaml
             development/pnpm-lock.yaml
+      - name: Inject Matomo variables
+        env:
+          MATOMO_URL: ${{ secrets.MATOMO_URL }}
+          MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}
+        if: env.MATOMO_URL != '' && env.MATOMO_SITE_ID != ''
+        run: |
+          {
+            echo "VITE_CUSTOM_HTML<<VITE_CUSTOM_HTML_EOF"
+            envsubst '${MATOMO_URL} ${MATOMO_SITE_ID}' < development/.github/pages/custom.html
+            echo "VITE_CUSTOM_HTML_EOF"
+          } >> "$GITHUB_ENV"
       - name: Build development
         working-directory: development
         run: pnpm install --frozen-lockfile && pnpm run build && pnpm run build:docs

--- a/apps/tissuumaps/index.html
+++ b/apps/tissuumaps/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/x-icon" href="/favicon.ico" />
     <title>TissUUmaps</title>
+    %VITE_CUSTOM_HTML%
   </head>
 
   <body>

--- a/apps/tissuumaps/vite.config.ts
+++ b/apps/tissuumaps/vite.config.ts
@@ -50,4 +50,9 @@ export default defineConfig(({ mode }) => ({
           : ["tissuumaps-development", ...defaultServerConditions],
     },
   },
+  define: {
+    "import.meta.env.VITE_CUSTOM_HTML": JSON.stringify(
+      process.env.VITE_CUSTOM_HTML ?? "",
+    ),
+  },
 }));


### PR DESCRIPTION
# References and relevant issues

Jira: https://scilifelab.atlassian.net/browse/TMAP-126

# Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- `apps/tissuumaps/index.html`: add a `%VITE_CUSTOM_HTML%` placeholder in `<head>` that Vite's HTML env replacement fills at build time
- `apps/tissuumaps/vite.config.ts`: `define` `import.meta.env.VITE_CUSTOM_HTML` from the environment, falling back to an empty string so local and unconfigured builds ship no placeholder
- `.github/pages/custom.html`: template for the Matomo snippet with `${MATOMO_URL}` and `${MATOMO_SITE_ID}` placeholders (currently a commented-out TODO)
- `.github/workflows/deploy.yaml`: new step that substitutes the placeholders from the `MATOMO_URL` and `MATOMO_SITE_ID` repository secrets via `envsubst` and exports the result as `VITE_CUSTOM_HTML` for both Pages builds; skipped when either secret is missing

# Screenshot of the fix

N/A

# Use of AI

Claude Code was used during development (design discussion, review of the staged changes, PR description).

# Testing

- Requires new configuration settings: `MATOMO_URL` (with trailing slash) and `MATOMO_SITE_ID` repository secrets
- Instructions on how to test: build `apps/tissuumaps` with and without `VITE_CUSTOM_HTML` set and inspect `<head>` in `dist/index.html`; with the variable set the snippet appears verbatim, without it there is no literal `%VITE_CUSTOM_HTML%` left in the output

# Further comments

The template is still a placeholder comment. Once the secrets exist, the substituted values will appear inside that comment in the deployed page, so the real snippet should replace the TODO before the secrets are configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
