### PR TITLE
fix(matomo): simplify and fix custom HTML integration

### DIFF
--- a/.github/pages/custom.html
+++ b/.github/pages/custom.html
@@ -2,8 +2,8 @@
 <script>
   var _paq = (window._paq = window._paq || []);
   /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+  _paq.push(["disableCookies"]);
   _paq.push(["trackPageView"]);
-  _paq.push(["enableLinkTracking"]);
   (function () {
     var u = "https://matomo.dc.scilifelab.se/";
     _paq.push(["setTrackerUrl", u + "matomo.php"]);

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -41,28 +41,19 @@ jobs:
           cache-dependency-path: |
             production/pnpm-lock.yaml
             development/pnpm-lock.yaml
-      - name: Inject Matomo variables
-        env:
-          MATOMO_URL: ${{ secrets.MATOMO_URL }}
-          MATOMO_SITE_ID: ${{ secrets.MATOMO_SITE_ID }}
-        if: env.MATOMO_URL != '' && env.MATOMO_SITE_ID != ''
-        run: |
-          {
-            echo "VITE_CUSTOM_HTML<<VITE_CUSTOM_HTML_EOF"
-            envsubst '${MATOMO_URL} ${MATOMO_SITE_ID}' < development/.github/pages/custom.html
-            echo "VITE_CUSTOM_HTML_EOF"
-          } >> "$GITHUB_ENV"
       - name: Build development
         working-directory: development
         run: pnpm install --frozen-lockfile && pnpm run build && pnpm run build:docs
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/live-dev/
+          VITE_CUSTOM_HTML_FILE: ${{ github.workspace }}/development/.github/pages/custom.html
           DOCUSAURUS_BASE_URL: /${{ github.event.repository.name }}/docs-dev/
       - name: Build production
         working-directory: production
         run: pnpm install --frozen-lockfile && pnpm run build
         env:
           VITE_BASE_PATH: /${{ github.event.repository.name }}/live/
+          VITE_CUSTOM_HTML_FILE: ${{ github.workspace }}/development/.github/pages/custom.html
           DOCUSAURUS_BASE_URL: /${{ github.event.repository.name }}/docs/
       - name: Prepare deployment
         run: |

--- a/apps/tissuumaps/vite.config.ts
+++ b/apps/tissuumaps/vite.config.ts
@@ -1,6 +1,7 @@
 /// <reference types="vitest/config" />
 import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import {
   defaultClientConditions,
@@ -52,7 +53,9 @@ export default defineConfig(({ mode }) => ({
   },
   define: {
     "import.meta.env.VITE_CUSTOM_HTML": JSON.stringify(
-      process.env.VITE_CUSTOM_HTML ?? "",
+      process.env.VITE_CUSTOM_HTML_FILE
+        ? readFileSync(process.env.VITE_CUSTOM_HTML_FILE, "utf8")
+        : "",
     ),
   },
 }));


### PR DESCRIPTION
# References and relevant issues

Jira: https://scilifelab.atlassian.net/browse/TMAP-126

Follow-up to #181.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- `apps/tissuumaps/vite.config.ts`: replace the `VITE_CUSTOM_HTML` environment variable with `VITE_CUSTOM_HTML_FILE`, a path to an HTML file that is read at config time and injected into `import.meta.env.VITE_CUSTOM_HTML`; unset falls back to an empty string as before
- `.github/workflows/deploy.yaml`: drop the "Inject Matomo variables" step (`envsubst` + multi-line `$GITHUB_ENV` heredoc) and instead point both Pages builds at `development/.github/pages/custom.html` via `VITE_CUSTOM_HTML_FILE`

Passing a multi-line HTML snippet through `$GITHUB_ENV` was fragile, and since `.github/pages/custom.html` now contains the final Matomo snippet with the tracker URL and site ID inlined, the secret substitution step is no longer needed. Reading the file directly in the Vite config keeps the mechanism simple and testable locally.

# Screenshot of the fix

N/A

# Use of AI

Claude Code was used to write the PR description.

# Testing

- Requires new configuration settings: the `MATOMO_URL` and `MATOMO_SITE_ID` repository secrets are no longer used and can be removed
- Instructions on how to test: in `apps/tissuumaps`, run `VITE_CUSTOM_HTML_FILE=$(pwd)/../../.github/pages/custom.html pnpm run build` and check that the Matomo snippet appears in `<head>` of `dist/index.html`; build again without the variable and check that no snippet and no literal `%VITE_CUSTOM_HTML%` is present

# Further comments

Both the development and production builds read the template from the `development` checkout, so the snippet is maintained in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
