### PR TITLE
fix(app): serve 404 for missing files in the dev server

### DIFF
--- a/apps/tissuumaps/vite.config.ts
+++ b/apps/tissuumaps/vite.config.ts
@@ -12,6 +12,8 @@ import { viteSingleFile } from "vite-plugin-singlefile";
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => ({
   plugins: [react(), tailwindcss(), mode === "production" && viteSingleFile()],
+  // Zarr probes for optional files: the dev server must 404 them, not serve index.html.
+  appType: "mpa",
   build: {
     chunkSizeWarningLimit: 2048,
     rolldownOptions: {


### PR DESCRIPTION
# References and relevant issues

None.

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies an existing feature)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other

# List of changes made

- Set `appType: "mpa"` in `apps/tissuumaps/vite.config.ts`, so the dev server answers a request for a missing file with a `404` instead of falling back to `index.html` with a `200`.
- Zarr detects store layout by probing for optional files (`.zmetadata`, `zarr.json`, `.zattrs`) and treats a `404` as "not present". With Vite's default SPA fallback every probe succeeded with an HTML body, so stores were mis-detected or failed while parsing HTML as JSON.
- The app has no client-side routes, so the fallback provided nothing and only made dev behave differently from production, where the built single-file app is served with no fallback at all.

# Screenshot of the fix

Not applicable.

# Use of AI

To write this description

# Testing

- Instructions on how to test

Run the dev server and request a file that does not exist:

```
curl -i http://localhost:5173/.zmetadata
```

Expected: `404`. Before this change: `200` with the `index.html` body. Loading a Zarr-based example exercises the same path.

# Further comments

`appType` affects the dev and `vite preview` servers only. It is read in four places in Vite's server middleware setup and nowhere in the build path, and `"spa"` vs `"mpa"` differ only by the boolean passed to `htmlFallbackMiddleware`.

The production single-file build is unaffected: `pnpm --filter tissuumaps build` still emits a single `dist/index.html` (3.96 MB, 1.26 MB gzipped) with JS and CSS inlined by `vite-plugin-singlefile`.

Note that `"mpa"` here does not mean a multi-page architecture, only "no HTML fallback".
